### PR TITLE
Implement paper weight step 2 data models

### DIFF
--- a/src/bmlibrarian/agents/__init__.py
+++ b/src/bmlibrarian/agents/__init__.py
@@ -16,6 +16,11 @@ Available Agents:
 - StudyAssessmentAgent: Evaluates research quality, study type, and trustworthiness of evidence
 - PRISMA2020Agent: Assesses systematic reviews against PRISMA 2020 reporting guidelines
 
+Paper Weight Assessment Data Models:
+- AssessmentDetail: Audit trail entry for single assessment component
+- DimensionScore: Score for one dimension with contributing details
+- PaperWeightResult: Complete paper weight assessment with all dimensions
+
 Note: FactCheckerAgent has been moved to bmlibrarian.factchecker module (import from there directly)
 
 Queue System:
@@ -47,6 +52,7 @@ from .document_interrogation_agent import (
 from .pico_agent import PICOAgent, PICOExtraction
 from .study_assessment_agent import StudyAssessmentAgent, StudyAssessment
 from .prisma2020_agent import PRISMA2020Agent, PRISMA2020Assessment, SuitabilityAssessment
+from .paper_weight_agent import AssessmentDetail, DimensionScore, PaperWeightResult
 from .text_chunking import TextChunker, TextChunk, chunk_text, DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP
 from .queue_manager import QueueManager, TaskStatus, TaskPriority
 from .orchestrator import AgentOrchestrator, Workflow, WorkflowStep
@@ -83,6 +89,9 @@ __all__ = [
     "PRISMA2020Agent",
     "PRISMA2020Assessment",
     "SuitabilityAssessment",
+    "AssessmentDetail",
+    "DimensionScore",
+    "PaperWeightResult",
     "TextChunker",
     "TextChunk",
     "chunk_text",

--- a/src/bmlibrarian/agents/paper_weight_agent.py
+++ b/src/bmlibrarian/agents/paper_weight_agent.py
@@ -1,0 +1,372 @@
+"""
+Paper Weight Assessment Agent - Multi-dimensional paper quality assessment
+
+This module provides an AI-powered agent for assessing the evidential weight of
+biomedical research papers across five dimensions: study design, sample size,
+methodological quality, risk of bias, and replication status.
+
+The module currently contains the data models (dataclasses) for representing
+assessments. The agent implementation will be added in later steps.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+import json
+
+
+@dataclass
+class AssessmentDetail:
+    """
+    Audit trail entry for a single assessment component.
+
+    Provides full reproducibility by storing:
+    - What was extracted from the paper
+    - How it contributed to the dimension score
+    - Evidence text supporting the assessment
+    - LLM reasoning (for AI-based assessments)
+
+    Attributes:
+        dimension: Name of the dimension (e.g., "study_design", "sample_size")
+        component: Specific component assessed (e.g., "randomization", "blinding_type")
+        extracted_value: Value found in the paper (e.g., "double-blind", "450")
+        score_contribution: Points contributed to dimension score (0-10)
+        evidence_text: Relevant excerpt from paper (optional)
+        reasoning: AI reasoning for this score (optional)
+
+    Example:
+        >>> detail = AssessmentDetail(
+        ...     dimension="methodological_quality",
+        ...     component="blinding_type",
+        ...     extracted_value="double-blind",
+        ...     score_contribution=3.0,
+        ...     evidence_text="Participants and investigators were masked...",
+        ...     reasoning="Double-blind design detected, contributing full 3.0 points"
+        ... )
+    """
+    dimension: str
+    component: str
+    extracted_value: Optional[str]
+    score_contribution: float
+    evidence_text: Optional[str] = None
+    reasoning: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for database storage."""
+        return {
+            'dimension': self.dimension,
+            'component': self.component,
+            'extracted_value': self.extracted_value,
+            'score_contribution': self.score_contribution,
+            'evidence_text': self.evidence_text,
+            'reasoning': self.reasoning
+        }
+
+
+@dataclass
+class DimensionScore:
+    """
+    Score for a single assessment dimension with full audit trail.
+
+    Each dimension (study design, sample size, etc.) has a final score
+    and a list of components that contributed to that score.
+
+    Attributes:
+        dimension_name: Name of this dimension
+        score: Final score for this dimension (0-10)
+        details: List of component assessments that contributed to the score
+
+    Example:
+        >>> sample_size_score = DimensionScore(dimension_name="sample_size", score=7.1)
+        >>> sample_size_score.add_detail(
+        ...     component="extracted_n",
+        ...     value="450",
+        ...     contribution=5.3,
+        ...     reasoning="Log10(450) * 2 = 5.3"
+        ... )
+        >>> sample_size_score.add_detail(
+        ...     component="power_calculation",
+        ...     value="yes",
+        ...     contribution=2.0,
+        ...     evidence="Sample size was calculated to provide 80% power...",
+        ...     reasoning="Power calculation mentioned, bonus +2.0"
+        ... )
+    """
+    dimension_name: str
+    score: float
+    details: List[AssessmentDetail] = field(default_factory=list)
+
+    def add_detail(self, component: str, value: str, contribution: float,
+                   evidence: Optional[str] = None, reasoning: Optional[str] = None) -> None:
+        """
+        Add an audit trail entry for a component of this dimension.
+
+        Args:
+            component: Name of the component (e.g., "randomization")
+            value: Extracted value (e.g., "proper sequence generation")
+            contribution: Points contributed to dimension score
+            evidence: Supporting text from paper (optional)
+            reasoning: AI reasoning for this score (optional)
+        """
+        self.details.append(AssessmentDetail(
+            dimension=self.dimension_name,
+            component=component,
+            extracted_value=value,
+            score_contribution=contribution,
+            evidence_text=evidence,
+            reasoning=reasoning
+        ))
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            'dimension_name': self.dimension_name,
+            'score': self.score,
+            'details': [d.to_dict() for d in self.details]
+        }
+
+
+@dataclass
+class PaperWeightResult:
+    """
+    Complete paper weight assessment with full audit trail.
+
+    This is the top-level result object containing all dimension scores,
+    the final weighted score, and complete reproducibility information.
+
+    Attributes:
+        document_id: Database ID of assessed document
+        assessor_version: Version of assessment methodology
+        assessed_at: Timestamp of assessment
+        study_design: Study design dimension score
+        sample_size: Sample size dimension score
+        methodological_quality: Methodological quality dimension score
+        risk_of_bias: Risk of bias dimension score (inverted: 10=low risk)
+        replication_status: Replication status dimension score
+        final_weight: Weighted combination of all dimensions (0-10)
+        dimension_weights: Weights used to compute final_weight
+        study_type: Extracted study type (e.g., "RCT", "cohort")
+        sample_size_n: Extracted sample size (number of participants)
+
+    Example:
+        >>> result = PaperWeightResult(
+        ...     document_id=12345,
+        ...     assessor_version="1.0.0",
+        ...     assessed_at=datetime.now(),
+        ...     study_design=DimensionScore("study_design", 8.0),
+        ...     sample_size=DimensionScore("sample_size", 7.5),
+        ...     methodological_quality=DimensionScore("methodological_quality", 6.5),
+        ...     risk_of_bias=DimensionScore("risk_of_bias", 7.0),
+        ...     replication_status=DimensionScore("replication_status", 5.0),
+        ...     final_weight=7.2,
+        ...     dimension_weights={
+        ...         "study_design": 0.25,
+        ...         "sample_size": 0.15,
+        ...         "methodological_quality": 0.30,
+        ...         "risk_of_bias": 0.20,
+        ...         "replication_status": 0.10
+        ...     },
+        ...     study_type="RCT",
+        ...     sample_size_n=450
+        ... )
+    """
+    document_id: int
+    assessor_version: str
+    assessed_at: datetime
+
+    # Dimension scores
+    study_design: DimensionScore
+    sample_size: DimensionScore
+    methodological_quality: DimensionScore
+    risk_of_bias: DimensionScore
+    replication_status: DimensionScore
+
+    # Final weight
+    final_weight: float
+    dimension_weights: Dict[str, float]
+
+    # Metadata
+    study_type: Optional[str] = None
+    sample_size_n: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        """
+        Convert to flat dictionary for database storage.
+
+        Returns flattened structure matching paper_weights.assessments table schema.
+        """
+        return {
+            'document_id': self.document_id,
+            'assessor_version': self.assessor_version,
+            'assessed_at': self.assessed_at,
+            'study_design_score': self.study_design.score,
+            'sample_size_score': self.sample_size.score,
+            'methodological_quality_score': self.methodological_quality.score,
+            'risk_of_bias_score': self.risk_of_bias.score,
+            'replication_status_score': self.replication_status.score,
+            'final_weight': self.final_weight,
+            'dimension_weights': json.dumps(self.dimension_weights),
+            'study_type': self.study_type,
+            'sample_size': self.sample_size_n
+        }
+
+    def get_all_details(self) -> List[AssessmentDetail]:
+        """
+        Collect all audit trail entries from all dimensions.
+
+        Returns:
+            Flat list of all AssessmentDetail objects across all dimensions
+        """
+        all_details = []
+        for dimension_score in [
+            self.study_design,
+            self.sample_size,
+            self.methodological_quality,
+            self.risk_of_bias,
+            self.replication_status
+        ]:
+            all_details.extend(dimension_score.details)
+        return all_details
+
+    def to_markdown(self) -> str:
+        """
+        Format assessment as human-readable Markdown report.
+
+        Returns:
+            Markdown-formatted assessment report with all dimensions and audit trail
+        """
+        lines = [
+            f"# Paper Weight Assessment Report",
+            f"",
+            f"**Document ID:** {self.document_id}",
+            f"**Study Type:** {self.study_type or 'Unknown'}",
+            f"**Sample Size:** {self.sample_size_n or 'Not extracted'}",
+            f"**Assessed:** {self.assessed_at.strftime('%Y-%m-%d %H:%M:%S')}",
+            f"**Assessor Version:** {self.assessor_version}",
+            f"",
+            f"## Final Weight: {self.final_weight:.2f}/10",
+            f"",
+            f"## Dimension Scores",
+            f"",
+        ]
+
+        # Add each dimension with details
+        for dim_name, dim_score in [
+            ("Study Design", self.study_design),
+            ("Sample Size", self.sample_size),
+            ("Methodological Quality", self.methodological_quality),
+            ("Risk of Bias", self.risk_of_bias),
+            ("Replication Status", self.replication_status)
+        ]:
+            lines.append(f"### {dim_name}: {dim_score.score:.2f}/10")
+            lines.append("")
+
+            if dim_score.details:
+                for detail in dim_score.details:
+                    lines.append(f"- **{detail.component}:** {detail.extracted_value}")
+                    lines.append(f"  - Score contribution: {detail.score_contribution:.2f}")
+                    if detail.reasoning:
+                        lines.append(f"  - Reasoning: {detail.reasoning}")
+                    if detail.evidence_text:
+                        # Truncate evidence text if too long
+                        evidence = detail.evidence_text
+                        if len(evidence) > 100:
+                            evidence = evidence[:100] + "..."
+                        lines.append(f"  - Evidence: *\"{evidence}\"*")
+                    lines.append("")
+            else:
+                lines.append("*No detailed breakdown available*")
+                lines.append("")
+
+        # Add dimension weights
+        lines.append("## Dimension Weights Used")
+        lines.append("")
+        for dim, weight in self.dimension_weights.items():
+            lines.append(f"- **{dim}:** {weight:.2f}")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    @classmethod
+    def from_db_row(cls, row: dict, details: List[dict]) -> 'PaperWeightResult':
+        """
+        Reconstruct PaperWeightResult from database rows.
+
+        Args:
+            row: Row from paper_weights.assessments table
+            details: Rows from paper_weights.assessment_details table
+
+        Returns:
+            Reconstructed PaperWeightResult object
+        """
+        # Parse dimension weights from JSONB
+        dimension_weights = row['dimension_weights']
+        if isinstance(dimension_weights, str):
+            dimension_weights = json.loads(dimension_weights)
+
+        # Group details by dimension
+        dimension_details: Dict[str, List[AssessmentDetail]] = {
+            'study_design': [],
+            'sample_size': [],
+            'methodological_quality': [],
+            'risk_of_bias': [],
+            'replication_status': []
+        }
+
+        for detail in details:
+            dim = detail['dimension']
+            if dim in dimension_details:
+                dimension_details[dim].append(AssessmentDetail(
+                    dimension=detail['dimension'],
+                    component=detail['component'],
+                    extracted_value=detail['extracted_value'],
+                    score_contribution=float(detail['score_contribution']) if detail['score_contribution'] else 0.0,
+                    evidence_text=detail['evidence_text'],
+                    reasoning=detail['reasoning']
+                ))
+
+        # Create dimension scores
+        study_design = DimensionScore(
+            dimension_name='study_design',
+            score=float(row['study_design_score']),
+            details=dimension_details['study_design']
+        )
+        sample_size = DimensionScore(
+            dimension_name='sample_size',
+            score=float(row['sample_size_score']),
+            details=dimension_details['sample_size']
+        )
+        methodological_quality = DimensionScore(
+            dimension_name='methodological_quality',
+            score=float(row['methodological_quality_score']),
+            details=dimension_details['methodological_quality']
+        )
+        risk_of_bias = DimensionScore(
+            dimension_name='risk_of_bias',
+            score=float(row['risk_of_bias_score']),
+            details=dimension_details['risk_of_bias']
+        )
+        replication_status = DimensionScore(
+            dimension_name='replication_status',
+            score=float(row['replication_status_score']),
+            details=dimension_details['replication_status']
+        )
+
+        return cls(
+            document_id=row['document_id'],
+            assessor_version=row['assessor_version'],
+            assessed_at=row['assessed_at'],
+            study_design=study_design,
+            sample_size=sample_size,
+            methodological_quality=methodological_quality,
+            risk_of_bias=risk_of_bias,
+            replication_status=replication_status,
+            final_weight=float(row['final_weight']),
+            dimension_weights=dimension_weights,
+            study_type=row.get('study_type'),
+            sample_size_n=row.get('sample_size')
+        )
+
+
+# Export all dataclasses
+__all__ = ['AssessmentDetail', 'DimensionScore', 'PaperWeightResult']

--- a/src/bmlibrarian/agents/paper_weight_agent.py
+++ b/src/bmlibrarian/agents/paper_weight_agent.py
@@ -14,6 +14,10 @@ from typing import Optional, List, Dict
 from datetime import datetime
 import json
 
+# Constants for formatting and display
+EVIDENCE_TRUNCATION_LENGTH = 100  # Max characters for evidence text in markdown output
+DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'  # Standard datetime format for reports
+
 
 @dataclass
 class AssessmentDetail:
@@ -241,7 +245,7 @@ class PaperWeightResult:
             f"**Document ID:** {self.document_id}",
             f"**Study Type:** {self.study_type or 'Unknown'}",
             f"**Sample Size:** {self.sample_size_n or 'Not extracted'}",
-            f"**Assessed:** {self.assessed_at.strftime('%Y-%m-%d %H:%M:%S')}",
+            f"**Assessed:** {self.assessed_at.strftime(DATETIME_FORMAT)}",
             f"**Assessor Version:** {self.assessor_version}",
             f"",
             f"## Final Weight: {self.final_weight:.2f}/10",
@@ -270,8 +274,8 @@ class PaperWeightResult:
                     if detail.evidence_text:
                         # Truncate evidence text if too long
                         evidence = detail.evidence_text
-                        if len(evidence) > 100:
-                            evidence = evidence[:100] + "..."
+                        if len(evidence) > EVIDENCE_TRUNCATION_LENGTH:
+                            evidence = evidence[:EVIDENCE_TRUNCATION_LENGTH] + "..."
                         lines.append(f"  - Evidence: *\"{evidence}\"*")
                     lines.append("")
             else:

--- a/src/bmlibrarian/agents/paper_weight_agent.py
+++ b/src/bmlibrarian/agents/paper_weight_agent.py
@@ -15,7 +15,6 @@ from datetime import datetime
 import json
 
 # Constants for formatting and display
-EVIDENCE_TRUNCATION_LENGTH = 100  # Max characters for evidence text in markdown output
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'  # Standard datetime format for reports
 
 
@@ -272,11 +271,8 @@ class PaperWeightResult:
                     if detail.reasoning:
                         lines.append(f"  - Reasoning: {detail.reasoning}")
                     if detail.evidence_text:
-                        # Truncate evidence text if too long
-                        evidence = detail.evidence_text
-                        if len(evidence) > EVIDENCE_TRUNCATION_LENGTH:
-                            evidence = evidence[:EVIDENCE_TRUNCATION_LENGTH] + "..."
-                        lines.append(f"  - Evidence: *\"{evidence}\"*")
+                        # Preserve full evidence text for audit trail integrity
+                        lines.append(f"  - Evidence: *\"{detail.evidence_text}\"*")
                     lines.append("")
             else:
                 lines.append("*No detailed breakdown available*")

--- a/tests/test_paper_weight_models.py
+++ b/tests/test_paper_weight_models.py
@@ -8,7 +8,8 @@ import pytest
 from datetime import datetime
 import json
 from bmlibrarian.agents.paper_weight_agent import (
-    AssessmentDetail, DimensionScore, PaperWeightResult
+    AssessmentDetail, DimensionScore, PaperWeightResult,
+    EVIDENCE_TRUNCATION_LENGTH
 )
 
 
@@ -323,7 +324,9 @@ class TestPaperWeightResult:
     def test_to_markdown_truncates_long_evidence(self):
         """Test that long evidence text is truncated in Markdown."""
         study_design = DimensionScore("study_design", 8.0)
-        long_evidence = "A" * 200  # 200 character evidence
+        # Create evidence longer than truncation threshold
+        long_evidence_length = EVIDENCE_TRUNCATION_LENGTH * 2
+        long_evidence = "A" * long_evidence_length
         study_design.add_detail(
             "study_type", "RCT", 8.0,
             evidence=long_evidence
@@ -346,8 +349,10 @@ class TestPaperWeightResult:
 
         # Evidence should be truncated with "..."
         assert "..." in markdown
-        # Should not contain full 200 A's
-        assert "A" * 200 not in markdown
+        # Should not contain full evidence string
+        assert "A" * long_evidence_length not in markdown
+        # Should contain truncated version
+        assert "A" * EVIDENCE_TRUNCATION_LENGTH in markdown
 
     def test_from_db_row(self):
         """Test reconstructing PaperWeightResult from database rows."""

--- a/tests/test_paper_weight_models.py
+++ b/tests/test_paper_weight_models.py
@@ -1,0 +1,554 @@
+"""Tests for paper weight assessment data models.
+
+This test module verifies the functionality of the paper weight assessment
+dataclasses: AssessmentDetail, DimensionScore, and PaperWeightResult.
+"""
+
+import pytest
+from datetime import datetime
+import json
+from bmlibrarian.agents.paper_weight_agent import (
+    AssessmentDetail, DimensionScore, PaperWeightResult
+)
+
+
+class TestAssessmentDetail:
+    """Tests for AssessmentDetail dataclass."""
+
+    def test_creation_with_all_fields(self):
+        """Test creating an AssessmentDetail with all fields populated."""
+        detail = AssessmentDetail(
+            dimension="study_design",
+            component="study_type",
+            extracted_value="RCT",
+            score_contribution=8.0,
+            evidence_text="randomized controlled trial",
+            reasoning="Identified as RCT from methods section"
+        )
+
+        assert detail.dimension == "study_design"
+        assert detail.component == "study_type"
+        assert detail.extracted_value == "RCT"
+        assert detail.score_contribution == 8.0
+        assert "randomized" in detail.evidence_text
+        assert "RCT" in detail.reasoning
+
+    def test_creation_with_optional_fields_none(self):
+        """Test creating an AssessmentDetail with optional fields as None."""
+        detail = AssessmentDetail(
+            dimension="sample_size",
+            component="extracted_n",
+            extracted_value="250",
+            score_contribution=4.8
+        )
+
+        assert detail.dimension == "sample_size"
+        assert detail.evidence_text is None
+        assert detail.reasoning is None
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        detail = AssessmentDetail(
+            dimension="methodological_quality",
+            component="blinding_type",
+            extracted_value="double-blind",
+            score_contribution=3.0,
+            evidence_text="participants were masked",
+            reasoning="Full blinding detected"
+        )
+
+        data = detail.to_dict()
+
+        assert data['dimension'] == "methodological_quality"
+        assert data['component'] == "blinding_type"
+        assert data['extracted_value'] == "double-blind"
+        assert data['score_contribution'] == 3.0
+        assert data['evidence_text'] == "participants were masked"
+        assert data['reasoning'] == "Full blinding detected"
+
+    def test_to_dict_with_none_values(self):
+        """Test serialization preserves None values."""
+        detail = AssessmentDetail(
+            dimension="risk_of_bias",
+            component="selection_bias",
+            extracted_value=None,
+            score_contribution=0.0
+        )
+
+        data = detail.to_dict()
+
+        assert data['extracted_value'] is None
+        assert data['evidence_text'] is None
+        assert data['reasoning'] is None
+
+
+class TestDimensionScore:
+    """Tests for DimensionScore dataclass."""
+
+    def test_creation_with_score(self):
+        """Test creating a DimensionScore with just a score."""
+        score = DimensionScore(dimension_name="sample_size", score=7.5)
+
+        assert score.dimension_name == "sample_size"
+        assert score.score == 7.5
+        assert score.details == []
+
+    def test_add_detail(self):
+        """Test adding details to DimensionScore."""
+        score = DimensionScore(dimension_name="sample_size", score=7.5)
+
+        score.add_detail(
+            component="extracted_n",
+            value="450",
+            contribution=5.5
+        )
+
+        score.add_detail(
+            component="power_calculation",
+            value="yes",
+            contribution=2.0,
+            reasoning="Power calculation mentioned in methods"
+        )
+
+        assert len(score.details) == 2
+        assert score.details[0].component == "extracted_n"
+        assert score.details[0].extracted_value == "450"
+        assert score.details[0].score_contribution == 5.5
+        assert score.details[0].dimension == "sample_size"  # Auto-set from dimension_name
+        assert score.details[1].component == "power_calculation"
+        assert score.details[1].score_contribution == 2.0
+        assert score.details[1].reasoning == "Power calculation mentioned in methods"
+
+    def test_add_detail_with_evidence(self):
+        """Test adding a detail with evidence text."""
+        score = DimensionScore(dimension_name="methodological_quality", score=6.5)
+
+        score.add_detail(
+            component="randomization",
+            value="computer-generated",
+            contribution=2.0,
+            evidence="Randomization was performed using a computer-generated sequence",
+            reasoning="Proper sequence generation method described"
+        )
+
+        assert len(score.details) == 1
+        detail = score.details[0]
+        assert detail.evidence_text is not None
+        assert "computer-generated" in detail.evidence_text
+        assert detail.reasoning is not None
+
+    def test_to_dict(self):
+        """Test serialization of DimensionScore."""
+        score = DimensionScore(dimension_name="study_design", score=8.0)
+        score.add_detail(
+            component="study_type",
+            value="RCT",
+            contribution=8.0
+        )
+
+        data = score.to_dict()
+
+        assert data['dimension_name'] == "study_design"
+        assert data['score'] == 8.0
+        assert len(data['details']) == 1
+        assert data['details'][0]['component'] == "study_type"
+
+    def test_to_dict_empty_details(self):
+        """Test serialization with no details."""
+        score = DimensionScore(dimension_name="replication_status", score=0.0)
+
+        data = score.to_dict()
+
+        assert data['details'] == []
+
+
+class TestPaperWeightResult:
+    """Tests for PaperWeightResult dataclass."""
+
+    @pytest.fixture
+    def sample_result(self):
+        """Create a sample PaperWeightResult for testing."""
+        return PaperWeightResult(
+            document_id=12345,
+            assessor_version="1.0.0",
+            assessed_at=datetime(2025, 1, 15, 10, 30),
+            study_design=DimensionScore("study_design", 8.0),
+            sample_size=DimensionScore("sample_size", 7.5),
+            methodological_quality=DimensionScore("methodological_quality", 6.5),
+            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
+            replication_status=DimensionScore("replication_status", 5.0),
+            final_weight=7.2,
+            dimension_weights={
+                "study_design": 0.25,
+                "sample_size": 0.15,
+                "methodological_quality": 0.30,
+                "risk_of_bias": 0.20,
+                "replication_status": 0.10
+            },
+            study_type="RCT",
+            sample_size_n=450
+        )
+
+    def test_creation(self, sample_result):
+        """Test creating a PaperWeightResult."""
+        assert sample_result.document_id == 12345
+        assert sample_result.assessor_version == "1.0.0"
+        assert sample_result.study_design.score == 8.0
+        assert sample_result.sample_size.score == 7.5
+        assert sample_result.final_weight == 7.2
+        assert sample_result.study_type == "RCT"
+        assert sample_result.sample_size_n == 450
+
+    def test_creation_without_metadata(self):
+        """Test creating without optional metadata."""
+        result = PaperWeightResult(
+            document_id=99999,
+            assessor_version="1.0.0",
+            assessed_at=datetime.now(),
+            study_design=DimensionScore("study_design", 5.0),
+            sample_size=DimensionScore("sample_size", 5.0),
+            methodological_quality=DimensionScore("methodological_quality", 5.0),
+            risk_of_bias=DimensionScore("risk_of_bias", 5.0),
+            replication_status=DimensionScore("replication_status", 5.0),
+            final_weight=5.0,
+            dimension_weights={}
+        )
+
+        assert result.study_type is None
+        assert result.sample_size_n is None
+
+    def test_to_dict(self, sample_result):
+        """Test serialization of PaperWeightResult."""
+        data = sample_result.to_dict()
+
+        assert data['document_id'] == 12345
+        assert data['assessor_version'] == "1.0.0"
+        assert data['study_design_score'] == 8.0
+        assert data['sample_size_score'] == 7.5
+        assert data['methodological_quality_score'] == 6.5
+        assert data['risk_of_bias_score'] == 7.0
+        assert data['replication_status_score'] == 5.0
+        assert data['final_weight'] == 7.2
+        assert data['study_type'] == "RCT"
+        assert data['sample_size'] == 450  # Note: maps to sample_size, not sample_size_n
+
+        # Dimension weights should be JSON string
+        weights = json.loads(data['dimension_weights'])
+        assert weights['study_design'] == 0.25
+        assert weights['methodological_quality'] == 0.30
+
+    def test_get_all_details(self):
+        """Test collecting all audit trail details."""
+        study_design = DimensionScore("study_design", 8.0)
+        study_design.add_detail("study_type", "RCT", 8.0)
+
+        sample_size = DimensionScore("sample_size", 7.5)
+        sample_size.add_detail("extracted_n", "450", 5.5)
+        sample_size.add_detail("power_calculation", "yes", 2.0)
+
+        methodological = DimensionScore("methodological_quality", 6.5)
+        methodological.add_detail("blinding", "double-blind", 3.0)
+
+        result = PaperWeightResult(
+            document_id=12345,
+            assessor_version="1.0.0",
+            assessed_at=datetime.now(),
+            study_design=study_design,
+            sample_size=sample_size,
+            methodological_quality=methodological,
+            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
+            replication_status=DimensionScore("replication_status", 5.0),
+            final_weight=7.2,
+            dimension_weights={}
+        )
+
+        all_details = result.get_all_details()
+
+        assert len(all_details) == 4  # 1 + 2 + 1 + 0 + 0
+        assert all_details[0].dimension == "study_design"
+        assert all_details[1].dimension == "sample_size"
+        assert all_details[2].dimension == "sample_size"
+        assert all_details[3].dimension == "methodological_quality"
+
+    def test_get_all_details_empty(self, sample_result):
+        """Test get_all_details when no details exist."""
+        all_details = sample_result.get_all_details()
+        assert all_details == []
+
+    def test_to_markdown(self):
+        """Test Markdown report generation."""
+        study_design = DimensionScore("study_design", 8.0)
+        study_design.add_detail(
+            "study_type", "RCT", 8.0,
+            evidence="This randomized controlled trial...",
+            reasoning="Clear RCT identified"
+        )
+
+        result = PaperWeightResult(
+            document_id=12345,
+            assessor_version="1.0.0",
+            assessed_at=datetime(2025, 1, 15, 10, 30),
+            study_design=study_design,
+            sample_size=DimensionScore("sample_size", 7.5),
+            methodological_quality=DimensionScore("methodological_quality", 6.5),
+            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
+            replication_status=DimensionScore("replication_status", 5.0),
+            final_weight=7.2,
+            dimension_weights={"study_design": 0.25},
+            study_type="RCT",
+            sample_size_n=450
+        )
+
+        markdown = result.to_markdown()
+
+        assert "# Paper Weight Assessment Report" in markdown
+        assert "**Document ID:** 12345" in markdown
+        assert "**Study Type:** RCT" in markdown
+        assert "**Sample Size:** 450" in markdown
+        assert "**Assessor Version:** 1.0.0" in markdown
+        assert "## Final Weight: 7.20/10" in markdown
+        assert "### Study Design: 8.00/10" in markdown
+        assert "### Sample Size: 7.50/10" in markdown
+        assert "**study_type:** RCT" in markdown
+        assert "Score contribution: 8.00" in markdown
+        assert "Clear RCT identified" in markdown
+
+    def test_to_markdown_without_details(self, sample_result):
+        """Test Markdown generation for dimensions without details."""
+        markdown = sample_result.to_markdown()
+
+        # Should indicate no detailed breakdown
+        assert "*No detailed breakdown available*" in markdown
+
+    def test_to_markdown_truncates_long_evidence(self):
+        """Test that long evidence text is truncated in Markdown."""
+        study_design = DimensionScore("study_design", 8.0)
+        long_evidence = "A" * 200  # 200 character evidence
+        study_design.add_detail(
+            "study_type", "RCT", 8.0,
+            evidence=long_evidence
+        )
+
+        result = PaperWeightResult(
+            document_id=12345,
+            assessor_version="1.0.0",
+            assessed_at=datetime.now(),
+            study_design=study_design,
+            sample_size=DimensionScore("sample_size", 5.0),
+            methodological_quality=DimensionScore("methodological_quality", 5.0),
+            risk_of_bias=DimensionScore("risk_of_bias", 5.0),
+            replication_status=DimensionScore("replication_status", 5.0),
+            final_weight=5.5,
+            dimension_weights={}
+        )
+
+        markdown = result.to_markdown()
+
+        # Evidence should be truncated with "..."
+        assert "..." in markdown
+        # Should not contain full 200 A's
+        assert "A" * 200 not in markdown
+
+    def test_from_db_row(self):
+        """Test reconstructing PaperWeightResult from database rows."""
+        # Simulate database row
+        row = {
+            'document_id': 12345,
+            'assessor_version': "1.0.0",
+            'assessed_at': datetime(2025, 1, 15, 10, 30),
+            'study_design_score': 8.0,
+            'sample_size_score': 7.5,
+            'methodological_quality_score': 6.5,
+            'risk_of_bias_score': 7.0,
+            'replication_status_score': 5.0,
+            'final_weight': 7.2,
+            'dimension_weights': '{"study_design": 0.25, "sample_size": 0.15}',
+            'study_type': "RCT",
+            'sample_size': 450
+        }
+
+        # Simulate detail rows
+        details = [
+            {
+                'dimension': 'study_design',
+                'component': 'study_type',
+                'extracted_value': 'RCT',
+                'score_contribution': 8.0,
+                'evidence_text': 'randomized controlled',
+                'reasoning': 'Identified as RCT'
+            },
+            {
+                'dimension': 'sample_size',
+                'component': 'extracted_n',
+                'extracted_value': '450',
+                'score_contribution': 5.5,
+                'evidence_text': None,
+                'reasoning': 'Log10(450) * 2'
+            }
+        ]
+
+        result = PaperWeightResult.from_db_row(row, details)
+
+        assert result.document_id == 12345
+        assert result.assessor_version == "1.0.0"
+        assert result.study_design.score == 8.0
+        assert result.sample_size.score == 7.5
+        assert result.final_weight == 7.2
+        assert result.study_type == "RCT"
+        assert result.sample_size_n == 450
+        assert len(result.study_design.details) == 1
+        assert len(result.sample_size.details) == 1
+        assert result.study_design.details[0].component == "study_type"
+        assert result.dimension_weights['study_design'] == 0.25
+
+    def test_from_db_row_with_dict_weights(self):
+        """Test from_db_row when dimension_weights is already a dict."""
+        row = {
+            'document_id': 99999,
+            'assessor_version': "1.0.0",
+            'assessed_at': datetime.now(),
+            'study_design_score': 5.0,
+            'sample_size_score': 5.0,
+            'methodological_quality_score': 5.0,
+            'risk_of_bias_score': 5.0,
+            'replication_status_score': 5.0,
+            'final_weight': 5.0,
+            'dimension_weights': {"study_design": 0.25},  # Already dict
+            'study_type': None,
+            'sample_size': None
+        }
+
+        result = PaperWeightResult.from_db_row(row, [])
+
+        assert result.dimension_weights == {"study_design": 0.25}
+
+    def test_from_db_row_empty_details(self):
+        """Test from_db_row with no detail rows."""
+        row = {
+            'document_id': 99999,
+            'assessor_version': "1.0.0",
+            'assessed_at': datetime.now(),
+            'study_design_score': 5.0,
+            'sample_size_score': 5.0,
+            'methodological_quality_score': 5.0,
+            'risk_of_bias_score': 5.0,
+            'replication_status_score': 5.0,
+            'final_weight': 5.0,
+            'dimension_weights': '{}',
+            'study_type': None,
+            'sample_size': None
+        }
+
+        result = PaperWeightResult.from_db_row(row, [])
+
+        assert len(result.get_all_details()) == 0
+
+    def test_from_db_row_null_score_contribution(self):
+        """Test from_db_row handles NULL score_contribution."""
+        row = {
+            'document_id': 99999,
+            'assessor_version': "1.0.0",
+            'assessed_at': datetime.now(),
+            'study_design_score': 5.0,
+            'sample_size_score': 5.0,
+            'methodological_quality_score': 5.0,
+            'risk_of_bias_score': 5.0,
+            'replication_status_score': 5.0,
+            'final_weight': 5.0,
+            'dimension_weights': '{}',
+            'study_type': None,
+            'sample_size': None
+        }
+
+        details = [
+            {
+                'dimension': 'study_design',
+                'component': 'unknown',
+                'extracted_value': None,
+                'score_contribution': None,  # NULL from database
+                'evidence_text': None,
+                'reasoning': None
+            }
+        ]
+
+        result = PaperWeightResult.from_db_row(row, details)
+
+        assert result.study_design.details[0].score_contribution == 0.0
+
+
+class TestIntegration:
+    """Integration tests for the complete data model workflow."""
+
+    def test_full_workflow_serialization_roundtrip(self):
+        """Test that data can be serialized and deserialized correctly."""
+        # Create a comprehensive result
+        study_design = DimensionScore("study_design", 8.0)
+        study_design.add_detail("study_type", "RCT", 8.0, reasoning="Clear RCT")
+
+        sample_size = DimensionScore("sample_size", 7.3)
+        sample_size.add_detail("extracted_n", "450", 5.3, reasoning="Log10(450) * 2")
+        sample_size.add_detail("power_calculation", "yes", 2.0, evidence="80% power")
+
+        result = PaperWeightResult(
+            document_id=12345,
+            assessor_version="1.0.0",
+            assessed_at=datetime(2025, 1, 15, 10, 30),
+            study_design=study_design,
+            sample_size=sample_size,
+            methodological_quality=DimensionScore("methodological_quality", 6.5),
+            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
+            replication_status=DimensionScore("replication_status", 5.0),
+            final_weight=7.2,
+            dimension_weights={
+                "study_design": 0.25,
+                "sample_size": 0.15,
+                "methodological_quality": 0.30,
+                "risk_of_bias": 0.20,
+                "replication_status": 0.10
+            },
+            study_type="RCT",
+            sample_size_n=450
+        )
+
+        # Serialize
+        data = result.to_dict()
+        all_details = [d.to_dict() for d in result.get_all_details()]
+
+        # Convert to DB format (simulate database retrieval)
+        db_row = {
+            'document_id': data['document_id'],
+            'assessor_version': data['assessor_version'],
+            'assessed_at': data['assessed_at'],
+            'study_design_score': data['study_design_score'],
+            'sample_size_score': data['sample_size_score'],
+            'methodological_quality_score': data['methodological_quality_score'],
+            'risk_of_bias_score': data['risk_of_bias_score'],
+            'replication_status_score': data['replication_status_score'],
+            'final_weight': data['final_weight'],
+            'dimension_weights': data['dimension_weights'],
+            'study_type': data['study_type'],
+            'sample_size': data['sample_size']
+        }
+
+        # Deserialize
+        reconstructed = PaperWeightResult.from_db_row(db_row, all_details)
+
+        # Verify
+        assert reconstructed.document_id == result.document_id
+        assert reconstructed.final_weight == result.final_weight
+        assert reconstructed.study_design.score == result.study_design.score
+        assert len(reconstructed.get_all_details()) == len(result.get_all_details())
+        assert reconstructed.study_design.details[0].reasoning == "Clear RCT"
+
+    def test_dimension_weights_sum_validation(self):
+        """Test that dimension weights can be validated to sum to 1.0."""
+        weights = {
+            "study_design": 0.25,
+            "sample_size": 0.15,
+            "methodological_quality": 0.30,
+            "risk_of_bias": 0.20,
+            "replication_status": 0.10
+        }
+
+        # Weights should sum to 1.0
+        assert abs(sum(weights.values()) - 1.0) < 0.001

--- a/tests/test_paper_weight_models.py
+++ b/tests/test_paper_weight_models.py
@@ -8,8 +8,7 @@ import pytest
 from datetime import datetime
 import json
 from bmlibrarian.agents.paper_weight_agent import (
-    AssessmentDetail, DimensionScore, PaperWeightResult,
-    EVIDENCE_TRUNCATION_LENGTH
+    AssessmentDetail, DimensionScore, PaperWeightResult
 )
 
 
@@ -321,12 +320,13 @@ class TestPaperWeightResult:
         # Should indicate no detailed breakdown
         assert "*No detailed breakdown available*" in markdown
 
-    def test_to_markdown_truncates_long_evidence(self):
-        """Test that long evidence text is truncated in Markdown."""
+    def test_to_markdown_preserves_full_evidence(self):
+        """Test that full evidence text is preserved in Markdown (no truncation)."""
         study_design = DimensionScore("study_design", 8.0)
-        # Create evidence longer than truncation threshold
-        long_evidence_length = EVIDENCE_TRUNCATION_LENGTH * 2
-        long_evidence = "A" * long_evidence_length
+        # Create substantial evidence text - should be fully preserved
+        long_evidence = "This is a detailed evidence excerpt from the paper that describes " \
+                        "the randomization procedure in full detail including the specific " \
+                        "method used for sequence generation and allocation concealment."
         study_design.add_detail(
             "study_type", "RCT", 8.0,
             evidence=long_evidence
@@ -347,12 +347,10 @@ class TestPaperWeightResult:
 
         markdown = result.to_markdown()
 
-        # Evidence should be truncated with "..."
-        assert "..." in markdown
-        # Should not contain full evidence string
-        assert "A" * long_evidence_length not in markdown
-        # Should contain truncated version
-        assert "A" * EVIDENCE_TRUNCATION_LENGTH in markdown
+        # Full evidence should be preserved for audit trail integrity
+        assert long_evidence in markdown
+        # Should not have truncation indicator
+        assert "..." not in markdown or long_evidence in markdown
 
     def test_from_db_row(self):
         """Test reconstructing PaperWeightResult from database rows."""


### PR DESCRIPTION
## Summary
- Implement Python dataclasses for multi-dimensional paper quality assessment with full type safety and audit trail support
- Add comprehensive test suite with 23 unit tests
- Preserve full evidence text without truncation for audit trail integrity

## Changes

**New Files:**
- `src/bmlibrarian/agents/paper_weight_agent.py` - Data models for paper weight assessment
- `tests/test_paper_weight_models.py` - Comprehensive test suite (23 tests)

**Modified Files:**
- `src/bmlibrarian/agents/__init__.py` - Export new dataclasses

## Data Models

| Class | Purpose |
|-------|---------|
| `AssessmentDetail` | Audit trail entry for single assessment component (dimension, component, value, score contribution, evidence, reasoning) |
| `DimensionScore` | Score for one dimension (0-10) with list of contributing details |
| `PaperWeightResult` | Complete assessment with all 5 dimension scores, final weight, and metadata |

## Key Methods
- `to_dict()` - Database serialization (flat structure for `paper_weights.assessments` table)
- `from_db_row()` - Reconstruct from database rows
- `to_markdown()` - Human-readable report generation with full evidence text preserved
- `get_all_details()` - Collect all audit trail entries

## Design Decisions
- **No truncation of evidence text**: Evidence in audit trails is preserved in full to maintain data integrity for document evaluation and human review
- **DATETIME_FORMAT constant**: Standardized datetime formatting across reports

## Test Plan
- [x] All 23 unit tests pass
- [x] Verified serialization/deserialization round-trip
- [x] Tested with None/NULL values
- [x] Verified full evidence text preservation in markdown output