### PR TITLE
Integrate QtDocumentCardFactory in search tab and increase abstract font size

### DIFF
--- a/src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py
+++ b/src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py
@@ -272,7 +272,7 @@ class CollapsibleDocumentCard(QFrame):
                     border: 1px solid {COLOR_BORDER_ABSTRACT};
                     border-radius: 4px;
                     padding: {ABSTRACT_PADDING}px;
-                    font-size: 9pt;
+                    font-size: 11pt;
                     color: {COLOR_TEXT_ABSTRACT};
                 }}
             """)


### PR DESCRIPTION
## Summary
This PR refactors the Qt-based GUI to use the document card factory pattern instead of creating `CollapsibleDocumentCard` instances directly, and improves readability by increasing the abstract font size.

## Changes

### 1. Search Tab Integration
- Updated `search_tab.py` to use `QtDocumentCardFactory`
- Replaced direct `CollapsibleDocumentCard` instantiation with `factory.create_card()`
- Added `DocumentCardData` creation with proper field mapping
- Initialized `card_factory` in `SearchTabWidget.__init__`
- Updated imports to include `QtDocumentCardFactory` and `DocumentCardData`

### 2. Improved Abstract Readability
- Increased abstract font size from **9pt to 11pt** in `CollapsibleDocumentCard`
- Better readability for users reviewing document abstracts

### 3. Code Analysis
**Why some components weren't changed:**

**Research Tab** (`research_tab.py`):
- Has specialized `_create_document_score_card` and `_create_citation_card` methods
- Includes workflow-specific features: AI reasoning sections, score badges with pending states, highlighted abstract passages, summary sections
- Intentionally kept separate as they serve a different purpose than general document browsing

**Fact-Checker Citation Widget** (`citation_widget.py`):
- Specialized component for the fact-checker review workflow
- Unique features like passage/excerpt highlighting and custom styling
- Not a general document card, so factory integration wouldn't be appropriate

## Testing
- ✅ All modified files pass Python syntax validation
- ✅ Changes are backward compatible
- ✅ Maintains existing functionality while providing better code organization

## Files Changed
- `src/bmlibrarian/gui/qt/plugins/search/search_tab.py`
- `src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py`