### PR TITLE
Redesign document cards to match Flet GUI style

### DIFF
--- a/src/bmlibrarian/gui/qt/plugins/research/research_tab.py
+++ b/src/bmlibrarian/gui/qt/plugins/research/research_tab.py
@@ -1982,12 +1982,9 @@ class ResearchTabWidget(QWidget):
 
         layout.addWidget(reasoning_container)
 
-        # Row 6: Abstract (truncated, if available)
+        # Row 6: Abstract (FULL, never truncated - essential for human review)
         abstract = doc.get('abstract', '')
         if abstract and abstract.strip():
-            # Truncate to ~300 characters for display
-            truncated_abstract = abstract[:300] + '...' if len(abstract) > 300 else abstract
-
             abstract_container = QFrame()
             abstract_container.setStyleSheet("""
                 QFrame {
@@ -2005,7 +2002,8 @@ class ResearchTabWidget(QWidget):
             abstract_title.setStyleSheet("font-size: 9pt; background-color: transparent; border: none;")
             abstract_layout.addWidget(abstract_title)
 
-            abstract_text = QLabel(truncated_abstract)
+            # Display FULL abstract with word wrapping (never truncate)
+            abstract_text = QLabel(abstract)
             abstract_text.setWordWrap(True)
             abstract_text.setStyleSheet("color: #555; font-size: 9pt; background-color: transparent; border: none;")
             abstract_layout.addWidget(abstract_text)


### PR DESCRIPTION
## Summary

This PR fixes the PySide6 document cards in the Research GUI to match the Flet GUI style and corrects critical field name errors that prevented proper data display.

## Problem

The PySide6 document cards had several issues:
1. **Field name errors**: Using `journal` instead of `publication` (field doesn't exist in database)
2. **Missing information**: Abstract, summary, PMID, DOI, publication, relevance score not displayed
3. **Styling differences**: Cards didn't match the Flet GUI appearance
4. **Truncation issues**: Abstracts were truncated, preventing proper human review

## Changes

### Fixed Field Name Errors
- Changed `journal` → `publication` (correct database field name)
- Journals/publications now display correctly

### Enhanced Citation Cards (`_create_citation_card`)
- ✅ Added summary section with green background (matches Flet)
- ✅ Added publication info and relevance score display
- ✅ Added PMID, DOI, and document ID display
- ✅ Improved author formatting (list handling, "et al." for 3+ authors)
- ✅ Extract year from `publication_date` field
- ✅ Structured containers with Flet-style colors
- ✅ Left border accent (blue) like Flet
- ✅ Hover effects for better UX

### Enhanced Document Score Cards (`_create_document_score_card`)
- ✅ Added FULL abstract display (no truncation - essential for review)
- ✅ Added PMID and DOI display
- ✅ Fixed publication field name
- ✅ Proper author list formatting (first 3 + "et al.")
- ✅ Extract year from `publication_date` field
- ✅ Styled containers (blue for AI reasoning, grey for abstract)
- ✅ Improved visual hierarchy

### Styling Improvements (Flet-matching)
- Citation cards: Light grey background with blue left border
- Document cards: White background with rounded corners, hover states
- Color-coded sections: Green (summary), Blue (reasoning), Grey (abstract)
- Consistent typography, spacing, and padding throughout

### Critical Fix: No Truncation of Essential Content
- **Abstracts**: Display in FULL (essential for human verification)
- **Titles**: Display in FULL with word wrapping
- **Passages**: Display in FULL with word wrapping
- **Summaries**: Display in FULL with word wrapping
- Author lists use "et al." truncation (standard academic practice)

## Testing

Verified that:
- All database fields are correctly accessed
- Cards match Flet GUI information display
- Word wrapping works properly for long content
- Hover effects work as expected
- No truncation of essential review content

## Impact

Users can now:
- See all document metadata (PMID, DOI, publication)
- Review FULL abstracts for proper verification
- Better understand document relevance with complete information
- Experience consistent UI between Flet and PySide6 versions

## Files Changed

- `src/bmlibrarian/gui/qt/plugins/research/research_tab.py`
  - `_create_citation_card()` - Enhanced with all missing fields
  - `_create_document_score_card()` - Enhanced with all missing fields and full abstracts

## Commits

1. Fix PySide6 document cards to match Flet GUI style
2. Remove abstract truncation from PySide6 document cards