### PR TITLE
Hide content for blind fact-checking mode

### DIFF
--- a/fact_checker_review_gui.py
+++ b/fact_checker_review_gui.py
@@ -39,6 +39,11 @@ def main():
         type=str,
         help="Username to use (suppresses login dialog)"
     )
+    parser.add_argument(
+        "--blind",
+        action="store_true",
+        help="Blind mode: hide original and AI annotations from human annotator"
+    )
 
     args = parser.parse_args()
 
@@ -56,7 +61,8 @@ def main():
     app = FactCheckerReviewApp(
         input_file=args.input_file,
         incremental=args.incremental,
-        default_username=args.user
+        default_username=args.user,
+        blind_mode=args.blind
     )
     ft.app(target=app.main)
 

--- a/src/bmlibrarian/factchecker/gui/review_app.py
+++ b/src/bmlibrarian/factchecker/gui/review_app.py
@@ -18,7 +18,7 @@ from .citation_display import CitationDisplay
 class FactCheckerReviewApp:
     """Main application for reviewing fact-check results."""
 
-    def __init__(self, input_file: Optional[str] = None, incremental: bool = False, default_username: Optional[str] = None):
+    def __init__(self, input_file: Optional[str] = None, incremental: bool = False, default_username: Optional[str] = None, blind_mode: bool = False):
         """
         Initialize the review application.
 
@@ -26,16 +26,18 @@ class FactCheckerReviewApp:
             input_file: Optional input file path provided via command line
             incremental: If True, only show statements you haven't annotated yet
             default_username: If provided, use this username and skip login dialog
+            blind_mode: If True, hide original and AI annotations from human annotator
         """
         self.page: Optional[ft.Page] = None
         self.initial_input_file = input_file
         self.incremental = incremental
         self.default_username = default_username
+        self.blind_mode = blind_mode
         self.current_index = 0
 
         # Initialize components
         self.data_manager = FactCheckDataManager(incremental=incremental)
-        self.statement_display = StatementDisplay()
+        self.statement_display = StatementDisplay(blind_mode=blind_mode)
         self.annotation_manager = AnnotationManager(on_annotation_change=self._on_annotation_change)
         self.citation_display = CitationDisplay()
 

--- a/src/bmlibrarian/factchecker/gui/statement_display.py
+++ b/src/bmlibrarian/factchecker/gui/statement_display.py
@@ -11,8 +11,15 @@ import flet as ft
 class StatementDisplay:
     """Manages statement display UI components."""
 
-    def __init__(self):
-        """Initialize statement display components."""
+    def __init__(self, blind_mode: bool = False):
+        """
+        Initialize statement display components.
+
+        Args:
+            blind_mode: If True, hide original and AI annotations from display
+        """
+        self.blind_mode = blind_mode
+
         # Progress components
         self.statement_counter = ft.Text(
             "Statement 0 of 0",
@@ -165,31 +172,41 @@ class StatementDisplay:
             human_annotation_section: Human annotation input section
 
         Returns:
-            Row containing all annotation sections
+            Row containing all annotation sections (or just human section in blind mode)
         """
-        return ft.Row([
-            ft.Container(
-                content=self.original_annotation,
-                expand=1
-            ),
-            ft.Container(
-                content=ft.Column([
-                    self.ai_annotation,
-                    ft.Container(height=10),
-                    ft.Container(
-                        content=ft.Column([
-                            ft.Text("AI Rationale:", size=11, weight=ft.FontWeight.BOLD, color=ft.Colors.GREY_700),
-                            self.ai_rationale
-                        ], spacing=5),
-                        padding=ft.padding.all(10),
-                        bgcolor=ft.Colors.GREY_50,
-                        border_radius=5
-                    )
-                ], spacing=0),
-                expand=1
-            ),
-            ft.Container(
-                content=human_annotation_section,
-                expand=1
-            )
-        ], spacing=15, vertical_alignment=ft.CrossAxisAlignment.START)
+        if self.blind_mode:
+            # In blind mode, only show the human annotation section
+            return ft.Row([
+                ft.Container(
+                    content=human_annotation_section,
+                    expand=1
+                )
+            ], spacing=15, vertical_alignment=ft.CrossAxisAlignment.START)
+        else:
+            # Normal mode: show all annotations
+            return ft.Row([
+                ft.Container(
+                    content=self.original_annotation,
+                    expand=1
+                ),
+                ft.Container(
+                    content=ft.Column([
+                        self.ai_annotation,
+                        ft.Container(height=10),
+                        ft.Container(
+                            content=ft.Column([
+                                ft.Text("AI Rationale:", size=11, weight=ft.FontWeight.BOLD, color=ft.Colors.GREY_700),
+                                self.ai_rationale
+                            ], spacing=5),
+                            padding=ft.padding.all(10),
+                            bgcolor=ft.Colors.GREY_50,
+                            border_radius=5
+                        )
+                    ], spacing=0),
+                    expand=1
+                ),
+                ft.Container(
+                    content=human_annotation_section,
+                    expand=1
+                )
+            ], spacing=15, vertical_alignment=ft.CrossAxisAlignment.START)


### PR DESCRIPTION
Implement blind mode feature that hides original and AI annotations from human annotators to reduce bias during review.

Changes:
- Add --blind command line flag to fact_checker_review_gui.py
- Pass blind_mode parameter through FactCheckerReviewApp
- Update StatementDisplay to conditionally hide original and AI annotation sections in blind mode
- In blind mode, only the human annotation input is visible

Usage:
  uv run python fact_checker_review_gui.py --blind uv run python fact_checker_review_gui.py --input-file results.json --blind --user alice

This feature enables less biased human annotation by preventing reviewers from seeing either the original expected answers or AI-generated verdicts before making their own judgments. Some bias will persist due to the extracted citations used for evidence. This can only be avoided by forcing the human reveiwer to conduct a manual literature review, which is beyond the scope of this system.