### PR TITLE
Add semantic search options to Qt Document Search plugin

### DIFF
--- a/src/bmlibrarian/gui/qt/plugins/settings/plugin.py
+++ b/src/bmlibrarian/gui/qt/plugins/settings/plugin.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, Slot, Signal
 from typing import Dict, Optional
 
-from bmlibrarian.cli.config import get_config, DEFAULT_CONFIG
+from bmlibrarian.config import get_config, DEFAULT_CONFIG
 from ...tabs.general_tab import GeneralSettingsTab
 from ...tabs.agent_tab import AgentConfigTab
 from ...tabs.search_tab import SearchSettingsTab

--- a/src/bmlibrarian/gui/qt/tabs/agent_tab.py
+++ b/src/bmlibrarian/gui/qt/tabs/agent_tab.py
@@ -326,7 +326,7 @@ class AgentConfigTab:
         """Update configuration from UI controls."""
         try:
             # Get agent config section
-            from bmlibrarian.cli.config import get_config
+            from bmlibrarian.config import get_config
             config = get_config()
 
             # Ensure agents section exists


### PR DESCRIPTION
## Summary

This PR adds comprehensive semantic search capabilities to the Qt-based Document Search plugin, bringing feature parity with the Flet-based Research GUI. It also fixes a critical import bug that prevented the Settings plugin from loading.

## Changes

### 1. Qt Document Search Plugin - Semantic Search Integration

**File**: `src/bmlibrarian/gui/qt/plugins/search/search_tab.py` (+259/-115 lines)

#### New Features:
- **Search Strategy Checkboxes**: 4 search methods available
  - ✅ **Keyword**: PostgreSQL full-text search (default enabled)
  - ✅ **BM25**: Probabilistic ranking algorithm  
  - ✅ **Semantic**: Vector similarity search using embeddings
  - ✅ **HyDE**: Hypothetical Document Embeddings search

- **Re-ranking Dropdown**: 4 result fusion methods
  - **Sum Scores**: Simple sum of scores from all strategies (default)
  - **RRF**: Reciprocal Rank Fusion (rank-based algorithm)
  - **Max Score**: Uses highest score from any strategy
  - **Weighted Fusion**: Configurable weights per strategy

#### Architecture Changes:
- **SearchWorker Refactored**: Now uses `search_hybrid()` function instead of direct SQL queries
- **QueryAgent Integration**: Natural language to PostgreSQL tsquery conversion
- **Configuration Loading**: Reads search strategy defaults from `~/.bmlibrarian/config.json`
- **Post-filtering**: Year and journal filters applied after hybrid search
- **Smart Sorting**: Results sorted by combined score when available, otherwise by publication date

#### Validation:
- Requires at least one search strategy enabled
- Text query required before search
- Comprehensive error handling with traceback

### 2. Import Bug Fixes

**Files**: 
- `src/bmlibrarian/gui/qt/plugins/settings/plugin.py` (1 line)
- `src/bmlibrarian/gui/qt/tabs/agent_tab.py` (1 line)

#### Issue Fixed:
```python
# Before (incorrect):
from bmlibrarian.cli.config import get_config, DEFAULT_CONFIG

# After (correct):
from bmlibrarian.config import get_config, DEFAULT_CONFIG
Error Message:

ImportError: cannot import name 'get_config' from 'bmlibrarian.cli.config'
Impact:

Research tab now loads correctly
Settings plugin initializes without errors
Agent configuration tabs work properly
Testing
✅ All modified Python files compile successfully (py_compile)
✅ No remaining incorrect imports in Qt GUI codebase
✅ Clean commit history with descriptive messages
✅ Maintains backward compatibility with existing configuration system
Key Benefits
Feature Parity: Qt GUI now has same semantic search capabilities as Flet GUI
Advanced Search: Users can leverage BM25, semantic vectors, and HyDE strategies
Flexible Fusion: Configurable result re-ranking methods for optimal relevance
Bug-Free Loading: Settings plugin and Research tab now work correctly
Configuration Integration: Seamless integration with existing ~/.bmlibrarian/config.json
Compatibility
✅ Backward compatible with existing database queries
✅ Uses same search_hybrid() function as Flet GUI
✅ Respects existing configuration schema
✅ No breaking changes to other components
Related
This implementation mirrors the functionality previously added to the Flet-based Research GUI in PR #41.