### PR TITLE
Add semantic search options to document plugin

### DIFF
--- a/src/bmlibrarian/config.py
+++ b/src/bmlibrarian/config.py
@@ -138,6 +138,17 @@ DEFAULT_CONFIG = {
             "embedding_model": "nomic-embed-text:latest",
             "num_hypothetical_docs": 3,  # Number of hypothetical documents to generate
             "similarity_threshold": 0.7   # Cosine similarity threshold (0-1)
+        },
+        "reranking": {
+            # Re-ranking method for combining results from multiple strategies
+            "method": "sum_scores",  # Options: sum_scores, rrf, max_score, weighted
+            "rrf_k": 60,  # RRF constant (Cormack et al., 2009)
+            "weights": {  # Weights for "weighted" method
+                "keyword": 1.0,
+                "bm25": 1.5,
+                "semantic": 2.0,
+                "hyde": 2.0
+            }
         }
     }
 }

--- a/src/bmlibrarian/gui/event_handlers.py
+++ b/src/bmlibrarian/gui/event_handlers.py
@@ -59,6 +59,34 @@ class EventHandlers:
         if self.app.page:
             self.app.page.update()
 
+    def on_keyword_search_change(self, e):
+        """Handle keyword search checkbox change."""
+        self.app.search_strategy_keyword = e.control.value
+        self._update_search_strategy_config()
+        if self.app.page:
+            self.app.page.update()
+
+    def on_bm25_search_change(self, e):
+        """Handle BM25 search checkbox change."""
+        self.app.search_strategy_bm25 = e.control.value
+        self._update_search_strategy_config()
+        if self.app.page:
+            self.app.page.update()
+
+    def on_semantic_search_change(self, e):
+        """Handle semantic search checkbox change."""
+        self.app.search_strategy_semantic = e.control.value
+        self._update_search_strategy_config()
+        if self.app.page:
+            self.app.page.update()
+
+    def on_hyde_search_change(self, e):
+        """Handle HyDE search checkbox change."""
+        self.app.search_strategy_hyde = e.control.value
+        self._update_search_strategy_config()
+        if self.app.page:
+            self.app.page.update()
+
     def on_step_expand(self, card: StepCard, expanded: bool):
         """Handle step card expansion change."""
         if self.app.page:
@@ -225,6 +253,22 @@ class EventHandlers:
         self.app.config_overrides['min_relevant'] = value
         if hasattr(self.app, 'workflow_executor') and self.app.workflow_executor:
             self.app.workflow_executor.config_overrides['min_relevant'] = value
+
+    def _update_search_strategy_config(self):
+        """Update search strategy configuration based on checkbox states."""
+        search_strategy_config = {
+            'keyword': {'enabled': self.app.search_strategy_keyword},
+            'bm25': {'enabled': self.app.search_strategy_bm25},
+            'semantic': {'enabled': self.app.search_strategy_semantic},
+            'hyde': {'enabled': self.app.search_strategy_hyde}
+        }
+
+        # Store in config_overrides for workflow executor
+        self.app.config_overrides['search_strategy'] = search_strategy_config
+
+        # Apply to workflow executor if it exists
+        if hasattr(self.app, 'workflow_executor') and self.app.workflow_executor:
+            self.app.workflow_executor.config_overrides['search_strategy'] = search_strategy_config
 
     def _start_workflow_execution(self):
         """Prepare and start workflow execution in a thread."""

--- a/src/bmlibrarian/gui/event_handlers.py
+++ b/src/bmlibrarian/gui/event_handlers.py
@@ -87,6 +87,13 @@ class EventHandlers:
         if self.app.page:
             self.app.page.update()
 
+    def on_reranking_change(self, e):
+        """Handle re-ranking method dropdown change."""
+        self.app.reranking_method = e.control.value
+        self._update_search_strategy_config()
+        if self.app.page:
+            self.app.page.update()
+
     def on_step_expand(self, card: StepCard, expanded: bool):
         """Handle step card expansion change."""
         if self.app.page:
@@ -255,12 +262,13 @@ class EventHandlers:
             self.app.workflow_executor.config_overrides['min_relevant'] = value
 
     def _update_search_strategy_config(self):
-        """Update search strategy configuration based on checkbox states."""
+        """Update search strategy configuration based on checkbox states and re-ranking method."""
         search_strategy_config = {
             'keyword': {'enabled': self.app.search_strategy_keyword},
             'bm25': {'enabled': self.app.search_strategy_bm25},
             'semantic': {'enabled': self.app.search_strategy_semantic},
-            'hyde': {'enabled': self.app.search_strategy_hyde}
+            'hyde': {'enabled': self.app.search_strategy_hyde},
+            'reranking': {'method': self.app.reranking_method}
         }
 
         # Store in config_overrides for workflow executor

--- a/src/bmlibrarian/gui/research_app.py
+++ b/src/bmlibrarian/gui/research_app.py
@@ -58,6 +58,7 @@ class ResearchGUI:
         self.search_strategy_bm25 = False
         self.search_strategy_semantic = False
         self.search_strategy_hyde = False
+        self.reranking_method = "sum_scores"  # Default re-ranking method
 
         # Managers and handlers (initialized in main())
         self.tab_manager = None
@@ -161,6 +162,7 @@ class ResearchGUI:
             self.search_strategy_bm25 = search_config.get('bm25', {}).get('enabled', False)
             self.search_strategy_semantic = search_config.get('semantic', {}).get('enabled', False)
             self.search_strategy_hyde = search_config.get('hyde', {}).get('enabled', False)
+            self.reranking_method = search_config.get('reranking', {}).get('method', 'sum_scores')
 
         except Exception as e:
             print(f"Warning: Could not load config defaults: {e}")
@@ -228,7 +230,9 @@ class ResearchGUI:
             self.event_handlers.on_keyword_search_change,
             self.event_handlers.on_bm25_search_change,
             self.event_handlers.on_semantic_search_change,
-            self.event_handlers.on_hyde_search_change
+            self.event_handlers.on_hyde_search_change,
+            self.reranking_method,
+            self.event_handlers.on_reranking_change
         )
 
         # Create status text (hidden by default)

--- a/src/bmlibrarian/gui/research_app.py
+++ b/src/bmlibrarian/gui/research_app.py
@@ -17,7 +17,8 @@ from .event_handlers import EventHandlers
 from .data_updaters import DataUpdaters
 from .ui_builder import (
     create_header, create_question_field, create_toggle_switch,
-    create_start_button, create_max_results_field, create_min_relevant_field, create_controls_section
+    create_start_button, create_max_results_field, create_min_relevant_field,
+    create_controls_section, create_search_strategy_checkboxes
 )
 from ..cli.workflow_steps import WorkflowStep
 from ..cli import CLIConfig, UserInterface, QueryProcessor, ReportFormatter, WorkflowOrchestrator
@@ -51,7 +52,13 @@ class ResearchGUI:
         # Default max results and min relevant values
         self.max_results = 100
         self.min_relevant = 10
-        
+
+        # Search strategy settings (will be loaded from config)
+        self.search_strategy_keyword = True  # Default enabled
+        self.search_strategy_bm25 = False
+        self.search_strategy_semantic = False
+        self.search_strategy_hyde = False
+
         # Managers and handlers (initialized in main())
         self.tab_manager = None
         self.event_handlers = None
@@ -138,16 +145,22 @@ class ResearchGUI:
     def _load_config_defaults(self):
         """Load default values from config file."""
         try:
-            from ..config import get_search_config
-            search_config = get_search_config()
+            from ..config import get_config
+            config = get_config()
+            search_config = config.get('search_strategy', {})
 
-            # Load max_results from config if not already set by command line
+            # Load max_results and min_relevant from config if not already set by command line
             if 'max_results' not in self.config_overrides:
-                self.max_results = search_config.get('max_results', 100)
+                self.max_results = config.get('max_results', 100)
 
-            # Load min_relevant from config
             if 'min_relevant' not in self.config_overrides:
-                self.min_relevant = search_config.get('min_relevant', 10)
+                self.min_relevant = config.get('min_relevant', 10)
+
+            # Load search strategy settings from config
+            self.search_strategy_keyword = search_config.get('keyword', {}).get('enabled', True)
+            self.search_strategy_bm25 = search_config.get('bm25', {}).get('enabled', False)
+            self.search_strategy_semantic = search_config.get('semantic', {}).get('enabled', False)
+            self.search_strategy_hyde = search_config.get('hyde', {}).get('enabled', False)
 
         except Exception as e:
             print(f"Warning: Could not load config defaults: {e}")
@@ -156,6 +169,7 @@ class ResearchGUI:
                 self.max_results = 100
             if 'min_relevant' not in self.config_overrides:
                 self.min_relevant = 10
+            # Search strategy defaults already set in __init__
     
     def _apply_config_overrides(self):
         """Apply command-line overrides to configuration."""
@@ -205,6 +219,18 @@ class ResearchGUI:
         )
         self.start_button = create_start_button(self.event_handlers.on_start_research)
 
+        # Create search strategy checkboxes
+        search_strategy_checkboxes = create_search_strategy_checkboxes(
+            self.search_strategy_keyword,
+            self.search_strategy_bm25,
+            self.search_strategy_semantic,
+            self.search_strategy_hyde,
+            self.event_handlers.on_keyword_search_change,
+            self.event_handlers.on_bm25_search_change,
+            self.event_handlers.on_semantic_search_change,
+            self.event_handlers.on_hyde_search_change
+        )
+
         # Create status text (hidden by default)
         self.status_text = ft.Text(
             "Enter a research question to begin",
@@ -220,7 +246,8 @@ class ResearchGUI:
             self.min_relevant_field,
             self.human_loop_toggle,
             self.counterfactual_toggle,
-            self.start_button
+            self.start_button,
+            search_strategy_checkboxes
         )
         
         # Create step cards and tabbed interface

--- a/src/bmlibrarian/gui/ui_builder.py
+++ b/src/bmlibrarian/gui/ui_builder.py
@@ -105,13 +105,31 @@ def create_search_strategy_checkboxes(
     on_keyword_change,
     on_bm25_change,
     on_semantic_change,
-    on_hyde_change
+    on_hyde_change,
+    reranking_method: str = "sum_scores",
+    on_reranking_change = None
 ) -> ft.Container:
-    """Create checkboxes for search strategy selection."""
+    """Create checkboxes for search strategy selection and re-ranking dropdown."""
+    # Re-ranking dropdown
+    reranking_dropdown = ft.Dropdown(
+        label="Re-ranking",
+        value=reranking_method,
+        options=[
+            ft.dropdown.Option("sum_scores", "Sum Scores"),
+            ft.dropdown.Option("rrf", "RRF (Reciprocal Rank Fusion)"),
+            ft.dropdown.Option("max_score", "Max Score"),
+            ft.dropdown.Option("weighted", "Weighted Fusion")
+        ],
+        width=220,
+        height=45,
+        on_change=on_reranking_change,
+        tooltip="Method for combining results from multiple strategies"
+    )
+
     return ft.Container(
         content=ft.Column([
             ft.Text(
-                "Search Strategies",
+                "Search Strategies & Re-ranking",
                 size=12,
                 weight=ft.FontWeight.BOLD,
                 color=ft.Colors.GREY_700
@@ -140,7 +158,9 @@ def create_search_strategy_checkboxes(
                     value=hyde_enabled,
                     on_change=on_hyde_change,
                     tooltip="Hypothetical Document Embeddings search"
-                )
+                ),
+                ft.Container(width=15),  # Spacer
+                reranking_dropdown
             ], spacing=15)
         ], spacing=5),
         padding=ft.padding.all(10),

--- a/src/bmlibrarian/gui/ui_builder.py
+++ b/src/bmlibrarian/gui/ui_builder.py
@@ -97,13 +97,66 @@ def create_min_relevant_field(value: int, on_change_handler) -> ft.TextField:
     )
 
 
+def create_search_strategy_checkboxes(
+    keyword_enabled: bool,
+    bm25_enabled: bool,
+    semantic_enabled: bool,
+    hyde_enabled: bool,
+    on_keyword_change,
+    on_bm25_change,
+    on_semantic_change,
+    on_hyde_change
+) -> ft.Container:
+    """Create checkboxes for search strategy selection."""
+    return ft.Container(
+        content=ft.Column([
+            ft.Text(
+                "Search Strategies",
+                size=12,
+                weight=ft.FontWeight.BOLD,
+                color=ft.Colors.GREY_700
+            ),
+            ft.Row([
+                ft.Checkbox(
+                    label="Keyword",
+                    value=keyword_enabled,
+                    on_change=on_keyword_change,
+                    tooltip="PostgreSQL full-text search"
+                ),
+                ft.Checkbox(
+                    label="BM25",
+                    value=bm25_enabled,
+                    on_change=on_bm25_change,
+                    tooltip="Probabilistic ranking (BM25)"
+                ),
+                ft.Checkbox(
+                    label="Semantic",
+                    value=semantic_enabled,
+                    on_change=on_semantic_change,
+                    tooltip="Vector similarity search using embeddings"
+                ),
+                ft.Checkbox(
+                    label="HyDE",
+                    value=hyde_enabled,
+                    on_change=on_hyde_change,
+                    tooltip="Hypothetical Document Embeddings search"
+                )
+            ], spacing=15)
+        ], spacing=5),
+        padding=ft.padding.all(10),
+        bgcolor=ft.Colors.BLUE_50,
+        border_radius=5
+    )
+
+
 def create_controls_section(
     question_field: ft.TextField,
     max_results_field: ft.TextField,
     min_relevant_field: ft.TextField,
     human_loop_toggle: ft.Switch,
     counterfactual_toggle: ft.Switch,
-    start_button: ft.ElevatedButton
+    start_button: ft.ElevatedButton,
+    search_strategy_checkboxes: Optional[ft.Container] = None
 ) -> ft.Container:
     """Create the controls section with reorganized layout."""
     # First row: Question field and Start button
@@ -126,11 +179,15 @@ def create_controls_section(
     ], alignment=ft.MainAxisAlignment.START,
        vertical_alignment=ft.CrossAxisAlignment.CENTER)
 
+    # Build layout rows
+    layout_rows = [first_row, second_row]
+
+    # Add search strategy checkboxes if provided
+    if search_strategy_checkboxes:
+        layout_rows.append(search_strategy_checkboxes)
+
     return ft.Container(
-        content=ft.Column([
-            first_row,
-            second_row
-        ], spacing=15),
+        content=ft.Column(layout_rows, spacing=15),
         padding=ft.padding.all(15),
         bgcolor=ft.Colors.GREY_50,
         border_radius=10,

--- a/src/bmlibrarian/gui/workflow_steps_handler.py
+++ b/src/bmlibrarian/gui/workflow_steps_handler.py
@@ -383,7 +383,8 @@ class WorkflowStepsHandler:
                 question=research_question,
                 max_rows=override_max_results,
                 human_in_the_loop=interactive_mode,
-                human_query_modifier=query_modifier if interactive_mode else None
+                human_query_modifier=query_modifier if interactive_mode else None,
+                search_config=self.config_overrides.get('search_strategy')
             )
             # Convert generator to list
             documents = list(documents_generator)
@@ -462,7 +463,8 @@ class WorkflowStepsHandler:
                         max_retry=search_config.get('max_retry', 3),
                         batch_size=search_config.get('batch_size', 100),
                         scoring_agent=self.agents['scoring_agent'],
-                        progress_callback=search_callback
+                        progress_callback=search_callback,
+                        search_config=self.config_overrides.get('search_strategy')
                     )
 
                     if all_documents:
@@ -1240,7 +1242,8 @@ class WorkflowStepsHandler:
                 max_retry=max_retry,
                 batch_size=batch_size,
                 scoring_agent=self.agents['scoring_agent'],
-                progress_callback=gui_progress_callback
+                progress_callback=gui_progress_callback,
+                search_config=self.config_overrides.get('search_strategy')
             )
 
             # Filter out documents we already have


### PR DESCRIPTION
Re-ranking Methods Implemented
Four different re-ranking methods are now available:

Sum Scores (default) - Simple sum of raw scores from all enabled strategies
RRF (Reciprocal Rank Fusion) - Rank-based fusion using the Cormack et al. (2009) algorithm
Formula: score = sum(1/(k+rank)) across all strategies
k=60 (standard constant from literature)
Max Score - Use the highest score from any strategy (best single-strategy match)
Weighted Fusion - Configurable weight multipliers per strategy:
Keyword: 1.0
BM25: 1.5
Semantic: 2.0
HyDE: 2.0
Key Changes
1. Configuration (src/bmlibrarian/config.py)

Added reranking section to search_strategy config (lines 142-152)
Includes method selection and RRF k parameter
Configurable weights for weighted fusion
2. Database Re-ranking (src/bmlibrarian/database.py)

Implemented 4 helper functions (lines 846-905):
_apply_sum_scores_reranking()
_apply_max_score_reranking()
_apply_weighted_reranking()
_apply_rrf_reranking() - Full RRF implementation with rank calculation
Updated search_hybrid() to apply configurable re-ranking (lines 1002-1028)
3. UI Components (src/bmlibrarian/gui/ui_builder.py)

Added re-ranking dropdown to search strategy controls (lines 113-127)
Dropdown options: Sum Scores, RRF, Max Score, Weighted Fusion
Updated section title to "Search Strategies & Re-ranking"
Positioned at right end of checkbox row
4. Application State (src/bmlibrarian/gui/research_app.py)

Added reranking_method state variable (line 61)
Loads default from ~/.bmlibrarian/config.json (line 165)
Passes to UI component creation (lines 234-235)
5. Event Handlers (src/bmlibrarian/gui/event_handlers.py)

Added on_reranking_change() handler (lines 90-95)
Updated _update_search_strategy_config() to include reranking (line 271)
Visual Layout
The re-ranking dropdown now appears alongside the search strategy checkboxes:

┌────────────────────────────────────────────────────────────────────────────┐
│ Search Strategies & Re-ranking                                              │
│ ☑ Keyword  ☐ BM25  ☐ Semantic  ☐ HyDE      Re-ranking: [Sum Scores ▼]    │
└────────────────────────────────────────────────────────────────────────────┘
How It Works
User selects search strategies via checkboxes (Keyword, BM25, Semantic, HyDE)
User selects re-ranking method via dropdown
Event handlers update config_overrides['search_strategy']['reranking']
Workflow executor passes config to QueryAgent
QueryAgent forwards to database.search_hybrid()
Search engine executes enabled strategies, collects results
Re-ranker applies selected method to combine scores
Results sorted by combined score and returned
RRF Algorithm Details
The RRF implementation follows the standard algorithm from Cormack et al. (2009):

For each document, sum its reciprocal ranks across all strategies
Rank position starts at 1 (top result)
Formula: RRF_score(doc) = sum(1 / (60 + rank_i)) for all strategies i
Documents appearing in more strategies get higher scores
Rank-based scoring is more robust than raw score fusion
Commits
Commit 1: 361820f - "Add search strategy selection to Research GUI with tick boxes"
Commit 2: bf89613 - "Add re-ranking options for hybrid search result fusion"
Branch: claude/add-semantic-search-options-01JTqMgNsLZ8UruSApatTta3
Pushed: Successfully to remote repository
Testing
All modified files validated for Python syntax ✓
No breaking changes to existing workflows ✓
Backward compatible (defaults to sum_scores) ✓
Config-driven (can be customized via ~/.bmlibrarian/config.json) ✓
Usage Example
Users can now:

Enable multiple search strategies (e.g., Keyword + Semantic + HyDE)
Select RRF re-ranking to get better fusion of results
Get documents that rank highly across multiple strategies
Or use Weighted fusion to prioritize semantic/HyDE results over keyword
The search infrastructure is now fully configurable with both strategy selection and result fusion under user control!