### PR TITLE
Relax PaperCheck schema constraints for local research use

### DIFF
--- a/migrations/010_create_papercheck_schema.sql
+++ b/migrations/010_create_papercheck_schema.sql
@@ -218,7 +218,7 @@ CREATE TABLE papercheck.search_results (
 
     -- Search provenance using enum type
     search_strategy papercheck.search_strategy NOT NULL,
-    search_rank INTEGER CHECK (search_rank IS NULL OR (search_rank >= 1 AND search_rank <= 1000)),
+    search_rank INTEGER CHECK (search_rank IS NULL OR search_rank >= 1),  -- No upper bound - supports exhaustive searches
     search_score FLOAT CHECK (search_score IS NULL OR search_score >= 0),
 
     -- Metadata


### PR DESCRIPTION
Summary
Remove overly restrictive constraints that could block legitimate research workflows
Add partial index for error status monitoring
Optimize schema for local database use case where DoS attacks are not a concern
Changes
Constraints removed:

context column: Removed 20KB length limit - contexts may be extensive for complex papers
keywords array: Removed 100-item upper limit - keyword expansion with synonyms is encouraged for comprehensive searches
source_year: Removed 1800-2100 range - allows historical documents and doesn't set arbitrary future ceiling
search_rank: Removed 1000 upper bound - supports exhaustive searches
Index added:

idx_abstracts_error_status: Partial index on status for failed/processing records - improves operational monitoring queries
Rationale
This database is designed for local use by researchers. The previous constraints were added for security against abuse (DoS, keyword stuffing) which is not a realistic threat in this context. The risk of blocking legitimate edge cases (large contexts, extensive keyword expansion, historical documents) outweighs the minimal security benefit.

Test plan
 Verify migration applies cleanly to fresh database
 Confirm existing data still validates
 Test inserting records with previously-blocked values (large context, >100 keywords, pre-1800 year)