### PR TITLE
Build PDF import routine with document matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,11 @@ Since this project uses `uv` for package management:
   - `uv run python embed_documents_cli.py embed --source medrxiv --limit 100` - Generate embeddings for medRxiv abstracts
   - `uv run python embed_documents_cli.py count --source medrxiv` - Count documents needing embeddings
   - `uv run python embed_documents_cli.py status` - Show embedding statistics
+  - `uv run python pdf_import_cli.py file /path/to/paper.pdf` - Import single PDF with LLM-based metadata extraction and database matching
+  - `uv run python pdf_import_cli.py directory /path/to/pdfs/` - Import directory of PDFs with intelligent matching
+  - `uv run python pdf_import_cli.py directory /pdfs/ --recursive` - Import PDFs recursively from subdirectories
+  - `uv run python pdf_import_cli.py file paper.pdf --dry-run` - Preview import without making changes
+  - `uv run python pdf_import_cli.py status` - Show PDF import statistics and coverage
   - `uv run python fact_checker_cli.py statements.json -o results.json` - Export results to JSON file (PostgreSQL is always used)
   - `uv run python fact_checker_stats.py` - Generate comprehensive statistical analysis report (console output)
   - `uv run python fact_checker_stats.py --export-csv stats_output/` - Export statistics to CSV files
@@ -212,6 +217,7 @@ bmlibrarian/
 │   │   ├── medrxiv_importer.py # MedRxiv preprint importer
 │   │   ├── pubmed_importer.py # PubMed E-utilities importer (targeted imports)
 │   │   ├── pubmed_bulk_importer.py # PubMed FTP bulk importer (complete mirror)
+│   │   ├── pdf_matcher.py     # LLM-based PDF matching and import (DOI/PMID/title matching)
 │   │   └── README.md          # Importer documentation
 │   ├── embeddings/            # Document embedding generation
 │   │   ├── __init__.py        # Embeddings module exports
@@ -284,6 +290,7 @@ bmlibrarian/
 │   │   ├── medrxiv_import_guide.md  # MedRxiv import guide
 │   │   ├── document_embedding_guide.md  # Document embedding guide
 │   │   ├── document_interrogation_guide.md  # Document interrogation tab guide
+│   │   ├── pdf_import_guide.md  # PDF import and matching guide
 │   │   └── multi_model_query_guide.md  # Multi-model query generation guide
 │   └── developers/            # Technical documentation
 │       ├── agent_module.md
@@ -306,6 +313,7 @@ bmlibrarian/
 ├── pubmed_import_cli.py       # PubMed E-utilities import CLI (targeted imports)
 ├── pubmed_bulk_cli.py         # PubMed FTP bulk download/import CLI (complete mirror)
 ├── embed_documents_cli.py     # Document embedding generation CLI
+├── pdf_import_cli.py          # PDF import CLI with LLM-based metadata extraction and matching
 ├── query_lab.py               # QueryAgent experimental laboratory GUI
 ├── initial_setup_and_download.py  # Database setup and battle-testing script
 ├── baseline_schema.sql        # Base PostgreSQL schema definition

--- a/doc/users/pdf_import_guide.md
+++ b/doc/users/pdf_import_guide.md
@@ -1,0 +1,399 @@
+# PDF Import Guide
+
+## Overview
+
+The PDF Import system provides intelligent matching of PDF files to existing documents in the BMLibrarian database. It uses AI-powered metadata extraction to identify papers and automatically organizes them according to BMLibrarian's naming conventions.
+
+## Features
+
+- **LLM-Based Metadata Extraction**: Uses Ollama to extract DOI, PMID, title, and authors from PDF first pages
+- **Multiple Matching Strategies**:
+  1. Exact DOI match
+  2. Exact PMID match
+  3. Fuzzy title matching
+- **Automatic Organization**: Renames and moves PDFs to year-based directory structure
+- **Database Integration**: Updates database with PDF locations
+- **Batch Processing**: Process entire directories at once
+- **Dry Run Mode**: Preview changes before committing
+
+## Installation
+
+The PDF import functionality requires PyMuPDF for PDF text extraction:
+
+```bash
+uv add pymupdf
+```
+
+## Usage
+
+### Import a Single PDF File
+
+```bash
+# Basic import
+uv run python pdf_import_cli.py file /path/to/paper.pdf
+
+# Dry run to see what would happen
+uv run python pdf_import_cli.py file paper.pdf --dry-run
+
+# Verbose output to see extracted metadata
+uv run python pdf_import_cli.py file paper.pdf --verbose
+```
+
+### Import a Directory of PDFs
+
+```bash
+# Import all PDFs from a directory
+uv run python pdf_import_cli.py directory /path/to/pdfs/
+
+# Include subdirectories recursively
+uv run python pdf_import_cli.py directory /path/to/pdfs/ --recursive
+
+# Dry run for entire directory
+uv run python pdf_import_cli.py directory /path/to/pdfs/ --dry-run
+```
+
+### Check Import Status
+
+```bash
+# View statistics about PDF coverage
+uv run python pdf_import_cli.py status
+```
+
+Example output:
+```
+============================================================
+PDF IMPORT STATUS
+============================================================
+Total documents:               42,156
+Documents with PDFs:           12,834 (30.4%)
+Documents missing PDFs:        29,322
+
+By source:
+  medrxiv             : 8,234/10,500 (78.4%)
+  PubMed              : 4,600/31,656 (14.5%)
+============================================================
+```
+
+## Configuration Options
+
+### Custom PDF Base Directory
+
+Override the default PDF storage location:
+
+```bash
+uv run python pdf_import_cli.py file paper.pdf --pdf-dir /custom/pdf/location
+```
+
+### Custom LLM Model
+
+Use a different Ollama model for metadata extraction:
+
+```bash
+# Use faster model
+uv run python pdf_import_cli.py file paper.pdf --model medgemma4B_it_q8:latest
+
+# Use more powerful model
+uv run python pdf_import_cli.py file paper.pdf --model gpt-oss:20b
+```
+
+### Custom Ollama URL
+
+If Ollama is running on a different host or port:
+
+```bash
+uv run python pdf_import_cli.py file paper.pdf --ollama-url http://192.168.1.100:11434
+```
+
+## How It Works
+
+### 1. Text Extraction
+
+The system extracts text from the **first page only** of each PDF using PyMuPDF. This is where metadata typically appears in academic papers.
+
+### 2. Metadata Extraction
+
+An LLM analyzes the extracted text to identify:
+
+- **DOI**: Digital Object Identifier (e.g., "10.1234/example")
+- **PMID**: PubMed ID (e.g., "12345678")
+- **Title**: Paper title
+- **Authors**: List of author names
+
+### 3. Database Matching
+
+The system attempts to match the PDF to an existing document using:
+
+1. **Exact DOI match** (highest priority)
+2. **Exact PMID match** (via external_id field)
+3. **Fuzzy title match** (using PostgreSQL similarity, threshold 0.6)
+
+### 4. PDF Organization
+
+If a match is found, the PDF is:
+
+1. **Renamed** to: `{doi_with_underscores}.pdf` (e.g., `10.1234_example.pdf`)
+2. **Moved** to: `{pdf_base_dir}/{year}/{filename}.pdf`
+3. **Database updated** with relative path: `{year}/{filename}.pdf`
+
+Example:
+```
+Source:  /downloads/random_paper_v2.pdf
+Target:  ~/knowledgebase/pdf/2023/10.1234_example.pdf
+```
+
+## Matching Strategies
+
+### DOI Matching (Most Reliable)
+
+The system looks for DOI patterns in the extracted text:
+- "doi:10.1234/example"
+- "DOI: 10.1234/example"
+- "https://doi.org/10.1234/example"
+
+If found, it queries the database:
+```sql
+SELECT * FROM document WHERE doi = '10.1234/example'
+```
+
+### PMID Matching (PubMed Papers)
+
+For PubMed papers, the system extracts PMIDs:
+- "PMID: 12345678"
+- "PubMed ID: 12345678"
+
+Query:
+```sql
+SELECT * FROM document WHERE external_id = '12345678'
+```
+
+### Title Matching (Fallback)
+
+If no DOI or PMID is found, the system uses fuzzy title matching:
+
+```sql
+SELECT * FROM document
+WHERE similarity(title, 'Extracted Title') > 0.6
+ORDER BY similarity(title, 'Extracted Title') DESC
+LIMIT 1
+```
+
+This uses PostgreSQL's trigram similarity for fuzzy matching.
+
+## Status Codes
+
+The CLI reports various status codes for each PDF:
+
+| Status | Icon | Meaning |
+|--------|------|---------|
+| `imported` | ✅ | Successfully imported and database updated |
+| `would_import` | 🔄 | Would import (dry run mode) |
+| `no_match` | ❌ | No matching document found in database |
+| `already_exists` | 📋 | PDF already exists at correct location |
+| `duplicate` | 📋 | PDF exists with same file size |
+| `skipped` | ⏭️ | Skipped (e.g., existing PDF is newer) |
+| `failed` | ⚠️ | Import failed due to error |
+| `extraction_failed` | 📄 | Could not extract text from PDF |
+| `no_metadata` | 📝 | Could not extract metadata from PDF |
+
+## Best Practices
+
+### 1. Always Start with Dry Run
+
+Before importing a large batch, run with `--dry-run` to preview:
+
+```bash
+uv run python pdf_import_cli.py directory /pdfs/ --dry-run --verbose
+```
+
+This shows what would be matched without making changes.
+
+### 2. Use Verbose Mode for Troubleshooting
+
+If matching isn't working as expected:
+
+```bash
+uv run python pdf_import_cli.py file paper.pdf --verbose
+```
+
+This shows the extracted metadata and helps diagnose issues.
+
+### 3. Check Status Regularly
+
+Monitor PDF coverage across sources:
+
+```bash
+uv run python pdf_import_cli.py status
+```
+
+### 4. Handle No-Match Cases
+
+PDFs with `no_match` status may need manual intervention:
+
+1. Check if the paper exists in database with different metadata
+2. Consider importing the paper metadata first
+3. Verify the PDF is a biomedical research paper (not a book chapter, etc.)
+
+## Troubleshooting
+
+### "Cannot connect to Ollama"
+
+**Problem**: The LLM service is not running or not reachable.
+
+**Solution**:
+```bash
+# Check Ollama is running
+curl http://localhost:11434/api/version
+
+# Start Ollama if needed
+ollama serve
+
+# Verify model is available
+ollama list | grep gpt-oss
+```
+
+### "Could not extract text from PDF"
+
+**Problem**: PDF may be image-based (scanned) or corrupted.
+
+**Cause**: PyMuPDF can only extract text from PDFs with text layers, not scanned images.
+
+**Solution**: These PDFs require OCR processing (not currently supported).
+
+### "No matching document found"
+
+**Problem**: The paper may not be in your database yet.
+
+**Solution**:
+1. Import the paper metadata first using appropriate importer:
+   ```bash
+   # For PubMed papers
+   uv run python pubmed_import_cli.py pmids 12345678
+
+   # For medRxiv papers
+   uv run python medrxiv_import_cli.py update
+   ```
+2. Then import the PDF again
+
+### "Fuzzy title match selected wrong paper"
+
+**Problem**: Title matching has false positives.
+
+**Solution**:
+- Prefer papers with DOI or PMID metadata
+- Manually verify title matches when similarity < 0.8
+- Consider using more specific search to import exact paper metadata first
+
+## Workflow Example
+
+### Scenario: Import 40,000 legacy PDFs
+
+You have a directory of 40,000 PDFs from a previous research project.
+
+#### Step 1: Dry Run on Sample
+
+```bash
+# Test with first 100 PDFs
+mkdir /tmp/sample_pdfs
+cp /legacy_pdfs/*.pdf /tmp/sample_pdfs/ | head -100
+
+uv run python pdf_import_cli.py directory /tmp/sample_pdfs/ --dry-run --verbose
+```
+
+Review results to understand matching rates.
+
+#### Step 2: Run Actual Import
+
+```bash
+# Import entire directory
+uv run python pdf_import_cli.py directory /legacy_pdfs/ --recursive
+```
+
+This processes all PDFs and shows progress bar.
+
+#### Step 3: Check Results
+
+```bash
+# View statistics
+uv run python pdf_import_cli.py status
+
+# Review logs for issues
+grep "no_match" pdf_import.log | wc -l
+```
+
+#### Step 4: Handle No-Match Cases
+
+For PDFs that didn't match, you can:
+
+1. **Check the extracted metadata**:
+   ```bash
+   uv run python pdf_import_cli.py file unmatched.pdf --verbose
+   ```
+
+2. **Import missing papers** if they should be in your database:
+   ```bash
+   # Import by DOI or PMID
+   uv run python pubmed_import_cli.py pmids <extracted_pmid>
+   ```
+
+3. **Re-run import** after adding papers to database:
+   ```bash
+   uv run python pdf_import_cli.py file unmatched.pdf
+   ```
+
+## Performance Considerations
+
+### Processing Speed
+
+- **LLM analysis**: ~2-5 seconds per PDF
+- **Database matching**: <100ms per PDF
+- **File operations**: <1 second per PDF
+
+**Estimated throughput**: ~400-600 PDFs per hour
+
+For 40,000 PDFs, expect ~70-100 hours of processing time.
+
+### Optimization Tips
+
+1. **Use faster model** for large batches:
+   ```bash
+   --model medgemma4B_it_q8:latest
+   ```
+
+2. **Run on machine with good CPU**: LLM inference benefits from multi-core processors
+
+3. **Process in batches**: Split large directories into smaller batches for better monitoring
+
+4. **Parallel processing**: Run multiple instances on different subdirectories (future enhancement)
+
+## Limitations
+
+1. **First page only**: Only analyzes first page of PDF for metadata
+2. **Text-based PDFs only**: Cannot process scanned/image-based PDFs without OCR
+3. **English language**: LLM trained primarily on English text
+4. **Biomedical focus**: Optimized for biomedical research papers
+5. **No duplicate detection**: If document already has PDF, newer file replaces older
+
+## Future Enhancements
+
+- OCR support for scanned PDFs
+- Multi-language support
+- Parallel batch processing
+- Semantic title matching using embeddings
+- Author name disambiguation
+- PDF quality assessment
+- Automatic metadata correction
+
+## Related Documentation
+
+- [PDF Manager Architecture](../developers/pdf_manager_architecture.md)
+- [medRxiv Import Guide](medrxiv_import_guide.md)
+- [PubMed Import Guide](pubmed_import_guide.md)
+- [Document Embedding Guide](document_embedding_guide.md)
+
+## Support
+
+For issues or questions:
+- Review logs with `--verbose` flag
+- Check Ollama service status
+- Verify database connectivity
+- Report issues at: https://github.com/hherb/bmlibrarian/issues

--- a/pdf_import_cli.py
+++ b/pdf_import_cli.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+PDF Import CLI for BMLibrarian
+
+This CLI tool analyzes PDF files, extracts metadata using LLMs, matches them to
+existing documents in the BMLibrarian database, and imports them with proper
+naming and organization.
+
+Usage:
+    # Import single PDF file
+    uv run python pdf_import_cli.py file /path/to/paper.pdf
+
+    # Import all PDFs from a directory
+    uv run python pdf_import_cli.py directory /path/to/pdfs/
+
+    # Dry run to see what would be done
+    uv run python pdf_import_cli.py file paper.pdf --dry-run
+
+    # Import with custom model
+    uv run python pdf_import_cli.py directory /pdfs/ --model medgemma4B_it_q8:latest
+
+    # Recursive directory search
+    uv run python pdf_import_cli.py directory /pdfs/ --recursive
+"""
+
+import sys
+import argparse
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+from bmlibrarian.importers import PDFMatcher
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def print_result(result: Dict[str, Any], verbose: bool = False):
+    """Print formatted result for a single PDF."""
+    status = result.get('status', 'unknown')
+    filename = result.get('pdf_filename', 'unknown')
+
+    # Status emoji
+    status_icon = {
+        'imported': '✅',
+        'would_import': '🔄',
+        'no_match': '❌',
+        'already_exists': '📋',
+        'duplicate': '📋',
+        'skipped': '⏭️',
+        'failed': '⚠️',
+        'not_found': '🔍',
+        'extraction_failed': '📄',
+        'no_metadata': '📝'
+    }.get(status, '❓')
+
+    print(f"\n{status_icon} {filename}")
+
+    if status == 'imported':
+        doc = result.get('matched_document', {})
+        print(f"  ✓ Imported successfully")
+        print(f"  Document ID: {result.get('doc_id')}")
+        print(f"  DOI: {result.get('doi', 'N/A')}")
+        print(f"  Title: {result.get('title', 'N/A')}")
+        print(f"  Target: {result.get('target')}")
+
+    elif status == 'would_import':
+        doc = result.get('matched_document', {})
+        print(f"  🔄 Would import (dry run)")
+        print(f"  Document ID: {result.get('doc_id')}")
+        print(f"  Title: {doc.get('title', 'N/A')}")
+        print(f"  Source: {result.get('source')}")
+        print(f"  Target: {result.get('target')}")
+
+    elif status == 'no_match':
+        metadata = result.get('metadata', {})
+        print(f"  ❌ No matching document found in database")
+        if metadata.get('doi'):
+            print(f"  Extracted DOI: {metadata['doi']}")
+        if metadata.get('pmid'):
+            print(f"  Extracted PMID: {metadata['pmid']}")
+        if metadata.get('title'):
+            print(f"  Extracted title: {metadata['title'][:80]}...")
+
+    elif status in ['already_exists', 'duplicate']:
+        print(f"  📋 {result.get('message', 'Already exists')}")
+        if result.get('existing_path'):
+            print(f"  Existing: {result.get('existing_path')}")
+
+    elif status == 'skipped':
+        print(f"  ⏭️ {result.get('reason', 'Skipped')}")
+
+    elif status == 'failed':
+        print(f"  ⚠️ Failed: {result.get('reason', result.get('error', 'Unknown error'))}")
+
+    elif status == 'extraction_failed':
+        print(f"  📄 Could not extract text from PDF")
+
+    elif status == 'no_metadata':
+        print(f"  📝 Could not extract metadata from PDF")
+
+    # Verbose output
+    if verbose and result.get('metadata'):
+        print("\n  Extracted metadata:")
+        metadata = result['metadata']
+        if metadata.get('doi'):
+            print(f"    DOI: {metadata['doi']}")
+        if metadata.get('pmid'):
+            print(f"    PMID: {metadata['pmid']}")
+        if metadata.get('title'):
+            print(f"    Title: {metadata['title'][:100]}")
+        if metadata.get('authors'):
+            print(f"    Authors: {', '.join(metadata['authors'][:3])}...")
+
+
+def print_stats(stats: Dict[str, Any]):
+    """Print summary statistics."""
+    print("\n" + "="*60)
+    print("SUMMARY")
+    print("="*60)
+    print(f"Total PDFs processed:     {stats['total']}")
+    print(f"Successfully imported:    {stats['imported']}")
+    print(f"No database match:        {stats['no_match']}")
+    print(f"Already exists:           {stats['already_exists']}")
+    print(f"Skipped:                  {stats['skipped']}")
+    print(f"Failed:                   {stats['failed']}")
+    print("="*60)
+
+
+def cmd_import_file(args):
+    """Import a single PDF file."""
+    pdf_path = Path(args.path)
+
+    if not pdf_path.exists():
+        logger.error(f"File not found: {pdf_path}")
+        return 1
+
+    if not pdf_path.suffix.lower() == '.pdf':
+        logger.error(f"Not a PDF file: {pdf_path}")
+        return 1
+
+    # Initialize matcher
+    matcher = PDFMatcher(
+        pdf_base_dir=args.pdf_dir,
+        ollama_url=args.ollama_url,
+        model=args.model
+    )
+
+    # Process PDF
+    print(f"\n{'DRY RUN - ' if args.dry_run else ''}Processing: {pdf_path.name}")
+    print("-" * 60)
+
+    result = matcher.match_and_import_pdf(pdf_path, dry_run=args.dry_run)
+    print_result(result, verbose=args.verbose)
+
+    if result['status'] == 'imported':
+        print("\n✅ Import successful!")
+        return 0
+    elif result['status'] == 'would_import':
+        print("\n🔄 Dry run complete. Use without --dry-run to actually import.")
+        return 0
+    else:
+        print(f"\n⚠️  Import failed or skipped")
+        return 1
+
+
+def cmd_import_directory(args):
+    """Import all PDFs from a directory."""
+    directory = Path(args.path)
+
+    if not directory.exists():
+        logger.error(f"Directory not found: {directory}")
+        return 1
+
+    if not directory.is_dir():
+        logger.error(f"Not a directory: {directory}")
+        return 1
+
+    # Initialize matcher
+    matcher = PDFMatcher(
+        pdf_base_dir=args.pdf_dir,
+        ollama_url=args.ollama_url,
+        model=args.model
+    )
+
+    # Process directory
+    print(f"\n{'DRY RUN - ' if args.dry_run else ''}Processing directory: {directory}")
+    if args.recursive:
+        print("(including subdirectories)")
+    print("-" * 60)
+
+    stats = matcher.match_and_import_directory(
+        directory,
+        dry_run=args.dry_run,
+        recursive=args.recursive
+    )
+
+    # Print detailed results if verbose
+    if args.verbose:
+        for result in stats['details']:
+            print_result(result, verbose=True)
+
+    # Print summary
+    print_stats(stats)
+
+    if args.dry_run:
+        print("\n🔄 Dry run complete. Use without --dry-run to actually import.")
+
+    if stats['imported'] > 0:
+        print(f"\n✅ Successfully imported {stats['imported']} PDFs")
+        return 0
+    else:
+        print(f"\n⚠️  No PDFs were imported")
+        return 1
+
+
+def cmd_status(args):
+    """Show PDF import status and statistics."""
+    from bmlibrarian.database import get_db_manager
+
+    db_manager = get_db_manager()
+
+    with db_manager.get_connection() as conn:
+        with conn.cursor() as cur:
+            # Count total documents
+            cur.execute("SELECT COUNT(*) FROM document")
+            total_docs = cur.fetchone()[0]
+
+            # Count documents with PDFs
+            cur.execute("SELECT COUNT(*) FROM document WHERE pdf_filename IS NOT NULL AND pdf_filename != ''")
+            docs_with_pdf = cur.fetchone()[0]
+
+            # Count documents without PDFs but with URL
+            cur.execute("SELECT COUNT(*) FROM document WHERE (pdf_filename IS NULL OR pdf_filename = '') AND pdf_url IS NOT NULL")
+            docs_missing_pdf = cur.fetchone()[0]
+
+            # Count by source
+            cur.execute("""
+                SELECT s.name,
+                       COUNT(*) as total,
+                       COUNT(d.pdf_filename) as with_pdf
+                FROM document d
+                JOIN sources s ON d.source_id = s.id
+                GROUP BY s.name
+                ORDER BY total DESC
+            """)
+            by_source = cur.fetchall()
+
+    print("\n" + "="*60)
+    print("PDF IMPORT STATUS")
+    print("="*60)
+    print(f"Total documents:               {total_docs:,}")
+    print(f"Documents with PDFs:           {docs_with_pdf:,} ({100*docs_with_pdf/total_docs:.1f}%)")
+    print(f"Documents missing PDFs:        {docs_missing_pdf:,}")
+    print("\nBy source:")
+    for source_name, total, with_pdf in by_source:
+        pct = 100 * with_pdf / total if total > 0 else 0
+        print(f"  {source_name:20s}: {with_pdf:,}/{total:,} ({pct:.1f}%)")
+    print("="*60)
+
+    return 0
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description='Import PDFs and match them to BMLibrarian documents using LLM-based metadata extraction',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Import single PDF
+  uv run python pdf_import_cli.py file /path/to/paper.pdf
+
+  # Import directory (dry run first)
+  uv run python pdf_import_cli.py directory /path/to/pdfs/ --dry-run
+
+  # Import directory with custom settings
+  uv run python pdf_import_cli.py directory /pdfs/ --recursive --model gpt-oss:20b
+
+  # Check import status
+  uv run python pdf_import_cli.py status
+        """
+    )
+
+    # Global options
+    parser.add_argument('--pdf-dir', help='Base directory for PDF storage (overrides PDF_BASE_DIR env var)')
+    parser.add_argument('--ollama-url', default='http://localhost:11434', help='Ollama service URL')
+    parser.add_argument('--model', help='LLM model for metadata extraction (default: gpt-oss:20b)')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+    parser.add_argument('--dry-run', action='store_true', help='Dry run - show what would be done without making changes')
+
+    # Subcommands
+    subparsers = parser.add_subparsers(dest='command', help='Command to execute')
+
+    # File command
+    file_parser = subparsers.add_parser('file', help='Import a single PDF file')
+    file_parser.add_argument('path', help='Path to PDF file')
+    file_parser.set_defaults(func=cmd_import_file)
+
+    # Directory command
+    dir_parser = subparsers.add_parser('directory', help='Import all PDFs from a directory')
+    dir_parser.add_argument('path', help='Path to directory containing PDFs')
+    dir_parser.add_argument('--recursive', '-r', action='store_true', help='Search subdirectories recursively')
+    dir_parser.set_defaults(func=cmd_import_directory)
+
+    # Status command
+    status_parser = subparsers.add_parser('status', help='Show PDF import statistics')
+    status_parser.set_defaults(func=cmd_status)
+
+    args = parser.parse_args()
+
+    # Show help if no command specified
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Execute command
+    try:
+        return args.func(args)
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user")
+        return 130
+    except Exception as e:
+        logger.error(f"Error: {e}", exc_info=args.verbose)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/bmlibrarian/importers/__init__.py
+++ b/src/bmlibrarian/importers/__init__.py
@@ -5,5 +5,6 @@ Importers for external data sources (medRxiv, PubMed, etc.)
 from .medrxiv_importer import MedRxivImporter
 from .pubmed_importer import PubMedImporter
 from .pubmed_bulk_importer import PubMedBulkImporter
+from .pdf_matcher import PDFMatcher
 
-__all__ = ['MedRxivImporter', 'PubMedImporter', 'PubMedBulkImporter']
+__all__ = ['MedRxivImporter', 'PubMedImporter', 'PubMedBulkImporter', 'PDFMatcher']

--- a/src/bmlibrarian/importers/pdf_matcher.py
+++ b/src/bmlibrarian/importers/pdf_matcher.py
@@ -1,0 +1,586 @@
+"""PDF Matcher for BMLibrarian
+
+This module provides functionality to analyze PDF files and match them to existing
+documents in the BMLibrarian database using LLM-based metadata extraction.
+
+Example usage:
+    from bmlibrarian.importers import PDFMatcher
+
+    matcher = PDFMatcher()
+    result = matcher.match_and_import_pdf('/path/to/paper.pdf')
+
+    # Or import entire directory
+    results = matcher.match_and_import_directory('/path/to/pdfs/')
+"""
+
+import os
+import sys
+import json
+import logging
+import requests
+from pathlib import Path
+from typing import Optional, Dict, Any, List, Tuple
+from datetime import datetime
+
+from bmlibrarian.database import get_db_manager
+from bmlibrarian.utils.pdf_manager import PDFManager
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pymupdf  # PyMuPDF
+except ImportError:
+    logger.error("pymupdf not installed. Please install with: uv add pymupdf")
+    pymupdf = None
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    logger.warning("tqdm not installed. Progress bars will not be displayed.")
+    tqdm = None
+
+
+class PDFMatcher:
+    """
+    PDF matcher and importer for BMLibrarian.
+
+    Analyzes PDF files to extract metadata using LLM, matches them to existing
+    documents in the database, and imports them with proper naming and organization.
+    """
+
+    DEFAULT_MODEL = "gpt-oss:20b"
+    FALLBACK_MODEL = "medgemma4B_it_q8:latest"
+
+    def __init__(
+        self,
+        pdf_base_dir: Optional[str] = None,
+        ollama_url: str = "http://localhost:11434",
+        model: Optional[str] = None
+    ):
+        """
+        Initialize the PDF matcher.
+
+        Args:
+            pdf_base_dir: Base directory for PDF storage. If None, uses PDF_BASE_DIR
+                         environment variable or defaults to ~/knowledgebase/pdf
+            ollama_url: URL for Ollama service
+            model: LLM model to use for metadata extraction
+        """
+        self.db_manager = get_db_manager()
+        self.ollama_url = ollama_url
+        self.model = model or self.DEFAULT_MODEL
+
+        # Initialize PDF manager with database connection
+        with self.db_manager.get_connection() as conn:
+            self.pdf_manager = PDFManager(base_dir=pdf_base_dir, db_conn=conn)
+
+        logger.info(f"PDF matcher initialized with model: {self.model}")
+        logger.info(f"PDF base directory: {self.pdf_manager.base_dir}")
+
+    def extract_first_page_text(self, pdf_path: Path) -> Optional[str]:
+        """
+        Extract text from the first page of a PDF.
+
+        Args:
+            pdf_path: Path to PDF file
+
+        Returns:
+            Extracted text or None if failed
+        """
+        if not pymupdf:
+            logger.error("PyMuPDF not available")
+            return None
+
+        try:
+            doc = pymupdf.open(str(pdf_path))
+            if len(doc) == 0:
+                logger.warning(f"PDF has no pages: {pdf_path}")
+                return None
+
+            # Get first page
+            page = doc[0]
+            text = page.get_text()
+            doc.close()
+
+            if not text or len(text.strip()) < 50:
+                logger.warning(f"Extracted text too short from {pdf_path}")
+                return None
+
+            logger.debug(f"Extracted {len(text)} characters from first page of {pdf_path.name}")
+            return text
+
+        except Exception as e:
+            logger.error(f"Error extracting text from {pdf_path}: {e}")
+            return None
+
+    def extract_metadata_with_llm(self, text: str) -> Dict[str, Any]:
+        """
+        Use LLM to extract metadata from PDF text.
+
+        Args:
+            text: Text from first page of PDF
+
+        Returns:
+            Dictionary with extracted metadata (doi, pmid, title, authors)
+        """
+        # Truncate text to first 3000 characters for efficiency
+        truncated_text = text[:3000] if len(text) > 3000 else text
+
+        prompt = f"""Analyze this text from the first page of a biomedical research paper and extract the following metadata in JSON format:
+
+1. DOI (Digital Object Identifier) - look for patterns like "10.xxxx/..." or "doi:" followed by the identifier
+2. PMID (PubMed ID) - look for "PMID:" or "PubMed ID:" followed by numbers
+3. Title - the paper title (usually prominent at top of page)
+4. Authors - list of author names (usually appears near title)
+
+Return ONLY a valid JSON object with these fields:
+{{
+  "doi": "the DOI if found, otherwise null",
+  "pmid": "the PMID if found, otherwise null",
+  "title": "the paper title if found, otherwise null",
+  "authors": ["list", "of", "author", "names"] or []
+}}
+
+Important:
+- Return ONLY the JSON object, no other text
+- Use null for missing values
+- For DOI, include the full identifier (e.g., "10.1234/example")
+- For PMID, include only the numeric ID
+- For title, include the complete title
+- For authors, extract as many as clearly visible
+
+Text to analyze:
+{truncated_text}
+"""
+
+        try:
+            response = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={
+                    "model": self.model,
+                    "prompt": prompt,
+                    "stream": False,
+                    "options": {
+                        "temperature": 0.1,  # Low temperature for factual extraction
+                        "top_p": 0.9
+                    }
+                },
+                timeout=60
+            )
+
+            if response.status_code != 200:
+                logger.error(f"Ollama API error: {response.status_code}")
+                return self._empty_metadata()
+
+            result = response.json()
+            response_text = result.get('response', '').strip()
+
+            # Try to parse JSON from response
+            metadata = self._parse_llm_response(response_text)
+            logger.debug(f"Extracted metadata: {metadata}")
+            return metadata
+
+        except requests.exceptions.ConnectionError:
+            logger.error(f"Cannot connect to Ollama at {self.ollama_url}")
+            return self._empty_metadata()
+        except Exception as e:
+            logger.error(f"Error calling LLM: {e}")
+            return self._empty_metadata()
+
+    def _parse_llm_response(self, response_text: str) -> Dict[str, Any]:
+        """
+        Parse LLM response to extract JSON metadata.
+
+        Args:
+            response_text: Raw LLM response
+
+        Returns:
+            Parsed metadata dictionary
+        """
+        try:
+            # Try to find JSON in response
+            # Look for opening brace
+            start_idx = response_text.find('{')
+            if start_idx == -1:
+                logger.warning("No JSON object found in LLM response")
+                return self._empty_metadata()
+
+            # Find matching closing brace
+            end_idx = response_text.rfind('}')
+            if end_idx == -1:
+                logger.warning("No closing brace found in LLM response")
+                return self._empty_metadata()
+
+            json_text = response_text[start_idx:end_idx + 1]
+            metadata = json.loads(json_text)
+
+            # Validate structure
+            return {
+                'doi': metadata.get('doi'),
+                'pmid': metadata.get('pmid'),
+                'title': metadata.get('title'),
+                'authors': metadata.get('authors', [])
+            }
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse JSON from LLM response: {e}")
+            logger.debug(f"Response text: {response_text}")
+            return self._empty_metadata()
+
+    def _empty_metadata(self) -> Dict[str, Any]:
+        """Return empty metadata structure."""
+        return {
+            'doi': None,
+            'pmid': None,
+            'title': None,
+            'authors': []
+        }
+
+    def find_matching_document(self, metadata: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Find matching document in database using extracted metadata.
+
+        Tries multiple matching strategies in order:
+        1. Exact DOI match
+        2. Exact PMID match (external_id for PubMed source)
+        3. Title similarity match (fuzzy matching)
+
+        Args:
+            metadata: Extracted metadata dictionary
+
+        Returns:
+            Matching document dictionary or None
+        """
+        with self.db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                # Strategy 1: Exact DOI match
+                if metadata.get('doi'):
+                    doi = metadata['doi'].strip()
+                    cur.execute(
+                        "SELECT id, doi, title, publication_date, pdf_filename, pdf_url, external_id FROM document WHERE doi = %s",
+                        (doi,)
+                    )
+                    result = cur.fetchone()
+                    if result:
+                        logger.info(f"Found match by DOI: {doi}")
+                        return self._row_to_dict(result)
+
+                # Strategy 2: Exact PMID match
+                if metadata.get('pmid'):
+                    pmid = str(metadata['pmid']).strip()
+                    cur.execute(
+                        "SELECT id, doi, title, publication_date, pdf_filename, pdf_url, external_id FROM document WHERE external_id = %s",
+                        (pmid,)
+                    )
+                    result = cur.fetchone()
+                    if result:
+                        logger.info(f"Found match by PMID: {pmid}")
+                        return self._row_to_dict(result)
+
+                # Strategy 3: Title similarity match
+                if metadata.get('title'):
+                    title = metadata['title'].strip()
+                    # Use PostgreSQL similarity for fuzzy matching
+                    cur.execute("""
+                        SELECT id, doi, title, publication_date, pdf_filename, pdf_url, external_id,
+                               similarity(title, %s) AS sim
+                        FROM document
+                        WHERE similarity(title, %s) > 0.6
+                        ORDER BY sim DESC
+                        LIMIT 1
+                    """, (title, title))
+                    result = cur.fetchone()
+                    if result:
+                        # Row now has 8 columns (7 original + similarity score)
+                        doc = self._row_to_dict(result[:7])  # Take first 7 columns
+                        similarity = result[7]
+                        logger.info(f"Found match by title similarity ({similarity:.2f}): {doc['title'][:50]}...")
+                        return doc
+
+        logger.info("No matching document found in database")
+        return None
+
+    def _row_to_dict(self, row: tuple) -> Dict[str, Any]:
+        """Convert database row to document dictionary."""
+        return {
+            'id': row[0],
+            'doi': row[1],
+            'title': row[2],
+            'publication_date': row[3],
+            'pdf_filename': row[4],
+            'pdf_url': row[5],
+            'external_id': row[6]
+        }
+
+    def import_pdf_for_document(
+        self,
+        pdf_path: Path,
+        document: Dict[str, Any],
+        dry_run: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Import PDF file for a matched document.
+
+        Renames and moves the PDF to the correct location according to naming
+        conventions, and updates the database.
+
+        Args:
+            pdf_path: Path to source PDF file
+            document: Matched document dictionary
+            dry_run: If True, only report what would be done
+
+        Returns:
+            Dictionary with import result details
+        """
+        doc_id = document['id']
+
+        # Generate proper filename from DOI or document ID
+        if document.get('doi'):
+            safe_doi = document['doi'].replace('/', '_').replace('\\', '_')
+            new_filename = f"{safe_doi}.pdf"
+        else:
+            new_filename = f"doc_{doc_id}.pdf"
+
+        # Update document dict with new filename
+        document['pdf_filename'] = new_filename
+
+        # Get target path (year-based organization)
+        with self.db_manager.get_connection() as conn:
+            pdf_manager = PDFManager(base_dir=self.pdf_manager.base_dir, db_conn=conn)
+            target_path = pdf_manager.get_pdf_path(document, create_dirs=not dry_run)
+
+        if not target_path:
+            return {
+                'status': 'failed',
+                'reason': 'Could not determine target path',
+                'doc_id': doc_id
+            }
+
+        # Check if PDF already exists at target
+        if target_path.exists():
+            # Compare file sizes and dates
+            source_size = pdf_path.stat().st_size
+            target_size = target_path.stat().st_size
+            source_mtime = pdf_path.stat().st_mtime
+            target_mtime = target_path.stat().st_mtime
+
+            if pdf_path.resolve() == target_path.resolve():
+                return {
+                    'status': 'already_exists',
+                    'message': 'PDF already at correct location',
+                    'doc_id': doc_id,
+                    'path': str(target_path)
+                }
+
+            if source_size == target_size:
+                return {
+                    'status': 'duplicate',
+                    'message': 'PDF already exists with same size',
+                    'doc_id': doc_id,
+                    'existing_path': str(target_path)
+                }
+
+            # Different files - prefer newer one
+            if source_mtime > target_mtime:
+                logger.warning(f"Source PDF is newer than existing - will replace")
+                if not dry_run:
+                    target_path.unlink()
+            else:
+                return {
+                    'status': 'skipped',
+                    'reason': 'Existing PDF is newer',
+                    'doc_id': doc_id,
+                    'existing_path': str(target_path)
+                }
+
+        if dry_run:
+            return {
+                'status': 'would_import',
+                'doc_id': doc_id,
+                'source': str(pdf_path),
+                'target': str(target_path),
+                'filename': new_filename
+            }
+
+        # Actually perform import
+        try:
+            import shutil
+
+            # Ensure target directory exists
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Copy file (don't move in case of errors)
+            shutil.copy2(str(pdf_path), str(target_path))
+            logger.info(f"Copied PDF: {pdf_path} -> {target_path}")
+
+            # Update database
+            relative_path = pdf_manager.get_relative_pdf_path(document)
+            with self.db_manager.get_connection() as conn:
+                pdf_manager_with_conn = PDFManager(base_dir=self.pdf_manager.base_dir, db_conn=conn)
+                success = pdf_manager_with_conn.update_database_pdf_path(doc_id, relative_path)
+
+            if not success:
+                # Rollback - delete copied file
+                target_path.unlink()
+                return {
+                    'status': 'failed',
+                    'reason': 'Database update failed',
+                    'doc_id': doc_id
+                }
+
+            return {
+                'status': 'imported',
+                'doc_id': doc_id,
+                'source': str(pdf_path),
+                'target': str(target_path),
+                'filename': new_filename,
+                'doi': document.get('doi'),
+                'title': document.get('title', '')[:100]
+            }
+
+        except Exception as e:
+            logger.error(f"Error importing PDF: {e}")
+            return {
+                'status': 'failed',
+                'reason': str(e),
+                'doc_id': doc_id
+            }
+
+    def match_and_import_pdf(
+        self,
+        pdf_path: Path,
+        dry_run: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Analyze PDF, match to database, and import if match found.
+
+        Args:
+            pdf_path: Path to PDF file
+            dry_run: If True, only report what would be done
+
+        Returns:
+            Dictionary with complete analysis and import results
+        """
+        result = {
+            'pdf_path': str(pdf_path),
+            'pdf_filename': pdf_path.name,
+            'status': 'unknown'
+        }
+
+        # Check file exists
+        if not pdf_path.exists():
+            result['status'] = 'not_found'
+            result['error'] = 'File not found'
+            return result
+
+        # Extract text from first page
+        logger.info(f"Analyzing PDF: {pdf_path.name}")
+        text = self.extract_first_page_text(pdf_path)
+        if not text:
+            result['status'] = 'extraction_failed'
+            result['error'] = 'Could not extract text from PDF'
+            return result
+
+        # Extract metadata with LLM
+        metadata = self.extract_metadata_with_llm(text)
+        result['metadata'] = metadata
+
+        # Check if we got any useful metadata
+        if not any([metadata.get('doi'), metadata.get('pmid'), metadata.get('title')]):
+            result['status'] = 'no_metadata'
+            result['error'] = 'Could not extract DOI, PMID, or title from PDF'
+            return result
+
+        # Find matching document
+        document = self.find_matching_document(metadata)
+        if not document:
+            result['status'] = 'no_match'
+            result['message'] = 'No matching document found in database'
+            return result
+
+        result['matched_document'] = {
+            'id': document['id'],
+            'doi': document.get('doi'),
+            'pmid': document.get('external_id'),
+            'title': document.get('title', '')[:100]
+        }
+
+        # Import PDF
+        import_result = self.import_pdf_for_document(pdf_path, document, dry_run)
+        result.update(import_result)
+
+        return result
+
+    def match_and_import_directory(
+        self,
+        directory: Path,
+        dry_run: bool = False,
+        recursive: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Process all PDF files in a directory.
+
+        Args:
+            directory: Directory containing PDF files
+            dry_run: If True, only report what would be done
+            recursive: If True, search subdirectories
+
+        Returns:
+            Dictionary with batch processing statistics
+        """
+        if not directory.exists():
+            logger.error(f"Directory not found: {directory}")
+            return {
+                'error': f'Directory not found: {directory}',
+                'total': 0
+            }
+
+        # Find all PDF files
+        if recursive:
+            pdf_files = list(directory.rglob('*.pdf'))
+        else:
+            pdf_files = list(directory.glob('*.pdf'))
+
+        stats = {
+            'total': len(pdf_files),
+            'imported': 0,
+            'no_match': 0,
+            'already_exists': 0,
+            'failed': 0,
+            'skipped': 0,
+            'details': []
+        }
+
+        logger.info(f"Found {stats['total']} PDF files in {directory}")
+
+        # Process each PDF
+        if tqdm:
+            progress = tqdm(pdf_files, desc="Processing PDFs", unit="file")
+        else:
+            progress = pdf_files
+
+        for pdf_file in progress:
+            if tqdm:
+                progress.set_description(f"Processing {pdf_file.name[:30]}")
+
+            result = self.match_and_import_pdf(pdf_file, dry_run)
+
+            # Update statistics
+            status = result.get('status', 'unknown')
+            if status == 'imported':
+                stats['imported'] += 1
+            elif status == 'no_match':
+                stats['no_match'] += 1
+            elif status in ['already_exists', 'duplicate']:
+                stats['already_exists'] += 1
+            elif status == 'skipped':
+                stats['skipped'] += 1
+            else:
+                stats['failed'] += 1
+
+            stats['details'].append(result)
+
+        logger.info(f"Batch processing complete: {stats['imported']} imported, "
+                   f"{stats['no_match']} no match, {stats['failed']} failed")
+
+        return stats


### PR DESCRIPTION
Implements a comprehensive PDF import system that analyzes PDF files, extracts metadata using LLMs, matches them to existing documents in the database, and imports them with proper naming and organization.

Key features:
- LLM-based metadata extraction (DOI, PMID, title, authors)
- Multiple matching strategies (DOI, PMID, fuzzy title matching)
- Automatic PDF organization by year
- Batch directory processing with progress tracking
- Dry run mode for previewing changes
- Comprehensive status reporting

Components added:
- src/bmlibrarian/importers/pdf_matcher.py: Core matching logic
- pdf_import_cli.py: Command-line interface for import operations
- doc/users/pdf_import_guide.md: Comprehensive user documentation
- Updated CLAUDE.md with CLI commands and project structure

Use cases:
- Import single PDF: uv run python pdf_import_cli.py file paper.pdf
- Import directory: uv run python pdf_import_cli.py directory /pdfs/
- Check status: uv run python pdf_import_cli.py status