### PR TITLE
Create document card factory pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,50 @@ BMLibrarian uses a sophisticated multi-agent architecture with enum-based workfl
 6. **EditorAgent**: Creates balanced comprehensive reports integrating all evidence
 7. **FactCheckerAgent**: Evaluates biomedical statements (yes/no/maybe) with literature evidence for training data auditing
 
+### Document Card Factory System
+
+BMLibrarian uses a factory pattern for creating document cards with consistent functionality across different UI frameworks (Flet and Qt).
+
+**Key Features**:
+- **Framework-Agnostic Interface**: Single API for creating cards in Flet or Qt
+- **Three-State PDF Buttons**: VIEW (local PDF), FETCH (download from URL), UPLOAD (manual upload)
+- **Consistent Styling**: Unified appearance across frameworks
+- **Context-Aware Rendering**: Different card styles for literature, scoring, citations, etc.
+- **Extensible Design**: Easy to add new card variations or contexts
+
+**Factory Classes**:
+- `DocumentCardFactoryBase`: Abstract base class with common utilities
+- `FletDocumentCardFactory`: Flet-specific implementation with `ft.ExpansionTile` cards
+- `QtDocumentCardFactory`: Qt-specific implementation with `QFrame` cards and integrated PDF buttons
+
+**Usage Example**:
+```python
+from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+from bmlibrarian.gui.document_card_factory_base import DocumentCardData, CardContext
+
+factory = FletDocumentCardFactory(page=page)
+card_data = DocumentCardData(
+    doc_id=12345,
+    title="Example Study",
+    authors=["Smith J", "Johnson A"],
+    year=2023,
+    relevance_score=4.5,
+    pdf_url="https://example.com/paper.pdf",
+    context=CardContext.LITERATURE,
+    show_pdf_button=True
+)
+card = factory.create_card(card_data)
+```
+
+**PDF Button States**:
+- **VIEW** (Blue): Local PDF exists → Opens in viewer
+- **FETCH** (Orange): URL available → Downloads then transitions to VIEW
+- **UPLOAD** (Green): No PDF → File picker then transitions to VIEW
+
+**See Documentation**:
+- Developer guide: `doc/developers/document_card_factory_system.md`
+- Demo: `examples/document_card_factory_demo.py`
+
 ### Multi-Model Query Generation
 
 BMLibrarian supports using multiple AI models to generate diverse database queries for improved document retrieval. This feature leverages the strengths of different models to create query variations that often find more relevant literature than single-model approaches.

--- a/doc/developers/document_card_factory_system.md
+++ b/doc/developers/document_card_factory_system.md
@@ -1,0 +1,621 @@
+# Document Card Factory System
+
+## Overview
+
+The Document Card Factory system provides a unified, framework-agnostic interface for creating document cards across different UI frameworks (Flet and Qt). This architecture ensures consistency in appearance and functionality while allowing for framework-specific implementations.
+
+## Architecture
+
+### Key Components
+
+1. **DocumentCardFactoryBase** (`document_card_factory_base.py`)
+   - Abstract base class defining the factory interface
+   - Common utility methods for formatting metadata, authors, scores
+   - PDF state determination logic
+   - Framework-agnostic data structures
+
+2. **FletDocumentCardFactory** (`flet_document_card_factory.py`)
+   - Flet-specific implementation
+   - Wraps existing `UnifiedDocumentCard` class
+   - Provides Flet-style PDF buttons with three states
+
+3. **QtDocumentCardFactory** (`qt/qt_document_card_factory.py`)
+   - Qt-specific implementation
+   - Integrates with existing Qt card widgets
+   - Adds PDF button functionality to Qt cards (previously missing)
+
+### Data Structures
+
+#### DocumentCardData
+```python
+@dataclass
+class DocumentCardData:
+    """Data for rendering a document card."""
+    # Core document data
+    doc_id: int
+    title: str
+    abstract: Optional[str] = None
+    authors: Optional[List[str]] = None
+    year: Optional[int] = None
+    journal: Optional[str] = None
+    pmid: Optional[str] = None
+    doi: Optional[str] = None
+    source: Optional[str] = None
+
+    # Scoring data
+    relevance_score: Optional[float] = None
+    human_score: Optional[float] = None
+    confidence: Optional[str] = None
+
+    # Citation data
+    citations: Optional[List[Dict[str, Any]]] = None
+
+    # PDF data
+    pdf_path: Optional[Path] = None
+    pdf_url: Optional[str] = None
+
+    # Display options
+    context: CardContext = CardContext.LITERATURE
+    show_abstract: bool = True
+    show_metadata: bool = True
+    show_pdf_button: bool = True
+    expanded_by_default: bool = False
+
+    # Callbacks
+    on_score_change: Optional[Callable] = None
+    on_citation_select: Optional[Callable] = None
+    on_pdf_action: Optional[Callable] = None
+```
+
+#### PDFButtonConfig
+```python
+@dataclass
+class PDFButtonConfig:
+    """Configuration for PDF button behavior."""
+    state: PDFButtonState
+    pdf_path: Optional[Path] = None
+    pdf_url: Optional[str] = None
+    on_view: Optional[Callable] = None
+    on_fetch: Optional[Callable] = None
+    on_upload: Optional[Callable] = None
+    show_notifications: bool = True
+```
+
+#### CardContext
+```python
+class CardContext(Enum):
+    """Context in which a document card is being displayed."""
+    LITERATURE = "literature"
+    SCORING = "scoring"
+    CITATIONS = "citations"
+    COUNTERFACTUAL = "counterfactual"
+    REPORT = "report"
+    SEARCH = "search"
+    REVIEW = "review"
+```
+
+#### PDFButtonState
+```python
+class PDFButtonState(Enum):
+    """State of the PDF button for a document."""
+    VIEW = "view"      # Local PDF exists, can view
+    FETCH = "fetch"    # PDF URL available, can download
+    UPLOAD = "upload"  # No PDF, allow manual upload
+    HIDDEN = "hidden"  # No PDF button shown
+```
+
+## PDF Button Three-State System
+
+The PDF button has three distinct states based on PDF availability:
+
+### 1. VIEW State (Blue)
+- **Condition**: Local PDF file exists
+- **Button Text**: "📄 View Full Text"
+- **Action**: Opens PDF in viewer (system default or embedded viewer)
+- **Color**: Blue (#1976D2)
+
+### 2. FETCH State (Orange)
+- **Condition**: PDF URL available but no local file
+- **Button Text**: "⬇️ Fetch Full Text"
+- **Action**: Downloads PDF from URL, then transitions to VIEW state
+- **Color**: Orange (#F57C00)
+
+### 3. UPLOAD State (Green)
+- **Condition**: No local PDF and no URL
+- **Button Text**: "📤 Upload Full Text"
+- **Action**: Opens file picker for manual upload, then transitions to VIEW state
+- **Color**: Green (#388E3C)
+
+### State Transitions
+
+```
+┌─────────┐  Download   ┌──────┐
+│  FETCH  │ ───────────>│ VIEW │
+└─────────┘             └──────┘
+                           ^
+┌─────────┐  Upload        │
+│ UPLOAD  │ ───────────────┘
+└─────────┘
+```
+
+After successful fetch or upload, the button automatically transitions to VIEW state.
+
+## Usage Examples
+
+### Basic Flet Example
+
+```python
+import flet as ft
+from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+from bmlibrarian.gui.document_card_factory_base import DocumentCardData, CardContext
+
+def main(page: ft.Page):
+    # Create factory
+    factory = FletDocumentCardFactory(page=page)
+
+    # Create card data
+    card_data = DocumentCardData(
+        doc_id=12345,
+        title="Example Study on Cardiovascular Health",
+        abstract="This study examines...",
+        authors=["Smith J", "Johnson A"],
+        year=2023,
+        journal="Journal of Cardiology",
+        pmid="12345678",
+        relevance_score=4.5,
+        pdf_url="https://example.com/paper.pdf",
+        context=CardContext.LITERATURE,
+        show_pdf_button=True
+    )
+
+    # Create card
+    card = factory.create_card(card_data)
+
+    # Add to page
+    page.add(card)
+
+ft.app(target=main)
+```
+
+### Basic Qt Example
+
+```python
+from PySide6.QtWidgets import QApplication, QVBoxLayout, QWidget
+from bmlibrarian.gui.qt.qt_document_card_factory import QtDocumentCardFactory
+from bmlibrarian.gui.document_card_factory_base import DocumentCardData, CardContext
+
+app = QApplication([])
+
+# Create factory
+factory = QtDocumentCardFactory()
+
+# Create card data
+card_data = DocumentCardData(
+    doc_id=12345,
+    title="Example Study on Cardiovascular Health",
+    abstract="This study examines...",
+    authors=["Smith J", "Johnson A"],
+    year=2023,
+    journal="Journal of Cardiology",
+    pmid="12345678",
+    relevance_score=4.5,
+    context=CardContext.LITERATURE,
+    show_pdf_button=True
+)
+
+# Create card
+card = factory.create_card(card_data)
+
+# Add to layout
+widget = QWidget()
+layout = QVBoxLayout(widget)
+layout.addWidget(card)
+widget.show()
+
+app.exec()
+```
+
+### Custom PDF Handlers
+
+```python
+from pathlib import Path
+from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+from bmlibrarian.gui.document_card_factory_base import DocumentCardData
+
+def custom_pdf_action_handler(action: str, doc_id: int, *args):
+    """Custom handler for PDF actions."""
+    if action == 'view':
+        print(f"Viewing PDF for document {doc_id}")
+        # Custom view logic
+    elif action == 'fetch':
+        pdf_url = args[0]
+        print(f"Fetching PDF from {pdf_url}")
+        # Custom fetch logic
+        return Path("/path/to/downloaded.pdf")
+    elif action == 'upload':
+        print(f"Uploading PDF for document {doc_id}")
+        # Custom upload logic
+        return Path("/path/to/uploaded.pdf")
+
+# Use with card data
+card_data = DocumentCardData(
+    doc_id=12345,
+    title="Example Study",
+    on_pdf_action=custom_pdf_action_handler,
+    show_pdf_button=True
+)
+```
+
+## Implementation Details
+
+### PDF State Determination Logic
+
+The factory automatically determines the appropriate PDF button state:
+
+```python
+def determine_pdf_state(
+    self,
+    doc_id: int,
+    pdf_path: Optional[Path] = None,
+    pdf_url: Optional[str] = None
+) -> PDFButtonState:
+    # 1. Check explicit path
+    if pdf_path and pdf_path.exists():
+        return PDFButtonState.VIEW
+
+    # 2. Check standard location
+    standard_path = self.base_pdf_dir / f"{doc_id}.pdf"
+    if standard_path.exists():
+        return PDFButtonState.VIEW
+
+    # 3. Check if URL available
+    if pdf_url:
+        return PDFButtonState.FETCH
+
+    # 4. Default to upload
+    return PDFButtonState.UPLOAD
+```
+
+### Framework-Specific Implementations
+
+#### Flet Implementation
+
+The Flet factory wraps the existing `UnifiedDocumentCard` class and maps the factory's data structures to Flet's expected format:
+
+```python
+class FletDocumentCardFactory(DocumentCardFactoryBase):
+    def create_card(self, card_data: DocumentCardData) -> ft.ExpansionTile:
+        # Convert CardContext to DocumentCardContext
+        # Prepare document dictionary
+        # Delegate to UnifiedDocumentCard
+        return self._card_creator.create_card(...)
+```
+
+#### Qt Implementation
+
+The Qt factory integrates with existing Qt card widgets and adds PDF button functionality:
+
+```python
+class QtDocumentCardFactory(DocumentCardFactoryBase):
+    def create_card(self, card_data: DocumentCardData) -> QFrame:
+        # Create CollapsibleDocumentCard
+        card = CollapsibleDocumentCard(doc)
+
+        # Add PDF button to details layout
+        if card_data.show_pdf_button:
+            pdf_button = self._create_pdf_button_for_card(card_data)
+            card.details_layout.addWidget(pdf_button)
+
+        return card
+```
+
+### Qt PDF Button Widget
+
+The `PDFButtonWidget` is a custom Qt widget that manages the three PDF button states:
+
+```python
+class PDFButtonWidget(QPushButton):
+    """Qt PDF button with three states."""
+
+    pdf_viewed = Signal()
+    pdf_fetched = Signal(Path)
+    pdf_uploaded = Signal(Path)
+
+    def _handle_click(self):
+        if self.config.state == PDFButtonState.VIEW:
+            self._handle_view()
+        elif self.config.state == PDFButtonState.FETCH:
+            self._handle_fetch()
+        elif self.config.state == PDFButtonState.UPLOAD:
+            self._handle_upload()
+
+    def _transition_to_view(self, pdf_path: Path):
+        """Transition to VIEW state after fetch/upload."""
+        self.config.pdf_path = pdf_path
+        self.config.state = PDFButtonState.VIEW
+        self._update_button_appearance()
+```
+
+## Extending the Factory System
+
+### Creating a New Card Context
+
+1. Add new context to `CardContext` enum:
+```python
+class CardContext(Enum):
+    LITERATURE = "literature"
+    SCORING = "scoring"
+    # ... existing contexts
+    NEW_CONTEXT = "new_context"  # Add new context
+```
+
+2. Update framework-specific factories to handle new context:
+```python
+def create_card(self, card_data: DocumentCardData):
+    if card_data.context == CardContext.NEW_CONTEXT:
+        # Handle new context-specific rendering
+        pass
+```
+
+### Adding Custom Card Variations
+
+To create a new card variation:
+
+1. Subclass the appropriate factory
+2. Override `create_card()` method
+3. Add custom rendering logic
+
+Example:
+```python
+class CustomFletCardFactory(FletDocumentCardFactory):
+    def create_card(self, card_data: DocumentCardData):
+        # Custom pre-processing
+        card_data = self._customize_card_data(card_data)
+
+        # Call parent implementation
+        card = super().create_card(card_data)
+
+        # Custom post-processing
+        return self._add_custom_features(card)
+```
+
+## Testing
+
+### Unit Tests
+
+Run the complete test suite:
+```bash
+uv run python -m pytest tests/test_document_card_factory.py -v
+```
+
+### Test Coverage
+
+The test suite covers:
+- PDF state determination logic
+- Author formatting
+- Metadata formatting
+- Score color mapping
+- Abstract truncation
+- Card creation for both frameworks
+- PDF button widget functionality
+- Custom callback handling
+
+### Example Test
+
+```python
+def test_determine_pdf_state_view(tmp_path):
+    """Test PDF state when local file exists."""
+    pdf_file = tmp_path / "12345.pdf"
+    pdf_file.write_text("test")
+
+    factory = TestFactory(base_pdf_dir=tmp_path)
+    state = factory.determine_pdf_state(12345)
+
+    assert state == PDFButtonState.VIEW
+```
+
+## Best Practices
+
+### 1. Use Factory Pattern for All New Cards
+
+Always use the factory pattern when creating new document cards:
+
+❌ **Don't**:
+```python
+# Directly instantiating card classes
+card = UnifiedDocumentCard(page, pdf_manager)
+card.create_card(index, doc, ...)
+```
+
+✅ **Do**:
+```python
+# Using factory pattern
+factory = FletDocumentCardFactory(page, pdf_manager)
+card_data = DocumentCardData(doc_id=123, title="Example")
+card = factory.create_card(card_data)
+```
+
+### 2. Leverage CardContext
+
+Use appropriate context for different scenarios:
+
+```python
+# Literature browsing
+card_data = DocumentCardData(..., context=CardContext.LITERATURE)
+
+# Document scoring
+card_data = DocumentCardData(..., context=CardContext.SCORING)
+
+# Citation extraction
+card_data = DocumentCardData(..., context=CardContext.CITATIONS)
+```
+
+### 3. Handle PDF Actions Consistently
+
+Implement PDF action handlers that return appropriate values:
+
+```python
+def on_pdf_fetch(url: str) -> Optional[Path]:
+    """Fetch handler should return downloaded path."""
+    try:
+        path = download_pdf(url)
+        return path
+    except Exception as e:
+        logger.error(f"Download failed: {e}")
+        return None
+```
+
+### 4. Maintain Consistent Styling
+
+Use the factory's built-in utilities for consistent formatting:
+
+```python
+# Use factory methods
+authors_text = factory.format_authors(authors, max_authors=3)
+score_color = factory.get_score_color(relevance_score)
+metadata = factory.format_metadata(year, journal, pmid, doi)
+
+# Don't reinvent formatting logic
+```
+
+### 5. Test Both Frameworks
+
+When making changes to the factory system, test both Flet and Qt implementations:
+
+```bash
+# Test Flet
+uv run python examples/document_card_factory_demo.py --framework flet
+
+# Test Qt
+uv run python examples/document_card_factory_demo.py --framework qt
+```
+
+## Migration Guide
+
+### Migrating Existing Code to Factory Pattern
+
+#### Before (Direct Card Creation)
+
+```python
+# Old Flet code
+card_creator = UnifiedDocumentCard(page, pdf_manager)
+card = card_creator.create_card(
+    index=0,
+    doc=doc_dict,
+    context="literature",
+    ai_score=4.5,
+    show_scoring_controls=False
+)
+```
+
+#### After (Factory Pattern)
+
+```python
+# New factory-based code
+from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+from bmlibrarian.gui.document_card_factory_base import DocumentCardData, CardContext
+
+factory = FletDocumentCardFactory(page, pdf_manager)
+card_data = DocumentCardData(
+    doc_id=doc_dict['id'],
+    title=doc_dict['title'],
+    abstract=doc_dict.get('abstract'),
+    authors=doc_dict.get('authors'),
+    year=doc_dict.get('year'),
+    journal=doc_dict.get('publication'),
+    pmid=doc_dict.get('pmid'),
+    doi=doc_dict.get('doi'),
+    relevance_score=4.5,
+    context=CardContext.LITERATURE
+)
+card = factory.create_card(card_data)
+```
+
+## Performance Considerations
+
+### Card Creation Overhead
+
+The factory pattern adds minimal overhead:
+- Factory instantiation: O(1)
+- Card data creation: O(1)
+- Card creation: Same as direct instantiation
+
+### Memory Usage
+
+- Factory instances are lightweight (shared utilities)
+- Card data structures use dataclasses (efficient)
+- Recommended: Create one factory instance per page/window
+
+### Optimization Tips
+
+1. **Reuse Factory Instances**:
+```python
+# Create once
+factory = FletDocumentCardFactory(page)
+
+# Reuse for multiple cards
+for doc in documents:
+    card_data = DocumentCardData(...)
+    card = factory.create_card(card_data)
+```
+
+2. **Lazy PDF State Determination**:
+```python
+# PDF state is only determined when card is created
+# No upfront filesystem checks
+```
+
+3. **Batch Card Creation**:
+```python
+# Create cards in batch
+cards = [factory.create_card(DocumentCardData(...))
+         for doc in documents]
+```
+
+## Troubleshooting
+
+### PDF Button Not Showing
+
+**Problem**: PDF button not appearing in card
+
+**Solutions**:
+1. Check `show_pdf_button=True` in `DocumentCardData`
+2. Verify PDF state is not `HIDDEN`
+3. For Qt: Ensure `details_layout` is accessible
+
+### PDF State Incorrect
+
+**Problem**: Button shows wrong state (e.g., FETCH instead of VIEW)
+
+**Solutions**:
+1. Check `base_pdf_dir` configuration
+2. Verify PDF file exists at expected location
+3. Check file permissions
+4. Use `factory.get_pdf_path(doc_id)` to debug
+
+### Qt Card Not Showing PDF Button
+
+**Problem**: Qt cards don't have PDF buttons after migration
+
+**Solution**:
+```python
+# Ensure using QtDocumentCardFactory
+from bmlibrarian.gui.qt.qt_document_card_factory import QtDocumentCardFactory
+
+factory = QtDocumentCardFactory()
+card = factory.create_card(card_data)  # PDF button included
+```
+
+## Related Documentation
+
+- [User Guide: Multi-Model Query Generation](../users/multi_model_query_guide.md)
+- [Developer Guide: Agent Module](agent_module.md)
+- [Developer Guide: Citation System](citation_system.md)
+- [Examples: Document Card Factory Demo](../../examples/document_card_factory_demo.py)
+
+## API Reference
+
+See inline documentation in:
+- `src/bmlibrarian/gui/document_card_factory_base.py`
+- `src/bmlibrarian/gui/flet_document_card_factory.py`
+- `src/bmlibrarian/gui/qt/qt_document_card_factory.py`

--- a/examples/document_card_factory_demo.py
+++ b/examples/document_card_factory_demo.py
@@ -1,0 +1,281 @@
+"""
+Document Card Factory Demo
+
+Demonstrates how to use the document card factory pattern to create
+consistent document cards across different UI frameworks (Flet and Qt).
+"""
+
+import sys
+from pathlib import Path
+
+# Example 1: Using Flet Factory
+def flet_example():
+    """Example of creating document cards with Flet."""
+    import flet as ft
+    from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+    from bmlibrarian.gui.document_card_factory_base import (
+        DocumentCardData, CardContext, PDFButtonConfig, PDFButtonState
+    )
+
+    def main(page: ft.Page):
+        page.title = "Flet Document Card Factory Demo"
+        page.padding = 20
+
+        # Create factory
+        factory = FletDocumentCardFactory(
+            page=page,
+            pdf_manager=None,  # Optional PDF manager
+            base_pdf_dir=Path.home() / "knowledgebase" / "pdf"
+        )
+
+        # Example 1: Card with VIEW PDF button (local PDF exists)
+        card_data_view = DocumentCardData(
+            doc_id=12345,
+            title="Cardiovascular Benefits of Regular Exercise: A Meta-Analysis",
+            abstract="This comprehensive meta-analysis examines the cardiovascular benefits...",
+            authors=["Smith J", "Johnson A", "Williams B"],
+            year=2023,
+            journal="Journal of Cardiology",
+            pmid="12345678",
+            doi="10.1234/jcard.2023.001",
+            relevance_score=4.5,
+            pdf_path=Path("/path/to/existing.pdf"),  # If file exists, shows VIEW button
+            context=CardContext.LITERATURE,
+            show_pdf_button=True
+        )
+
+        # Example 2: Card with FETCH PDF button (URL available)
+        card_data_fetch = DocumentCardData(
+            doc_id=23456,
+            title="Novel Biomarkers for Early Detection of Alzheimer's Disease",
+            abstract="Recent advances in proteomics have identified several novel biomarkers...",
+            authors=["Chen X", "Rodriguez M", "Kim S", "et al."],
+            year=2024,
+            journal="Nature Neuroscience",
+            doi="10.1038/nn.2024.456",
+            relevance_score=3.8,
+            pdf_url="https://example.com/paper.pdf",  # URL available, shows FETCH button
+            context=CardContext.SCORING,
+            show_pdf_button=True
+        )
+
+        # Example 3: Card with UPLOAD PDF button (no PDF available)
+        card_data_upload = DocumentCardData(
+            doc_id=34567,
+            title="Machine Learning in Medical Diagnosis: Current State and Future Directions",
+            abstract="This review explores the application of machine learning algorithms...",
+            authors=["Anderson T", "Brown K"],
+            year=2023,
+            journal="AI in Medicine",
+            pmid="34567890",
+            relevance_score=2.9,
+            # No pdf_path or pdf_url, shows UPLOAD button
+            context=CardContext.CITATIONS,
+            show_pdf_button=True
+        )
+
+        # Create cards using factory
+        card1 = factory.create_card(card_data_view)
+        card2 = factory.create_card(card_data_fetch)
+        card3 = factory.create_card(card_data_upload)
+
+        # Add to page
+        page.add(
+            ft.Text("Document Card Factory Demo", size=24, weight=ft.FontWeight.BOLD),
+            ft.Divider(),
+            ft.Text("Card 1: With local PDF (VIEW button)", size=16, weight=ft.FontWeight.BOLD),
+            card1,
+            ft.Divider(),
+            ft.Text("Card 2: With PDF URL (FETCH button)", size=16, weight=ft.FontWeight.BOLD),
+            card2,
+            ft.Divider(),
+            ft.Text("Card 3: No PDF (UPLOAD button)", size=16, weight=ft.FontWeight.BOLD),
+            card3,
+        )
+
+    ft.app(target=main)
+
+
+# Example 2: Using Qt Factory
+def qt_example():
+    """Example of creating document cards with Qt."""
+    from PySide6.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget, QLabel
+    from bmlibrarian.gui.qt.qt_document_card_factory import QtDocumentCardFactory
+    from bmlibrarian.gui.document_card_factory_base import (
+        DocumentCardData, CardContext
+    )
+
+    app = QApplication(sys.argv)
+
+    # Create factory
+    factory = QtDocumentCardFactory(
+        pdf_manager=None,
+        base_pdf_dir=Path.home() / "knowledgebase" / "pdf"
+    )
+
+    # Example document cards
+    card_data_1 = DocumentCardData(
+        doc_id=12345,
+        title="Cardiovascular Benefits of Regular Exercise: A Meta-Analysis",
+        abstract="This comprehensive meta-analysis examines the cardiovascular benefits...",
+        authors=["Smith J", "Johnson A", "Williams B"],
+        year=2023,
+        journal="Journal of Cardiology",
+        pmid="12345678",
+        doi="10.1234/jcard.2023.001",
+        relevance_score=4.5,
+        context=CardContext.LITERATURE,
+        show_pdf_button=True
+    )
+
+    card_data_2 = DocumentCardData(
+        doc_id=23456,
+        title="Novel Biomarkers for Early Detection of Alzheimer's Disease",
+        abstract="Recent advances in proteomics have identified several novel biomarkers...",
+        authors=["Chen X", "Rodriguez M", "Kim S"],
+        year=2024,
+        journal="Nature Neuroscience",
+        doi="10.1038/nn.2024.456",
+        relevance_score=3.8,
+        pdf_url="https://example.com/paper.pdf",
+        context=CardContext.SCORING,
+        show_pdf_button=True
+    )
+
+    # Create main window
+    window = QMainWindow()
+    window.setWindowTitle("Qt Document Card Factory Demo")
+    window.setGeometry(100, 100, 800, 600)
+
+    # Create central widget with layout
+    central_widget = QWidget()
+    layout = QVBoxLayout(central_widget)
+
+    # Add title
+    title = QLabel("Document Card Factory Demo")
+    title.setStyleSheet("font-size: 18pt; font-weight: bold; margin: 10px;")
+    layout.addWidget(title)
+
+    # Create and add cards
+    layout.addWidget(QLabel("Card 1: Literature Context"))
+    card1 = factory.create_card(card_data_1)
+    layout.addWidget(card1)
+
+    layout.addWidget(QLabel("\nCard 2: Scoring Context with PDF Fetch"))
+    card2 = factory.create_card(card_data_2)
+    layout.addWidget(card2)
+
+    layout.addStretch()
+
+    window.setCentralWidget(central_widget)
+    window.show()
+
+    sys.exit(app.exec())
+
+
+# Example 3: Custom PDF Button Configuration
+def custom_pdf_button_example():
+    """Example of creating custom PDF buttons with custom handlers."""
+    import flet as ft
+    from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+    from bmlibrarian.gui.document_card_factory_base import PDFButtonConfig, PDFButtonState
+    from pathlib import Path
+
+    def main(page: ft.Page):
+        page.title = "Custom PDF Button Demo"
+        page.padding = 20
+
+        factory = FletDocumentCardFactory(page=page)
+
+        # Custom handlers
+        def custom_view_handler():
+            page.snack_bar = ft.SnackBar(
+                content=ft.Text("Custom view handler called!"),
+                bgcolor=ft.Colors.GREEN
+            )
+            page.snack_bar.open = True
+            page.update()
+
+        def custom_fetch_handler():
+            page.snack_bar = ft.SnackBar(
+                content=ft.Text("Custom fetch handler called!"),
+                bgcolor=ft.Colors.ORANGE
+            )
+            page.snack_bar.open = True
+            page.update()
+            return Path("/tmp/downloaded.pdf")  # Return path after download
+
+        def custom_upload_handler():
+            page.snack_bar = ft.SnackBar(
+                content=ft.Text("Custom upload handler called!"),
+                bgcolor=ft.Colors.BLUE
+            )
+            page.snack_bar.open = True
+            page.update()
+            return Path("/tmp/uploaded.pdf")  # Return path after upload
+
+        # Create custom PDF button configurations
+        view_config = PDFButtonConfig(
+            state=PDFButtonState.VIEW,
+            pdf_path=Path("/path/to/existing.pdf"),
+            on_view=custom_view_handler,
+            show_notifications=True
+        )
+
+        fetch_config = PDFButtonConfig(
+            state=PDFButtonState.FETCH,
+            pdf_url="https://example.com/paper.pdf",
+            on_fetch=custom_fetch_handler,
+            show_notifications=True
+        )
+
+        upload_config = PDFButtonConfig(
+            state=PDFButtonState.UPLOAD,
+            on_upload=custom_upload_handler,
+            show_notifications=True
+        )
+
+        # Create buttons
+        view_button = factory.create_pdf_button(view_config)
+        fetch_button = factory.create_pdf_button(fetch_config)
+        upload_button = factory.create_pdf_button(upload_config)
+
+        # Add to page
+        page.add(
+            ft.Text("Custom PDF Button Handlers", size=24, weight=ft.FontWeight.BOLD),
+            ft.Divider(),
+            ft.Text("VIEW button with custom handler:"),
+            view_button,
+            ft.Divider(),
+            ft.Text("FETCH button with custom handler:"),
+            fetch_button,
+            ft.Divider(),
+            ft.Text("UPLOAD button with custom handler:"),
+            upload_button,
+        )
+
+    ft.app(target=main)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Document Card Factory Demo")
+    parser.add_argument(
+        "--framework",
+        choices=["flet", "qt", "custom"],
+        default="flet",
+        help="Which example to run"
+    )
+
+    args = parser.parse_args()
+
+    if args.framework == "flet":
+        print("Running Flet example...")
+        flet_example()
+    elif args.framework == "qt":
+        print("Running Qt example...")
+        qt_example()
+    elif args.framework == "custom":
+        print("Running custom PDF button example...")
+        custom_pdf_button_example()

--- a/src/bmlibrarian/gui/document_card_factory_base.py
+++ b/src/bmlibrarian/gui/document_card_factory_base.py
@@ -1,0 +1,294 @@
+"""
+Abstract base class for document card factories.
+
+This module provides the foundation for creating document cards across different
+UI frameworks (Flet, Qt) with consistent interfaces and functionality.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Optional, Dict, List
+from pathlib import Path
+
+
+class CardContext(Enum):
+    """Context in which a document card is being displayed."""
+    LITERATURE = "literature"  # General literature browsing
+    SCORING = "scoring"  # Document relevance scoring
+    CITATIONS = "citations"  # Citation extraction
+    COUNTERFACTUAL = "counterfactual"  # Counterfactual analysis
+    REPORT = "report"  # Final report generation
+    SEARCH = "search"  # Search results
+    REVIEW = "review"  # Fact-checker review
+
+
+class PDFButtonState(Enum):
+    """State of the PDF button for a document."""
+    VIEW = "view"  # Local PDF exists, can view
+    FETCH = "fetch"  # PDF URL available, can download
+    UPLOAD = "upload"  # No PDF, allow manual upload
+    HIDDEN = "hidden"  # No PDF button shown
+
+
+@dataclass
+class PDFButtonConfig:
+    """Configuration for PDF button behavior."""
+    state: PDFButtonState
+    pdf_path: Optional[Path] = None
+    pdf_url: Optional[str] = None
+    on_view: Optional[Callable] = None  # Callback for viewing PDF
+    on_fetch: Optional[Callable] = None  # Callback for fetching PDF
+    on_upload: Optional[Callable] = None  # Callback for uploading PDF
+    show_notifications: bool = True  # Show success/error notifications
+
+
+@dataclass
+class DocumentCardData:
+    """Data for rendering a document card."""
+    # Core document data
+    doc_id: int
+    title: str
+    abstract: Optional[str] = None
+    authors: Optional[List[str]] = None
+    year: Optional[int] = None
+    journal: Optional[str] = None
+    pmid: Optional[str] = None
+    doi: Optional[str] = None
+    source: Optional[str] = None  # e.g., "pubmed", "medrxiv"
+
+    # Scoring data
+    relevance_score: Optional[float] = None
+    human_score: Optional[float] = None
+    confidence: Optional[str] = None
+
+    # Citation data
+    citations: Optional[List[Dict[str, Any]]] = None  # List of extracted citations
+
+    # PDF data
+    pdf_path: Optional[Path] = None
+    pdf_url: Optional[str] = None
+
+    # Display options
+    context: CardContext = CardContext.LITERATURE
+    show_abstract: bool = True
+    show_metadata: bool = True
+    show_pdf_button: bool = True
+    expanded_by_default: bool = False
+
+    # Callbacks
+    on_score_change: Optional[Callable] = None  # Callback when score changes
+    on_citation_select: Optional[Callable] = None  # Callback when citation selected
+    on_pdf_action: Optional[Callable] = None  # Callback for PDF actions
+
+
+class DocumentCardFactoryBase(ABC):
+    """
+    Abstract base class for document card factories.
+
+    This class defines the interface that all document card factories must implement,
+    regardless of the UI framework being used. It provides common functionality for:
+
+    - Creating document cards with consistent styling
+    - Managing PDF button states (View/Fetch/Upload)
+    - Handling card variations based on context
+    - Formatting document metadata
+
+    Subclasses must implement framework-specific rendering methods.
+    """
+
+    def __init__(self, base_pdf_dir: Optional[Path] = None):
+        """
+        Initialize the document card factory.
+
+        Args:
+            base_pdf_dir: Base directory for PDF files (defaults to ~/knowledgebase/pdf)
+        """
+        if base_pdf_dir is None:
+            base_pdf_dir = Path.home() / "knowledgebase" / "pdf"
+        self.base_pdf_dir = Path(base_pdf_dir)
+
+    @abstractmethod
+    def create_card(self, card_data: DocumentCardData) -> Any:
+        """
+        Create a document card widget.
+
+        Args:
+            card_data: Data and configuration for the card
+
+        Returns:
+            A framework-specific card widget (e.g., ft.ExpansionTile for Flet,
+            QFrame for Qt)
+        """
+        pass
+
+    @abstractmethod
+    def create_pdf_button(self, config: PDFButtonConfig) -> Any:
+        """
+        Create a PDF button widget with appropriate state.
+
+        Args:
+            config: Configuration for the PDF button
+
+        Returns:
+            A framework-specific button widget
+        """
+        pass
+
+    def determine_pdf_state(
+        self,
+        doc_id: int,
+        pdf_path: Optional[Path] = None,
+        pdf_url: Optional[str] = None
+    ) -> PDFButtonState:
+        """
+        Determine the appropriate PDF button state for a document.
+
+        Args:
+            doc_id: Document ID
+            pdf_path: Explicit PDF path if known
+            pdf_url: PDF URL if available
+
+        Returns:
+            The appropriate PDFButtonState
+        """
+        # Check if explicit path provided and exists
+        if pdf_path and pdf_path.exists():
+            return PDFButtonState.VIEW
+
+        # Check standard location
+        standard_path = self.base_pdf_dir / f"{doc_id}.pdf"
+        if standard_path.exists():
+            return PDFButtonState.VIEW
+
+        # Check if URL available for fetching
+        if pdf_url:
+            return PDFButtonState.FETCH
+
+        # No PDF available, allow upload
+        return PDFButtonState.UPLOAD
+
+    def get_pdf_path(self, doc_id: int, pdf_path: Optional[Path] = None) -> Optional[Path]:
+        """
+        Get the actual PDF path for a document.
+
+        Args:
+            doc_id: Document ID
+            pdf_path: Explicit PDF path if known
+
+        Returns:
+            Path to PDF file if it exists, None otherwise
+        """
+        if pdf_path and pdf_path.exists():
+            return pdf_path
+
+        standard_path = self.base_pdf_dir / f"{doc_id}.pdf"
+        if standard_path.exists():
+            return standard_path
+
+        return None
+
+    def format_authors(self, authors: Optional[List[str]], max_authors: int = 3) -> str:
+        """
+        Format author list for display.
+
+        Args:
+            authors: List of author names
+            max_authors: Maximum number of authors to show before truncating
+
+        Returns:
+            Formatted author string
+        """
+        if not authors:
+            return "Unknown authors"
+
+        if len(authors) <= max_authors:
+            return ", ".join(authors)
+
+        return f"{', '.join(authors[:max_authors])}, et al."
+
+    def format_metadata(
+        self,
+        year: Optional[int] = None,
+        journal: Optional[str] = None,
+        pmid: Optional[str] = None,
+        doi: Optional[str] = None,
+        source: Optional[str] = None
+    ) -> Dict[str, str]:
+        """
+        Format document metadata for display.
+
+        Args:
+            year: Publication year
+            journal: Journal name
+            pmid: PubMed ID
+            doi: DOI
+            source: Data source
+
+        Returns:
+            Dictionary of formatted metadata items
+        """
+        metadata = {}
+
+        if year:
+            metadata["Year"] = str(year)
+
+        if journal:
+            metadata["Journal"] = journal
+
+        if pmid:
+            metadata["PMID"] = pmid
+
+        if doi:
+            metadata["DOI"] = doi
+
+        if source:
+            metadata["Source"] = source.upper()
+
+        return metadata
+
+    def get_score_color(self, score: float, context: CardContext = CardContext.LITERATURE) -> str:
+        """
+        Get color for relevance score display.
+
+        Args:
+            score: Relevance score (typically 1-5)
+            context: Context in which the score is being displayed
+
+        Returns:
+            Color string (hex or named color)
+        """
+        if score >= 4.5:
+            return "#2E7D32"  # Dark green
+        elif score >= 3.5:
+            return "#1976D2"  # Blue
+        elif score >= 2.5:
+            return "#F57C00"  # Orange
+        else:
+            return "#C62828"  # Red
+
+    def truncate_abstract(self, abstract: Optional[str], max_length: int = 500) -> str:
+        """
+        Truncate abstract to specified length.
+
+        Args:
+            abstract: Full abstract text
+            max_length: Maximum length before truncation
+
+        Returns:
+            Truncated abstract with ellipsis if needed
+        """
+        if not abstract:
+            return "No abstract available."
+
+        if len(abstract) <= max_length:
+            return abstract
+
+        # Find last complete sentence within limit
+        truncated = abstract[:max_length]
+        last_period = truncated.rfind('. ')
+
+        if last_period > max_length * 0.7:  # At least 70% of desired length
+            return abstract[:last_period + 1]
+
+        return truncated + "..."

--- a/src/bmlibrarian/gui/flet_document_card_factory.py
+++ b/src/bmlibrarian/gui/flet_document_card_factory.py
@@ -1,0 +1,285 @@
+"""
+Flet implementation of the document card factory.
+
+This module provides a Flet-specific implementation of the DocumentCardFactoryBase,
+wrapping the existing UnifiedDocumentCard class and providing the standardized
+factory interface.
+"""
+
+import flet as ft
+from typing import Optional, Callable, Dict, Any, List
+from pathlib import Path
+import logging
+
+from .document_card_factory_base import (
+    DocumentCardFactoryBase,
+    DocumentCardData,
+    PDFButtonConfig,
+    PDFButtonState,
+    CardContext
+)
+from .unified_document_card import UnifiedDocumentCard, DocumentCardContext
+
+logger = logging.getLogger(__name__)
+
+
+class FletDocumentCardFactory(DocumentCardFactoryBase):
+    """
+    Flet-specific document card factory.
+
+    This class wraps the existing UnifiedDocumentCard implementation and provides
+    the standardized factory interface for creating document cards in Flet applications.
+    """
+
+    def __init__(
+        self,
+        page: ft.Page,
+        pdf_manager=None,
+        on_pdf_status_change: Optional[Callable[[int, str], None]] = None,
+        base_pdf_dir: Optional[Path] = None
+    ):
+        """
+        Initialize Flet document card factory.
+
+        Args:
+            page: Flet page instance for dialogs
+            pdf_manager: PDFManager instance for handling PDF operations
+            on_pdf_status_change: Callback when PDF status changes (doc_id, status)
+            base_pdf_dir: Base directory for PDF files
+        """
+        super().__init__(base_pdf_dir)
+        self.page = page
+        self.pdf_manager = pdf_manager
+        self.on_pdf_status_change = on_pdf_status_change
+
+        # Create the underlying UnifiedDocumentCard instance
+        self._card_creator = UnifiedDocumentCard(
+            page=page,
+            pdf_manager=pdf_manager,
+            on_pdf_status_change=on_pdf_status_change
+        )
+
+    def create_card(self, card_data: DocumentCardData) -> ft.ExpansionTile:
+        """
+        Create a Flet document card.
+
+        Args:
+            card_data: Data and configuration for the card
+
+        Returns:
+            ft.ExpansionTile widget for the document
+        """
+        # Convert CardContext to DocumentCardContext
+        context_mapping = {
+            CardContext.LITERATURE: DocumentCardContext.LITERATURE,
+            CardContext.SCORING: DocumentCardContext.SCORING,
+            CardContext.CITATIONS: DocumentCardContext.CITATIONS,
+            CardContext.COUNTERFACTUAL: DocumentCardContext.COUNTERFACTUAL,
+            CardContext.REPORT: DocumentCardContext.REPORT,
+            CardContext.SEARCH: DocumentCardContext.LITERATURE,
+            CardContext.REVIEW: DocumentCardContext.LITERATURE
+        }
+        flet_context = context_mapping.get(card_data.context, DocumentCardContext.LITERATURE)
+
+        # Prepare document dictionary for UnifiedDocumentCard
+        doc = {
+            'id': card_data.doc_id,
+            'document_id': card_data.doc_id,
+            'title': card_data.title,
+            'abstract': card_data.abstract or "No abstract available",
+            'authors': self.format_authors(card_data.authors) if card_data.authors else "Unknown authors",
+            'publication': card_data.journal or "Unknown",
+            'year': card_data.year,
+            'pmid': card_data.pmid,
+            'doi': card_data.doi,
+            'source': card_data.source
+        }
+
+        # Add PDF information if available
+        pdf_path = self.get_pdf_path(card_data.doc_id, card_data.pdf_path)
+        if pdf_path:
+            doc['pdf_path'] = str(pdf_path)
+        if card_data.pdf_url:
+            doc['pdf_url'] = card_data.pdf_url
+
+        # Determine which score to use
+        ai_score = None
+        human_score = None
+        relevance_score = None
+
+        if card_data.context == CardContext.SCORING:
+            ai_score = card_data.relevance_score
+            human_score = card_data.human_score
+        elif card_data.context == CardContext.CITATIONS:
+            relevance_score = card_data.relevance_score
+        else:
+            ai_score = card_data.relevance_score
+
+        # Create the card using UnifiedDocumentCard
+        return self._card_creator.create_card(
+            index=0,  # Index not used in factory pattern
+            doc=doc,
+            context=flet_context,
+            ai_score=ai_score,
+            human_score=human_score,
+            relevance_score=relevance_score,
+            citation_data={'citations': card_data.citations} if card_data.citations else None,
+            on_score_change=card_data.on_score_change,
+            show_scoring_controls=(card_data.context == CardContext.SCORING)
+        )
+
+    def create_pdf_button(self, config: PDFButtonConfig) -> ft.Container:
+        """
+        Create a Flet PDF button widget.
+
+        Args:
+            config: Configuration for the PDF button
+
+        Returns:
+            ft.Container with the appropriate button
+        """
+        if config.state == PDFButtonState.HIDDEN:
+            return ft.Container()
+
+        # Create button based on state
+        if config.state == PDFButtonState.VIEW:
+            button = ft.ElevatedButton(
+                "📄 View Full Text",
+                icon=ft.Icons.PICTURE_AS_PDF,
+                on_click=lambda e: self._handle_view(config),
+                style=ft.ButtonStyle(
+                    bgcolor=ft.Colors.BLUE_600,
+                    color=ft.Colors.WHITE
+                ),
+                height=40
+            )
+        elif config.state == PDFButtonState.FETCH:
+            button = ft.ElevatedButton(
+                "⬇️ Fetch Full Text",
+                icon=ft.Icons.DOWNLOAD,
+                on_click=lambda e: self._handle_fetch(config, button),
+                style=ft.ButtonStyle(
+                    bgcolor=ft.Colors.ORANGE_600,
+                    color=ft.Colors.WHITE
+                ),
+                height=40
+            )
+        else:  # UPLOAD
+            button = ft.ElevatedButton(
+                "📤 Upload Full Text",
+                icon=ft.Icons.UPLOAD_FILE,
+                on_click=lambda e: self._handle_upload(config, button),
+                style=ft.ButtonStyle(
+                    bgcolor=ft.Colors.GREEN_600,
+                    color=ft.Colors.WHITE
+                ),
+                height=40
+            )
+
+        return ft.Container(
+            content=ft.Row([button], alignment=ft.MainAxisAlignment.START),
+            padding=ft.padding.only(top=8)
+        )
+
+    def _handle_view(self, config: PDFButtonConfig):
+        """Handle view PDF action."""
+        if config.on_view:
+            config.on_view()
+        elif config.pdf_path and config.pdf_path.exists():
+            # Default behavior: open in PDF viewer
+            from .pdf_viewer_dialog import PDFViewerDialog
+            viewer = PDFViewerDialog(self.page)
+            doc = {'pdf_path': str(config.pdf_path)}
+            viewer.show_pdf(config.pdf_path, doc)
+        else:
+            self._show_notification("PDF file not found", is_error=True)
+
+    def _handle_fetch(self, config: PDFButtonConfig, button: ft.ElevatedButton):
+        """Handle fetch PDF action."""
+        if config.on_fetch:
+            # Call custom handler
+            success = config.on_fetch()
+            if success and config.show_notifications:
+                self._show_notification("PDF downloaded successfully")
+                # Update button to View state
+                button.text = "📄 View Full Text"
+                button.icon = ft.Icons.PICTURE_AS_PDF
+                button.on_click = lambda _: self._handle_view(config)
+                button.style = ft.ButtonStyle(
+                    bgcolor=ft.Colors.BLUE_600,
+                    color=ft.Colors.WHITE
+                )
+                self.page.update()
+        elif config.pdf_url:
+            # Default behavior: download from URL
+            from .pdf_viewer_dialog import PDFViewerDialog
+            viewer = PDFViewerDialog(self.page)
+            doc = {'pdf_url': config.pdf_url, 'id': 'unknown'}
+            viewer.download_and_show_pdf(
+                doc,
+                on_success=lambda path: self._on_pdf_success(path, button, config),
+                on_error=lambda msg: self._show_notification(msg, is_error=True)
+            )
+        else:
+            self._show_notification("No PDF URL available", is_error=True)
+
+    def _handle_upload(self, config: PDFButtonConfig, button: ft.ElevatedButton):
+        """Handle upload PDF action."""
+        if config.on_upload:
+            # Call custom handler
+            success = config.on_upload()
+            if success and config.show_notifications:
+                self._show_notification("PDF uploaded successfully")
+                # Update button to View state
+                button.text = "📄 View Full Text"
+                button.icon = ft.Icons.PICTURE_AS_PDF
+                button.on_click = lambda _: self._handle_view(config)
+                button.style = ft.ButtonStyle(
+                    bgcolor=ft.Colors.BLUE_600,
+                    color=ft.Colors.WHITE
+                )
+                self.page.update()
+        else:
+            # Default behavior: show file picker
+            from .pdf_viewer_dialog import PDFViewerDialog
+            viewer = PDFViewerDialog(self.page)
+            doc = {'id': 'unknown'}
+            viewer.import_pdf(
+                doc,
+                on_success=lambda path: self._on_pdf_success(path, button, config),
+                on_error=lambda msg: self._show_notification(msg, is_error=True)
+            )
+
+    def _on_pdf_success(self, pdf_path: Path, button: ft.ElevatedButton, config: PDFButtonConfig):
+        """Handle successful PDF download/upload."""
+        logger.info(f"PDF operation successful: {pdf_path}")
+
+        # Update config
+        config.pdf_path = pdf_path
+        config.state = PDFButtonState.VIEW
+
+        # Update button
+        button.text = "📄 View Full Text"
+        button.icon = ft.Icons.PICTURE_AS_PDF
+        button.on_click = lambda _: self._handle_view(config)
+        button.style = ft.ButtonStyle(
+            bgcolor=ft.Colors.BLUE_600,
+            color=ft.Colors.WHITE
+        )
+
+        if config.show_notifications:
+            self._show_notification("✅ PDF ready! Click 'View Full Text' to open it.")
+
+        self.page.update()
+
+    def _show_notification(self, message: str, is_error: bool = False):
+        """Show notification snackbar."""
+        if not self.page:
+            return
+
+        snack_bar = ft.SnackBar(
+            content=ft.Text(message),
+            bgcolor=ft.Colors.RED_700 if is_error else ft.Colors.GREEN_700,
+            duration=5000
+        )
+        self.page.open(snack_bar)

--- a/src/bmlibrarian/gui/qt/qt_document_card_factory.py
+++ b/src/bmlibrarian/gui/qt/qt_document_card_factory.py
@@ -1,0 +1,340 @@
+"""
+Qt implementation of the document card factory.
+
+This module provides a Qt-specific implementation of the DocumentCardFactoryBase,
+integrating with existing Qt document card classes and adding PDF button functionality
+that matches the Flet implementation.
+"""
+
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QFrame, QLabel
+)
+from PySide6.QtCore import Qt, Signal, QObject
+from PySide6.QtGui import QIcon, QDesktopServices
+from PySide6.QtCore import QUrl
+from typing import Optional, Callable, Dict, Any, Union
+from pathlib import Path
+import logging
+
+from bmlibrarian.gui.document_card_factory_base import (
+    DocumentCardFactoryBase,
+    DocumentCardData,
+    PDFButtonConfig,
+    PDFButtonState,
+    CardContext
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PDFButtonWidget(QPushButton):
+    """
+    Qt PDF button with three states: View, Fetch, Upload.
+
+    Signals:
+        pdf_viewed: Emitted when PDF is viewed
+        pdf_fetched: Emitted when PDF is fetched (returns path)
+        pdf_uploaded: Emitted when PDF is uploaded (returns path)
+    """
+
+    pdf_viewed = Signal()
+    pdf_fetched = Signal(Path)
+    pdf_uploaded = Signal(Path)
+
+    def __init__(self, config: PDFButtonConfig, parent: Optional[QWidget] = None):
+        """
+        Initialize PDF button.
+
+        Args:
+            config: Button configuration
+            parent: Optional parent widget
+        """
+        super().__init__(parent)
+        self.config = config
+        self._update_button_appearance()
+
+        # Connect click handler
+        self.clicked.connect(self._handle_click)
+
+    def _update_button_appearance(self):
+        """Update button text, icon, and style based on state."""
+        if self.config.state == PDFButtonState.VIEW:
+            self.setText("📄 View Full Text")
+            self.setStyleSheet("""
+                QPushButton {
+                    background-color: #1976D2;
+                    color: white;
+                    border: none;
+                    padding: 8px 12px;
+                    border-radius: 4px;
+                    font-weight: bold;
+                }
+                QPushButton:hover {
+                    background-color: #1565C0;
+                }
+            """)
+        elif self.config.state == PDFButtonState.FETCH:
+            self.setText("⬇️ Fetch Full Text")
+            self.setStyleSheet("""
+                QPushButton {
+                    background-color: #F57C00;
+                    color: white;
+                    border: none;
+                    padding: 8px 12px;
+                    border-radius: 4px;
+                    font-weight: bold;
+                }
+                QPushButton:hover {
+                    background-color: #EF6C00;
+                }
+            """)
+        elif self.config.state == PDFButtonState.UPLOAD:
+            self.setText("📤 Upload Full Text")
+            self.setStyleSheet("""
+                QPushButton {
+                    background-color: #388E3C;
+                    color: white;
+                    border: none;
+                    padding: 8px 12px;
+                    border-radius: 4px;
+                    font-weight: bold;
+                }
+                QPushButton:hover {
+                    background-color: #2E7D32;
+                }
+            """)
+
+        self.setMinimumHeight(40)
+        self.setCursor(Qt.PointingHandCursor)
+
+    def _handle_click(self):
+        """Handle button click based on current state."""
+        if self.config.state == PDFButtonState.VIEW:
+            self._handle_view()
+        elif self.config.state == PDFButtonState.FETCH:
+            self._handle_fetch()
+        elif self.config.state == PDFButtonState.UPLOAD:
+            self._handle_upload()
+
+    def _handle_view(self):
+        """Handle view PDF action."""
+        if self.config.on_view:
+            self.config.on_view()
+        elif self.config.pdf_path and self.config.pdf_path.exists():
+            # Default behavior: open in system PDF viewer
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(self.config.pdf_path)))
+        else:
+            logger.error("PDF file not found")
+
+        self.pdf_viewed.emit()
+
+    def _handle_fetch(self):
+        """Handle fetch PDF action."""
+        if self.config.on_fetch:
+            result = self.config.on_fetch()
+            if result:
+                # Callback should return the downloaded path
+                if isinstance(result, Path):
+                    self._transition_to_view(result)
+                    self.pdf_fetched.emit(result)
+        else:
+            logger.warning("No fetch handler configured")
+
+    def _handle_upload(self):
+        """Handle upload PDF action."""
+        if self.config.on_upload:
+            result = self.config.on_upload()
+            if result:
+                # Callback should return the uploaded path
+                if isinstance(result, Path):
+                    self._transition_to_view(result)
+                    self.pdf_uploaded.emit(result)
+        else:
+            # Default behavior: show file dialog
+            from PySide6.QtWidgets import QFileDialog
+            file_path, _ = QFileDialog.getOpenFileName(
+                self,
+                "Upload PDF",
+                str(Path.home()),
+                "PDF Files (*.pdf)"
+            )
+            if file_path:
+                path = Path(file_path)
+                self._transition_to_view(path)
+                self.pdf_uploaded.emit(path)
+
+    def _transition_to_view(self, pdf_path: Path):
+        """Transition button to VIEW state after successful fetch/upload."""
+        self.config.pdf_path = pdf_path
+        self.config.state = PDFButtonState.VIEW
+        self._update_button_appearance()
+
+
+class QtDocumentCardFactory(DocumentCardFactoryBase):
+    """
+    Qt-specific document card factory.
+
+    This class provides Qt widgets for document cards with integrated PDF button
+    functionality, matching the Flet implementation's three-state PDF buttons.
+    """
+
+    def __init__(
+        self,
+        pdf_manager=None,
+        base_pdf_dir: Optional[Path] = None
+    ):
+        """
+        Initialize Qt document card factory.
+
+        Args:
+            pdf_manager: PDFManager instance for handling PDF operations
+            base_pdf_dir: Base directory for PDF files
+        """
+        super().__init__(base_pdf_dir)
+        self.pdf_manager = pdf_manager
+
+    def create_card(self, card_data: DocumentCardData) -> QFrame:
+        """
+        Create a Qt document card.
+
+        Args:
+            card_data: Data and configuration for the card
+
+        Returns:
+            QFrame widget for the document
+        """
+        from .widgets.collapsible_document_card import CollapsibleDocumentCard
+
+        # Prepare document dictionary for Qt card
+        doc = {
+            'id': card_data.doc_id,
+            'title': card_data.title,
+            'abstract': card_data.abstract or "No abstract available",
+            'authors': card_data.authors or [],
+            'journal': card_data.journal,
+            'year': card_data.year,
+            'pmid': card_data.pmid,
+            'doi': card_data.doi,
+            'source': card_data.source,
+            'relevance_score': card_data.relevance_score or card_data.human_score
+        }
+
+        # Create the base card
+        card = CollapsibleDocumentCard(doc)
+
+        # Add PDF button if requested
+        if card_data.show_pdf_button:
+            pdf_button = self._create_pdf_button_for_card(card_data)
+            if pdf_button:
+                # Add button to the card's details section
+                # We'll insert it after the card's existing layout
+                card.details_layout.addWidget(pdf_button)
+
+        return card
+
+    def _create_pdf_button_for_card(self, card_data: DocumentCardData) -> Optional[QWidget]:
+        """Create and configure PDF button for a document card."""
+        # Determine PDF state
+        pdf_state = self.determine_pdf_state(
+            card_data.doc_id,
+            card_data.pdf_path,
+            card_data.pdf_url
+        )
+
+        if pdf_state == PDFButtonState.HIDDEN:
+            return None
+
+        # Get actual PDF path if available
+        pdf_path = self.get_pdf_path(card_data.doc_id, card_data.pdf_path)
+
+        # Create button configuration
+        config = PDFButtonConfig(
+            state=pdf_state,
+            pdf_path=pdf_path,
+            pdf_url=card_data.pdf_url,
+            on_view=self._create_view_handler(card_data),
+            on_fetch=self._create_fetch_handler(card_data),
+            on_upload=self._create_upload_handler(card_data),
+            show_notifications=True
+        )
+
+        # Create the button widget
+        return self.create_pdf_button(config)
+
+    def create_pdf_button(self, config: PDFButtonConfig) -> Optional[QWidget]:
+        """
+        Create a Qt PDF button widget.
+
+        Args:
+            config: Configuration for the PDF button
+
+        Returns:
+            QWidget with the PDF button, or None if hidden
+        """
+        if config.state == PDFButtonState.HIDDEN:
+            return None
+
+        # Create button
+        button = PDFButtonWidget(config)
+
+        # Wrap in container for consistent layout
+        container = QWidget()
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 8, 0, 0)
+        layout.addWidget(button)
+        layout.addStretch()
+
+        return container
+
+    def _create_view_handler(self, card_data: DocumentCardData) -> Callable:
+        """Create handler for viewing PDF."""
+        def handler():
+            if card_data.on_pdf_action:
+                card_data.on_pdf_action('view', card_data.doc_id)
+
+            pdf_path = self.get_pdf_path(card_data.doc_id, card_data.pdf_path)
+            if pdf_path and pdf_path.exists():
+                # Open in Qt PDF viewer or system default
+                QDesktopServices.openUrl(QUrl.fromLocalFile(str(pdf_path)))
+                logger.info(f"Opened PDF for document {card_data.doc_id}")
+            else:
+                logger.error(f"PDF not found for document {card_data.doc_id}")
+
+        return handler
+
+    def _create_fetch_handler(self, card_data: DocumentCardData) -> Callable:
+        """Create handler for fetching PDF."""
+        def handler() -> Optional[Path]:
+            if card_data.on_pdf_action:
+                result = card_data.on_pdf_action('fetch', card_data.doc_id, card_data.pdf_url)
+                if isinstance(result, Path):
+                    return result
+
+            # Default fetch behavior
+            if self.pdf_manager and card_data.pdf_url:
+                try:
+                    pdf_path = self.pdf_manager.download_pdf(
+                        card_data.doc_id,
+                        card_data.pdf_url
+                    )
+                    logger.info(f"Downloaded PDF for document {card_data.doc_id}")
+                    return pdf_path
+                except Exception as e:
+                    logger.error(f"Failed to download PDF: {e}")
+
+            return None
+
+        return handler
+
+    def _create_upload_handler(self, card_data: DocumentCardData) -> Callable:
+        """Create handler for uploading PDF."""
+        def handler() -> Optional[Path]:
+            if card_data.on_pdf_action:
+                result = card_data.on_pdf_action('upload', card_data.doc_id)
+                if isinstance(result, Path):
+                    return result
+
+            # Default upload behavior handled by PDFButtonWidget
+            return None
+
+        return handler

--- a/src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py
+++ b/src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py
@@ -207,9 +207,9 @@ class CollapsibleDocumentCard(QFrame):
     def _create_details(self):
         """Create the details section (shown when expanded)."""
         self.details_widget = QWidget()
-        details_layout = QVBoxLayout(self.details_widget)
-        details_layout.setContentsMargins(0, DETAILS_SPACING, 0, 0)
-        details_layout.setSpacing(DETAILS_SPACING)
+        self.details_layout = QVBoxLayout(self.details_widget)
+        self.details_layout.setContentsMargins(0, DETAILS_SPACING, 0, 0)
+        self.details_layout.setSpacing(DETAILS_SPACING)
 
         # Authors
         authors = format_authors(
@@ -221,7 +221,7 @@ class CollapsibleDocumentCard(QFrame):
         authors_label.setObjectName("authors")
         authors_label.setWordWrap(True)
         authors_label.setStyleSheet(f"color: {COLOR_TEXT_SECONDARY}; font-size: 10pt;")
-        details_layout.addWidget(authors_label)
+        self.details_layout.addWidget(authors_label)
 
         # Journal and year
         journal_year = format_journal_year(
@@ -232,7 +232,7 @@ class CollapsibleDocumentCard(QFrame):
             journal_label = QLabel(html_escape(journal_year))
             journal_label.setObjectName("journal")
             journal_label.setStyleSheet(f"color: {COLOR_TEXT_TERTIARY}; font-size: 9pt;")
-            details_layout.addWidget(journal_label)
+            self.details_layout.addWidget(journal_label)
 
         # PMID/DOI
         ids_text = format_document_ids(
@@ -244,7 +244,7 @@ class CollapsibleDocumentCard(QFrame):
             ids_label = QLabel(ids_text)
             ids_label.setObjectName("metadata")
             ids_label.setStyleSheet(f"color: {COLOR_TEXT_METADATA}; font-size: 8pt;")
-            details_layout.addWidget(ids_label)
+            self.details_layout.addWidget(ids_label)
 
         # Abstract (if available)
         abstract = self.document_data.get("abstract")
@@ -254,12 +254,12 @@ class CollapsibleDocumentCard(QFrame):
             separator.setFrameShape(QFrame.HLine)
             separator.setFrameShadow(QFrame.Sunken)
             separator.setStyleSheet(f"background-color: {COLOR_SEPARATOR};")
-            details_layout.addWidget(separator)
+            self.details_layout.addWidget(separator)
 
             # Abstract label
             abstract_header = QLabel("<b>Abstract:</b>")
             abstract_header.setStyleSheet(f"color: {COLOR_TEXT_DARK}; font-size: 9pt; margin-top: {DETAILS_SPACING}px;")
-            details_layout.addWidget(abstract_header)
+            self.details_layout.addWidget(abstract_header)
 
             # Abstract text (read-only, scrollable for very long abstracts)
             abstract_text = QTextEdit()
@@ -276,7 +276,7 @@ class CollapsibleDocumentCard(QFrame):
                     color: {COLOR_TEXT_ABSTRACT};
                 }}
             """)
-            details_layout.addWidget(abstract_text)
+            self.details_layout.addWidget(abstract_text)
 
         self.main_layout.addWidget(self.details_widget)
 

--- a/tests/test_document_card_factory.py
+++ b/tests/test_document_card_factory.py
@@ -1,0 +1,486 @@
+"""
+Unit tests for document card factory classes.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, MagicMock, patch
+
+from bmlibrarian.gui.document_card_factory_base import (
+    DocumentCardFactoryBase,
+    DocumentCardData,
+    PDFButtonConfig,
+    PDFButtonState,
+    CardContext
+)
+
+
+class TestDocumentCardFactoryBase:
+    """Tests for DocumentCardFactoryBase abstract class."""
+
+    def test_determine_pdf_state_view(self, tmp_path):
+        """Test PDF state determination when local file exists."""
+        # Create a test PDF file
+        pdf_file = tmp_path / "12345.pdf"
+        pdf_file.write_text("test")
+
+        # Create a concrete subclass for testing
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory(base_pdf_dir=tmp_path)
+        state = factory.determine_pdf_state(12345)
+
+        assert state == PDFButtonState.VIEW
+
+    def test_determine_pdf_state_fetch(self, tmp_path):
+        """Test PDF state determination when URL available but no local file."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory(base_pdf_dir=tmp_path)
+        state = factory.determine_pdf_state(
+            12345,
+            pdf_url="https://example.com/paper.pdf"
+        )
+
+        assert state == PDFButtonState.FETCH
+
+    def test_determine_pdf_state_upload(self, tmp_path):
+        """Test PDF state determination when no local file or URL."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory(base_pdf_dir=tmp_path)
+        state = factory.determine_pdf_state(12345)
+
+        assert state == PDFButtonState.UPLOAD
+
+    def test_get_pdf_path_exists(self, tmp_path):
+        """Test getting PDF path when file exists."""
+        pdf_file = tmp_path / "12345.pdf"
+        pdf_file.write_text("test")
+
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory(base_pdf_dir=tmp_path)
+        path = factory.get_pdf_path(12345)
+
+        assert path == pdf_file
+        assert path.exists()
+
+    def test_get_pdf_path_not_exists(self, tmp_path):
+        """Test getting PDF path when file doesn't exist."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory(base_pdf_dir=tmp_path)
+        path = factory.get_pdf_path(12345)
+
+        assert path is None
+
+    def test_format_authors_short_list(self):
+        """Test author formatting with short list."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        authors = ["Smith J", "Johnson A"]
+        formatted = factory.format_authors(authors)
+
+        assert formatted == "Smith J, Johnson A"
+
+    def test_format_authors_long_list(self):
+        """Test author formatting with long list (et al)."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        authors = ["Smith J", "Johnson A", "Williams B", "Chen X", "Kim S"]
+        formatted = factory.format_authors(authors, max_authors=3)
+
+        assert formatted == "Smith J, Johnson A, Williams B, et al."
+
+    def test_format_authors_none(self):
+        """Test author formatting with None."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        formatted = factory.format_authors(None)
+
+        assert formatted == "Unknown authors"
+
+    def test_format_metadata(self):
+        """Test metadata formatting."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        metadata = factory.format_metadata(
+            year=2023,
+            journal="Nature",
+            pmid="12345678",
+            doi="10.1234/test"
+        )
+
+        assert metadata["Year"] == "2023"
+        assert metadata["Journal"] == "Nature"
+        assert metadata["PMID"] == "12345678"
+        assert metadata["DOI"] == "10.1234/test"
+
+    def test_get_score_color_high(self):
+        """Test score color for high relevance."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        color = factory.get_score_color(4.8)
+
+        assert color == "#2E7D32"  # Dark green
+
+    def test_get_score_color_medium(self):
+        """Test score color for medium relevance."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        color = factory.get_score_color(3.5)
+
+        assert color == "#1976D2"  # Blue
+
+    def test_get_score_color_low(self):
+        """Test score color for low relevance."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        color = factory.get_score_color(2.0)
+
+        assert color == "#C62828"  # Red
+
+    def test_truncate_abstract_short(self):
+        """Test abstract truncation with short text."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        abstract = "This is a short abstract."
+        truncated = factory.truncate_abstract(abstract, max_length=500)
+
+        assert truncated == abstract
+
+    def test_truncate_abstract_long(self):
+        """Test abstract truncation with long text."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        abstract = "This is a very long abstract. " * 50  # Create long text
+        truncated = factory.truncate_abstract(abstract, max_length=100)
+
+        assert len(truncated) <= 103  # 100 + "..."
+        assert truncated.endswith("...") or truncated.endswith(".")
+
+    def test_truncate_abstract_none(self):
+        """Test abstract truncation with None."""
+        class TestFactory(DocumentCardFactoryBase):
+            def create_card(self, card_data):
+                pass
+
+            def create_pdf_button(self, config):
+                pass
+
+        factory = TestFactory()
+        truncated = factory.truncate_abstract(None)
+
+        assert truncated == "No abstract available."
+
+
+class TestDocumentCardData:
+    """Tests for DocumentCardData dataclass."""
+
+    def test_create_minimal_card_data(self):
+        """Test creating card data with minimal required fields."""
+        data = DocumentCardData(
+            doc_id=12345,
+            title="Test Document"
+        )
+
+        assert data.doc_id == 12345
+        assert data.title == "Test Document"
+        assert data.abstract is None
+        assert data.context == CardContext.LITERATURE
+        assert data.show_pdf_button is True
+
+    def test_create_full_card_data(self):
+        """Test creating card data with all fields."""
+        data = DocumentCardData(
+            doc_id=12345,
+            title="Test Document",
+            abstract="Test abstract",
+            authors=["Smith J", "Johnson A"],
+            year=2023,
+            journal="Nature",
+            pmid="12345678",
+            doi="10.1234/test",
+            source="pubmed",
+            relevance_score=4.5,
+            human_score=5.0,
+            confidence="high",
+            context=CardContext.SCORING,
+            show_abstract=True,
+            show_metadata=True,
+            show_pdf_button=True,
+            pdf_path=Path("/path/to/pdf"),
+            pdf_url="https://example.com/pdf"
+        )
+
+        assert data.doc_id == 12345
+        assert data.title == "Test Document"
+        assert data.abstract == "Test abstract"
+        assert data.authors == ["Smith J", "Johnson A"]
+        assert data.year == 2023
+        assert data.journal == "Nature"
+        assert data.pmid == "12345678"
+        assert data.doi == "10.1234/test"
+        assert data.source == "pubmed"
+        assert data.relevance_score == 4.5
+        assert data.human_score == 5.0
+        assert data.confidence == "high"
+        assert data.context == CardContext.SCORING
+        assert data.pdf_path == Path("/path/to/pdf")
+        assert data.pdf_url == "https://example.com/pdf"
+
+
+class TestPDFButtonConfig:
+    """Tests for PDFButtonConfig dataclass."""
+
+    def test_create_view_config(self):
+        """Test creating VIEW button configuration."""
+        config = PDFButtonConfig(
+            state=PDFButtonState.VIEW,
+            pdf_path=Path("/path/to/pdf")
+        )
+
+        assert config.state == PDFButtonState.VIEW
+        assert config.pdf_path == Path("/path/to/pdf")
+        assert config.show_notifications is True
+
+    def test_create_fetch_config(self):
+        """Test creating FETCH button configuration."""
+        config = PDFButtonConfig(
+            state=PDFButtonState.FETCH,
+            pdf_url="https://example.com/pdf"
+        )
+
+        assert config.state == PDFButtonState.FETCH
+        assert config.pdf_url == "https://example.com/pdf"
+
+    def test_create_upload_config(self):
+        """Test creating UPLOAD button configuration."""
+        config = PDFButtonConfig(
+            state=PDFButtonState.UPLOAD
+        )
+
+        assert config.state == PDFButtonState.UPLOAD
+
+    def test_config_with_callbacks(self):
+        """Test configuration with callback functions."""
+        view_callback = Mock()
+        fetch_callback = Mock()
+        upload_callback = Mock()
+
+        config = PDFButtonConfig(
+            state=PDFButtonState.VIEW,
+            on_view=view_callback,
+            on_fetch=fetch_callback,
+            on_upload=upload_callback
+        )
+
+        assert config.on_view == view_callback
+        assert config.on_fetch == fetch_callback
+        assert config.on_upload == upload_callback
+
+
+# Flet Factory Tests (requires mocking Flet components)
+@pytest.mark.skipif(
+    not pytest.importorskip("flet", minversion="0.24.0"),
+    reason="Flet not installed"
+)
+class TestFletDocumentCardFactory:
+    """Tests for FletDocumentCardFactory."""
+
+    @patch('bmlibrarian.gui.flet_document_card_factory.UnifiedDocumentCard')
+    def test_create_card(self, mock_unified_card, tmp_path):
+        """Test creating Flet card."""
+        from bmlibrarian.gui.flet_document_card_factory import FletDocumentCardFactory
+        import flet as ft
+
+        # Mock page
+        page = Mock(spec=ft.Page)
+
+        # Create factory
+        factory = FletDocumentCardFactory(
+            page=page,
+            base_pdf_dir=tmp_path
+        )
+
+        # Create card data
+        card_data = DocumentCardData(
+            doc_id=12345,
+            title="Test Document",
+            abstract="Test abstract",
+            authors=["Smith J"],
+            year=2023,
+            context=CardContext.LITERATURE
+        )
+
+        # Create card
+        card = factory.create_card(card_data)
+
+        # Verify UnifiedDocumentCard was called
+        assert mock_unified_card.return_value.create_card.called
+
+
+# Qt Factory Tests (requires Qt components)
+@pytest.mark.skipif(
+    not pytest.importorskip("PySide6"),
+    reason="PySide6 not installed"
+)
+class TestQtDocumentCardFactory:
+    """Tests for QtDocumentCardFactory."""
+
+    def test_create_card(self, tmp_path, qapp):
+        """Test creating Qt card."""
+        from bmlibrarian.gui.qt.qt_document_card_factory import QtDocumentCardFactory
+
+        # Create factory
+        factory = QtDocumentCardFactory(base_pdf_dir=tmp_path)
+
+        # Create card data
+        card_data = DocumentCardData(
+            doc_id=12345,
+            title="Test Document",
+            abstract="Test abstract",
+            authors=["Smith J"],
+            year=2023,
+            context=CardContext.LITERATURE
+        )
+
+        # Create card
+        card = factory.create_card(card_data)
+
+        # Verify card was created
+        assert card is not None
+
+    def test_pdf_button_widget_view(self, qapp):
+        """Test PDF button widget in VIEW state."""
+        from bmlibrarian.gui.qt.qt_document_card_factory import PDFButtonWidget
+
+        config = PDFButtonConfig(
+            state=PDFButtonState.VIEW,
+            pdf_path=Path("/path/to/pdf")
+        )
+
+        button = PDFButtonWidget(config)
+
+        assert "View Full Text" in button.text()
+
+    def test_pdf_button_widget_fetch(self, qapp):
+        """Test PDF button widget in FETCH state."""
+        from bmlibrarian.gui.qt.qt_document_card_factory import PDFButtonWidget
+
+        config = PDFButtonConfig(
+            state=PDFButtonState.FETCH,
+            pdf_url="https://example.com/pdf"
+        )
+
+        button = PDFButtonWidget(config)
+
+        assert "Fetch Full Text" in button.text()
+
+    def test_pdf_button_widget_upload(self, qapp):
+        """Test PDF button widget in UPLOAD state."""
+        from bmlibrarian.gui.qt.qt_document_card_factory import PDFButtonWidget
+
+        config = PDFButtonConfig(
+            state=PDFButtonState.UPLOAD
+        )
+
+        button = PDFButtonWidget(config)
+
+        assert "Upload Full Text" in button.text()
+
+
+# Fixtures
+@pytest.fixture
+def qapp():
+    """Create QApplication instance for Qt tests."""
+    try:
+        from PySide6.QtWidgets import QApplication
+        import sys
+
+        app = QApplication.instance()
+        if app is None:
+            app = QApplication(sys.argv)
+        yield app
+    except ImportError:
+        pytest.skip("PySide6 not available")


### PR DESCRIPTION
This commit introduces a factory pattern for creating document cards across different UI frameworks (Flet and Qt) with consistent functionality and appearance.

Key Features:
- Abstract DocumentCardFactoryBase class with framework-agnostic interface
- FletDocumentCardFactory wrapping existing UnifiedDocumentCard
- QtDocumentCardFactory with newly integrated PDF button support
- Three-state PDF button system (VIEW/FETCH/UPLOAD) for both frameworks
- Context-aware card rendering for different use cases
- Comprehensive utility methods for formatting metadata, authors, scores

PDF Button Three-State System:
- VIEW (Blue): Local PDF exists → Opens in viewer
- FETCH (Orange): URL available → Downloads then transitions to VIEW
- UPLOAD (Green): No PDF → File picker then transitions to VIEW

Benefits:
- Consistent card creation API across Flet and Qt
- Eliminates code duplication
- Easier to maintain and extend
- Qt cards now have PDF buttons (previously missing)
- Centralized formatting logic

Files Added:
- src/bmlibrarian/gui/document_card_factory_base.py (abstract base class)
- src/bmlibrarian/gui/flet_document_card_factory.py (Flet implementation)
- src/bmlibrarian/gui/qt/qt_document_card_factory.py (Qt implementation)
- doc/developers/document_card_factory_system.md (comprehensive guide)
- examples/document_card_factory_demo.py (usage examples)
- tests/test_document_card_factory.py (unit tests)

Files Modified:
- src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py (expose details_layout)
- CLAUDE.md (document new factory system)

Testing:
- Comprehensive unit tests for factory classes
- Example demos for both Flet and Qt frameworks
- Custom PDF button handler examples

Documentation:
- Complete developer guide with architecture details
- Usage examples for basic and advanced scenarios
- Migration guide for existing code
- API reference and troubleshooting tips