### PR TITLE
Fix Document Search Tab Issues and Improve UX

### DIFF
--- a/src/bmlibrarian/database.py
+++ b/src/bmlibrarian/database.py
@@ -991,7 +991,25 @@ def search_hybrid(
         'fulltext_search_params': None
     }
 
-    logger.info("Starting hybrid search")
+    # Determine which strategies are enabled for better logging
+    enabled_strategies = []
+    if search_config.get('semantic', {}).get('enabled', False):
+        enabled_strategies.append('semantic')
+    if search_config.get('bm25', {}).get('enabled', False):
+        enabled_strategies.append('BM25')
+    if search_config.get('fulltext', search_config.get('keyword', {})).get('enabled', False):
+        enabled_strategies.append('fulltext')
+    if search_config.get('hyde', {}).get('enabled', False):
+        enabled_strategies.append('HyDE')
+
+    # Log appropriate search type
+    if len(enabled_strategies) == 0:
+        logger.info("Starting search (no strategies explicitly enabled, will use fulltext fallback)")
+    elif len(enabled_strategies) == 1:
+        logger.info(f"Starting {enabled_strategies[0]} search")
+    else:
+        logger.info(f"Starting hybrid search (strategies: {', '.join(enabled_strategies)})")
+
     logger.info(f"  Search text: '{search_text}'")
     logger.info(f"  Query text: '{query_text}'")
 


### PR DESCRIPTION
# Fix Document Search Tab Issues and Improve UX

This PR addresses critical bugs and significantly improves the user experience of the Qt GUI Document Search tab.

## Issues Fixed

### 1. AttributeError Crash
**Problem**: Search crashed with `'NoneType' object has no attribute 'strip'` when journal filter was None  
**Solution**: Fixed by using `(value or '').strip()` pattern to safely handle None values

### 2. Misleading Logging
**Problem**: Database always logged "Starting hybrid search" even when only one strategy was enabled (e.g., semantic-only search)  
**Solution**: Updated `search_hybrid()` to intelligently detect enabled strategies and log appropriately:
- `"Starting semantic search"` when only semantic is enabled
- `"Starting BM25 search"` when only BM25 is enabled  
- `"Starting hybrid search (strategies: X, Y)"` when multiple enabled
- `"Starting search (no strategies explicitly enabled, will use fulltext fallback)"` when none enabled

## UX Improvements

### 3. Redesigned Search Interface
**Changes**:
- **Removed** unnecessary "Journal" filter field to save screen space
- **Expanded** search text box to use maximum available width
- **Moved** Search button to same row as search box
- **New layout**: `[Search for: ______________________________ [Search]]`
- Search box now properly accommodates long research questions

### 4. Improved Filter Controls
**Year Fields**:
- Replaced spinners (QSpinBox) with text fields (QLineEdit)
- Fields now **empty by default** (no preset 2000/2025 values)
- Compact 80px width for space efficiency
- Year filters **only applied when fields contain values**
- Added validation with user-friendly error dialogs

**Semantic Search Threshold**:
- New field for controlling semantic similarity threshold
- Default placeholder shows "0.7" (standard threshold)
- Compact 60px width
- Validates input is float between 0.0 and 1.0
- Properly passes threshold to `search_hybrid()` via search_config
- Uses default (0.7) if field is empty

## Updated UI Layout

```
[Search for: ____________________________________________ [Search]]

Year From: [____]  |  Year To: [____]  |  Semantic Threshold: [____]
Source: [All ▼]  |  Max Results: [100 ▼]

☑ Keyword  ☑ BM25  ☑ Semantic  ☑ HyDE  |  Re-ranking: [Sum Scores ▼]

[Clear Filters]
```

All filters are now optional and empty by default.

## Files Modified
- `src/bmlibrarian/gui/qt/plugins/search/search_tab.py` - Complete filter interface redesign
- `src/bmlibrarian/database.py` - Improved logging for search strategies

## Testing
- ✅ Syntax validated with `python -m py_compile`
- ✅ AttributeError fixed (handles None values properly)
- ✅ Year validation works (shows error for invalid input)
- ✅ Semantic threshold validation works (0.0-1.0 range)
- ✅ Clear Filters properly clears all new fields
- ✅ Semantic-only search now logs correctly

## Breaking Changes
None - all changes are backward compatible.
