### PR TITLE
Fix citation card display and layout in fact checker

### DIFF
--- a/src/bmlibrarian/gui/qt/plugins/fact_checker/citation_widget.py
+++ b/src/bmlibrarian/gui/qt/plugins/fact_checker/citation_widget.py
@@ -143,12 +143,20 @@ class CitationListWidget(QWidget):
         if not db or 'document_id' not in citation:
             return citation
 
-        # Check if we need to enrich (missing abstract or PMID)
+        # Check if we need to enrich (missing any important fields)
         needs_enrichment = (
             not citation.get('abstract') or
-            citation.get('abstract') == 'No abstract' or
+            citation.get('abstract') in ('No abstract', 'No abstract available') or
             not citation.get('pmid') or
-            citation.get('pmid') == 'N/A'
+            citation.get('pmid') == 'N/A' or
+            not citation.get('title') or
+            citation.get('title') == 'No title' or
+            not citation.get('authors') or
+            citation.get('authors') == 'Unknown' or
+            not citation.get('journal') or
+            citation.get('journal') == 'Unknown' or
+            not citation.get('pub_year') or
+            citation.get('pub_year') == 'N/A'
         )
 
         if not needs_enrichment:


### PR DESCRIPTION
Fixed Issues:
1. Citation cards now properly display title, authors, year, and journal metadata
2. Redesigned card layout: title has frame with blue left border, metadata area has NO frame or border
3. Improved data enrichment to fetch all missing metadata fields from database

Changes:
- Modified CitationCard widget to separate title frame from metadata section
- Title section: retains gray background, border, and blue left accent
- Metadata section: plain text below title with no styling, showing "Authors. Journal, Year"
- Enhanced enrichment check to include title, authors, journal, and pub_year fields
- Ensures database lookup triggers when any metadata field has placeholder values

This resolves the awkward layout where metadata had unnecessary framing and ensures all citation information is properly displayed from the database.