### PR TITLE
Fix plugin loading errors in Qt GUI

### DIFF
--- a/src/bmlibrarian/gui/qt/plugins/settings/__init__.py
+++ b/src/bmlibrarian/gui/qt/plugins/settings/__init__.py
@@ -2,6 +2,7 @@
 Settings plugin for BMLibrarian Qt GUI.
 """
 
-from .plugin import SettingsPlugin
+# Note: create_plugin is imported directly by PluginManager from plugin.py
+# Don't import plugin classes here to avoid circular imports
 
-__all__ = ['SettingsPlugin']
+__all__ = []

--- a/src/bmlibrarian/gui/qt/plugins/study_assessment/__init__.py
+++ b/src/bmlibrarian/gui/qt/plugins/study_assessment/__init__.py
@@ -5,11 +5,11 @@ Interactive interface for evaluating research quality, study design,
 and trustworthiness of biomedical evidence.
 """
 
-from .plugin import create_plugin, StudyAssessmentLabPlugin
+# Note: create_plugin is imported directly by PluginManager from plugin.py
+# Don't import it here to avoid circular imports
+
 from .study_assessment_tab import StudyAssessmentTabWidget
 
 __all__ = [
-    'create_plugin',
-    'StudyAssessmentLabPlugin',
     'StudyAssessmentTabWidget'
 ]


### PR DESCRIPTION
Fixed two plugin loading errors in the Qt GUI:

1. **Settings plugin** (`settings/plugin.py`):
   - Renamed `SettingsPlugin` class to `SettingsWidget` (the actual widget)
   - Created new `SettingsPlugin` class that inherits from `BaseTabPlugin`
   - Added required `get_metadata()` method with plugin metadata
   - Renamed `_init_ui()` to `create_widget()` to match plugin interface
   - Added `create_plugin()` factory function
   - Updated `__init__.py` to avoid circular imports

2. **Study Assessment plugin** (`study_assessment/__init__.py`):
   - Removed circular import by not importing `create_plugin` from `__init__.py`
   - Plugin manager imports `create_plugin` directly from `plugin.py`
   - Added explanatory comment about avoiding circular imports

Both plugins now follow the standard plugin architecture:
- Inherit from `BaseTabPlugin`
- Implement `get_metadata()` and `create_widget()` methods
- Provide `create_plugin()` factory function
- Avoid circular imports in `__init__.py`

Error messages before fix:
- settings: "Plugin 'settings' missing create_plugin() function"
- study_assessment: "cannot import name 'create_plugin'"

Verified with AST-based structure validation that both plugins now have: ✅ create_plugin() function returning BaseTabPlugin ✅ Plugin class inheriting from BaseTabPlugin
✅ No circular imports in __init__.py