### PR TITLE
Integrate QtDocumentCardFactory in Literature tab with styling improvements

### DIFF
--- a/src/bmlibrarian/gui/qt/resources/constants.py
+++ b/src/bmlibrarian/gui/qt/resources/constants.py
@@ -56,15 +56,15 @@ class ScoreColors:
 
 class ButtonSizes:
     """Size constants for buttons."""
-    MIN_HEIGHT: Final[int] = 40  # Minimum button height in pixels
-    PADDING_HORIZONTAL: Final[int] = 12  # Horizontal padding in pixels
-    PADDING_VERTICAL: Final[int] = 8  # Vertical padding in pixels
+    MIN_HEIGHT: Final[int] = 30  # Minimum button height in pixels (reduced for compact design)
+    PADDING_HORIZONTAL: Final[int] = 10  # Horizontal padding in pixels
+    PADDING_VERTICAL: Final[int] = 5  # Vertical padding in pixels (reduced for compact design)
     BORDER_RADIUS: Final[int] = 4  # Border radius in pixels
 
 
 class LayoutSpacing:
     """Spacing constants for layouts."""
-    PDF_BUTTON_TOP_MARGIN: Final[int] = 8  # Top margin for PDF button container
+    PDF_BUTTON_TOP_MARGIN: Final[int] = 6  # Top margin for PDF button container (reduced)
     CONTAINER_MARGIN: Final[int] = 0  # Margin for containers
 
 

--- a/src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py
+++ b/src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py
@@ -272,7 +272,7 @@ class CollapsibleDocumentCard(QFrame):
                     border: 1px solid {COLOR_BORDER_ABSTRACT};
                     border-radius: 4px;
                     padding: {ABSTRACT_PADDING}px;
-                    font-size: 11pt;
+                    font-size: 12pt;
                     color: {COLOR_TEXT_ABSTRACT};
                 }}
             """)


### PR DESCRIPTION
## Summary

Integrates the `QtDocumentCardFactory` into the Research tab's Literature display and improves PDF button and abstract styling across all document cards.

## Changes

### 1. Literature Tab Integration
**File**: `src/bmlibrarian/gui/qt/plugins/research/research_tab.py`

- Added imports for `QtDocumentCardFactory` and `DocumentCardData`
- Initialized factory in `ResearchTab.__init__()`
- Refactored `_create_document_score_card` method to use factory pattern
  - **Code reduction**: ~220 lines → ~85 lines
  - Adds automatic PDF button support (VIEW/FETCH/UPLOAD states)
  - Preserves AI reasoning section by inserting into card details
  - Improves consistency with Search tab implementation

### 2. PDF Button Styling Improvements
**File**: `src/bmlibrarian/gui/qt/resources/constants.py`

Made PDF buttons more compact and professional:
- Button height: 40px → 30px (25% reduction)
- Vertical padding: 8px → 5px (37% reduction)
- Horizontal padding: 12px → 10px (17% reduction)
- Top margin: 8px → 6px (25% reduction)

### 3. Abstract Font Size Increase
**File**: `src/bmlibrarian/gui/qt/widgets/collapsible_document_card.py`

Improved abstract text readability:
- Font size: 11pt → 12pt (9% increase)

## Benefits

✅ **Consistency**: Literature tab now uses same card factory as Search tab  
✅ **PDF Support**: Automatic three-state PDF buttons (VIEW/FETCH/UPLOAD)  
✅ **Maintainability**: Reduced code duplication, centralized styling  
✅ **Features**: Inherits all factory features (PDF caching, error handling)  
✅ **UX Improvements**: More compact buttons, larger abstract text

## Testing

- Code compiles successfully
- `CollapsibleDocumentCard` integration verified
- Styling changes apply consistently across all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>