### PR TITLE
Implement counter statement generation feature

### DIFF
--- a/src/bmlibrarian/paperchecker/__init__.py
+++ b/src/bmlibrarian/paperchecker/__init__.py
@@ -55,11 +55,10 @@ from .database import PaperCheckDB
 
 from .components import (
     StatementExtractor,
-# STILL TO BE IMPLEMENTED - uncomment once done
-#    CounterStatementGenerator,
-#    HyDEGenerator,
-#    SearchCoordinator,
-#    VerdictAnalyzer,
+    CounterStatementGenerator,
+    HyDEGenerator,
+    SearchCoordinator,
+    VerdictAnalyzer,
 )
 
 __all__ = [

--- a/src/bmlibrarian/paperchecker/components/__init__.py
+++ b/src/bmlibrarian/paperchecker/components/__init__.py
@@ -5,12 +5,24 @@ This package contains the modular components that implement each step
 of the PaperChecker workflow:
 
 - StatementExtractor: Extracts core research claims from medical abstracts
+- CounterStatementGenerator: Generates semantically precise negations of claims
+- HyDEGenerator: Generates hypothetical abstracts and keywords for search
+- SearchCoordinator: Coordinates multi-strategy search (stub - Step 07)
+- VerdictAnalyzer: Analyzes evidence and generates verdicts (stub - Step 11)
 
 Each component is designed to be independently testable and reusable.
 """
 
 from .statement_extractor import StatementExtractor
+from .counter_statement_generator import CounterStatementGenerator
+from .hyde_generator import HyDEGenerator
+from .search_coordinator import SearchCoordinator
+from .verdict_analyzer import VerdictAnalyzer
 
 __all__ = [
     "StatementExtractor",
+    "CounterStatementGenerator",
+    "HyDEGenerator",
+    "SearchCoordinator",
+    "VerdictAnalyzer",
 ]

--- a/src/bmlibrarian/paperchecker/components/counter_statement_generator.py
+++ b/src/bmlibrarian/paperchecker/components/counter_statement_generator.py
@@ -12,7 +12,6 @@ The generator produces logical negations rather than simple grammatical negation
 """
 
 import logging
-import re
 import time
 from typing import Any, Dict
 

--- a/src/bmlibrarian/paperchecker/components/counter_statement_generator.py
+++ b/src/bmlibrarian/paperchecker/components/counter_statement_generator.py
@@ -1,0 +1,329 @@
+"""
+Counter-statement generation component for PaperChecker.
+
+Generates semantically precise negations of research claims. This is a key step
+in the PaperChecker workflow, creating counter-statements that can be used to
+search for contradictory evidence.
+
+The generator produces logical negations rather than simple grammatical negations:
+- Comparative claims (X > Y) become (Y >= X)
+- Effect claims (X reduces Y) become (X doesn't reduce Y or X increases Y)
+- Association claims become negated associations
+"""
+
+import logging
+import re
+import time
+from typing import Any, Dict
+
+import ollama
+
+from ..data_models import Statement
+
+logger = logging.getLogger(__name__)
+
+# Configuration Constants
+DEFAULT_TEMPERATURE: float = 0.3
+DEFAULT_OLLAMA_URL: str = "http://localhost:11434"
+DEFAULT_MAX_RETRIES: int = 3
+DEFAULT_RETRY_DELAY_SECONDS: float = 1.0
+MIN_COUNTER_STATEMENT_LENGTH: int = 10
+
+
+class CounterStatementGenerator:
+    """
+    Generates counter-statements that negate original research claims.
+
+    This component creates semantically precise negations that maintain
+    scientific validity. For example:
+    - "X is superior to Y" -> "Y is superior or equivalent to X"
+    - "X reduces Y by 30%" -> "X does not significantly reduce Y"
+    - "High-dose aspirin prevents stroke" -> "High-dose aspirin does not prevent stroke"
+
+    Attributes:
+        model: Ollama model name to use for generation
+        temperature: LLM temperature (lower = more deterministic)
+        host: Ollama server URL
+        client: Ollama client instance
+    """
+
+    def __init__(
+        self,
+        model: str,
+        temperature: float = DEFAULT_TEMPERATURE,
+        host: str = DEFAULT_OLLAMA_URL,
+    ):
+        """
+        Initialize CounterStatementGenerator.
+
+        Args:
+            model: Ollama model name (e.g., "gpt-oss:20b")
+            temperature: LLM temperature (lower = more deterministic)
+            host: Ollama server URL
+        """
+        self.model = model
+        self.temperature = temperature
+        self.host = host.rstrip("/")
+        self.client = ollama.Client(host=self.host)
+
+    def generate(self, statement: Statement) -> str:
+        """
+        Generate counter-statement for a given statement.
+
+        Creates a semantically precise negation of the original statement
+        that can be used to search for contradictory evidence.
+
+        Args:
+            statement: Original Statement object to negate
+
+        Returns:
+            Negated statement text
+
+        Raises:
+            ValueError: If statement is invalid
+            RuntimeError: If generation fails
+        """
+        logger.info(f"Generating counter-statement for: {statement.text[:50]}...")
+
+        # Validate input
+        if not statement.text or not statement.text.strip():
+            raise ValueError("Statement text cannot be empty")
+
+        prompt = self._build_negation_prompt(statement)
+
+        try:
+            response = self._call_llm(prompt)
+            counter_text = self._parse_response(response)
+
+            logger.info(f"Generated counter-statement: {counter_text[:50]}...")
+            return counter_text
+
+        except ValueError:
+            # Re-raise ValueError as-is (validation errors)
+            raise
+        except Exception as e:
+            logger.error(f"Counter-statement generation failed: {e}", exc_info=True)
+            raise RuntimeError(f"Failed to generate counter-statement: {e}") from e
+
+    def _build_negation_prompt(self, statement: Statement) -> str:
+        """
+        Build prompt for generating counter-statement.
+
+        Creates a comprehensive prompt that guides the LLM to produce
+        semantically precise negations rather than simple grammatical ones.
+
+        Args:
+            statement: Original Statement object
+
+        Returns:
+            Formatted prompt string
+        """
+        return f"""You are an expert medical researcher. Your task is to create a semantically precise NEGATION of a research claim.
+
+**Important Guidelines:**
+1. Maintain scientific precision - don't just add "not"
+2. Consider the logical opposite, not just grammatical negation
+3. For comparative claims (X > Y), the negation is (Y >= X)
+4. For effect claims (X reduces Y), the negation is (X doesn't reduce Y OR X increases Y)
+5. For association claims, negate the association
+6. Keep the same level of specificity as the original
+7. The negation should be a complete, standalone statement
+
+**Original Statement:**
+Type: {statement.statement_type}
+Text: {statement.text}
+
+**Context:** {statement.context if statement.context else "N/A"}
+
+**Examples of Good Negations:**
+- Original: "Metformin is superior to GLP-1 agonists"
+  Negation: "GLP-1 agonists are superior or equivalent to metformin"
+
+- Original: "Exercise reduces cardiovascular risk by 30%"
+  Negation: "Exercise does not significantly reduce cardiovascular risk"
+
+- Original: "High-dose aspirin prevents stroke"
+  Negation: "High-dose aspirin does not prevent stroke or increases stroke risk"
+
+- Original: "Vitamin D supplementation improves bone density in elderly patients"
+  Negation: "Vitamin D supplementation does not improve bone density in elderly patients"
+
+- Original: "Early intervention leads to better outcomes"
+  Negation: "Early intervention does not lead to better outcomes compared to delayed intervention"
+
+**Output Format:**
+Return ONLY the negated statement text, nothing else. No JSON, no explanation, just the counter-statement.
+
+**Counter-Statement:**"""
+
+    def _call_llm(
+        self,
+        prompt: str,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_delay: float = DEFAULT_RETRY_DELAY_SECONDS,
+    ) -> str:
+        """
+        Call Ollama API with prompt using the ollama library.
+
+        Args:
+            prompt: The prompt to send to the LLM
+            max_retries: Maximum number of retry attempts
+            retry_delay: Initial delay between retries in seconds
+
+        Returns:
+            LLM response text
+
+        Raises:
+            RuntimeError: If API call fails after all retries
+        """
+        last_exception: Exception | None = None
+        current_delay = retry_delay
+
+        for attempt in range(max_retries):
+            start_time = time.time()
+
+            log_msg = f"Ollama request to {self.model}"
+            if attempt > 0:
+                log_msg += f" (retry {attempt}/{max_retries - 1})"
+            logger.info(log_msg)
+
+            try:
+                response = self.client.chat(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    options={
+                        "temperature": self.temperature,
+                    },
+                )
+
+                content = response.get("message", {}).get("content", "")
+                if not content or not content.strip():
+                    raise ValueError("Empty response from model")
+
+                response_time = (time.time() - start_time) * 1000
+                logger.info(f"Ollama response received in {response_time:.2f}ms")
+                return content.strip()
+
+            except ollama.ResponseError as e:
+                last_exception = e
+                response_time = (time.time() - start_time) * 1000
+
+                is_retryable = (
+                    "timeout" in str(e).lower() or "connection" in str(e).lower()
+                )
+
+                if attempt < max_retries - 1 and is_retryable:
+                    logger.warning(
+                        f"Transient error in Ollama request after {response_time:.2f}ms, "
+                        f"retrying in {current_delay:.1f}s: {e}"
+                    )
+                    time.sleep(current_delay)
+                    current_delay *= 2
+                else:
+                    logger.error(
+                        f"Ollama request failed after {response_time:.2f}ms "
+                        f"(attempt {attempt + 1}/{max_retries}): {e}"
+                    )
+
+            except ValueError as e:
+                # Empty response - retry
+                last_exception = e
+                response_time = (time.time() - start_time) * 1000
+
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        f"Empty response after {response_time:.2f}ms, "
+                        f"retrying in {current_delay:.1f}s"
+                    )
+                    time.sleep(current_delay)
+                    current_delay *= 2
+                else:
+                    logger.error(f"Empty response after {max_retries} attempts")
+
+            except Exception as e:
+                last_exception = e
+                response_time = (time.time() - start_time) * 1000
+                logger.error(
+                    f"Unexpected error in Ollama request after {response_time:.2f}ms: {e}"
+                )
+
+                # Check for connection-related errors
+                error_str = str(e).lower()
+                if "connection" in error_str or "refused" in error_str:
+                    raise RuntimeError(
+                        f"Failed to connect to Ollama server at {self.host}"
+                    ) from e
+                raise RuntimeError(f"LLM call failed: {e}") from e
+
+        # All retries exhausted
+        raise RuntimeError(
+            f"Failed to get response from Ollama after {max_retries} attempts: "
+            f"{last_exception}"
+        )
+
+    def _parse_response(self, response: str) -> str:
+        """
+        Extract counter-statement from LLM response.
+
+        Cleans up the response by removing common prefixes, quotes, and
+        other formatting artifacts.
+
+        Args:
+            response: Raw LLM response string
+
+        Returns:
+            Cleaned counter-statement text
+
+        Raises:
+            ValueError: If response is too short or empty
+        """
+        # Clean up response
+        counter = response.strip()
+
+        # Remove common prefixes (case-insensitive)
+        prefixes = [
+            "Counter-statement:",
+            "Counter statement:",
+            "Negation:",
+            "The negated statement is:",
+            "Here is the counter-statement:",
+            "The counter-statement is:",
+            "Negated statement:",
+        ]
+        counter_lower = counter.lower()
+        for prefix in prefixes:
+            if counter_lower.startswith(prefix.lower()):
+                counter = counter[len(prefix):].strip()
+                counter_lower = counter.lower()
+
+        # Remove quotes if present
+        if counter.startswith('"') and counter.endswith('"'):
+            counter = counter[1:-1].strip()
+        elif counter.startswith("'") and counter.endswith("'"):
+            counter = counter[1:-1].strip()
+
+        # Remove leading dash or bullet
+        if counter.startswith("- "):
+            counter = counter[2:].strip()
+
+        # Validate length
+        if not counter or len(counter) < MIN_COUNTER_STATEMENT_LENGTH:
+            raise ValueError(
+                f"Generated counter-statement too short or empty "
+                f"(minimum {MIN_COUNTER_STATEMENT_LENGTH} characters, got {len(counter)})"
+            )
+
+        return counter
+
+    def test_connection(self) -> bool:
+        """
+        Test connection to Ollama server.
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        try:
+            self.client.list()
+            return True
+        except Exception:
+            return False

--- a/src/bmlibrarian/paperchecker/components/hyde_generator.py
+++ b/src/bmlibrarian/paperchecker/components/hyde_generator.py
@@ -14,7 +14,7 @@ import json
 import logging
 import re
 import time
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import ollama
 
@@ -79,7 +79,7 @@ class HyDEGenerator:
         self,
         original_statement: Statement,
         counter_text: str,
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, List[str]]:
         """
         Generate HyDE abstracts and keywords for counter-statement.
 
@@ -285,7 +285,7 @@ Return ONLY the JSON, nothing else."""
             f"{last_exception}"
         )
 
-    def _parse_response(self, response: str) -> Dict[str, Any]:
+    def _parse_response(self, response: str) -> Dict[str, List[str]]:
         """
         Parse HyDE response into abstracts and keywords.
 

--- a/src/bmlibrarian/paperchecker/components/hyde_generator.py
+++ b/src/bmlibrarian/paperchecker/components/hyde_generator.py
@@ -1,0 +1,405 @@
+"""
+HyDE (Hypothetical Document Embeddings) generation for PaperChecker.
+
+Generates hypothetical abstracts and keywords that would support counter-statements.
+HyDE is a technique where we generate hypothetical documents that WOULD support
+our counter-claim, then search for real documents similar to these hypotheticals.
+
+This approach often finds more relevant evidence than direct keyword search because
+the hypothetical documents capture the semantic structure and terminology that
+real supporting evidence would use.
+"""
+
+import json
+import logging
+import re
+import time
+from typing import Any, Dict, List
+
+import ollama
+
+from ..data_models import Statement
+
+logger = logging.getLogger(__name__)
+
+# Configuration Constants
+DEFAULT_NUM_ABSTRACTS: int = 2
+DEFAULT_MAX_KEYWORDS: int = 10
+DEFAULT_TEMPERATURE: float = 0.3
+DEFAULT_OLLAMA_URL: str = "http://localhost:11434"
+DEFAULT_MAX_RETRIES: int = 3
+DEFAULT_RETRY_DELAY_SECONDS: float = 1.0
+MIN_ABSTRACT_LENGTH: int = 100
+
+
+class HyDEGenerator:
+    """
+    Generates HyDE abstracts and keywords for counter-evidence search.
+
+    HyDE (Hypothetical Document Embeddings) is a technique where we generate
+    hypothetical abstracts that WOULD support our counter-claim, then search
+    for documents similar to these hypothetical abstracts. This captures
+    semantic similarity better than pure keyword search.
+
+    Attributes:
+        model: Ollama model name to use for generation
+        num_abstracts: Number of hypothetical abstracts to generate
+        max_keywords: Maximum number of keywords to generate
+        temperature: LLM temperature (lower = more deterministic)
+        host: Ollama server URL
+        client: Ollama client instance
+    """
+
+    def __init__(
+        self,
+        model: str,
+        num_abstracts: int = DEFAULT_NUM_ABSTRACTS,
+        max_keywords: int = DEFAULT_MAX_KEYWORDS,
+        temperature: float = DEFAULT_TEMPERATURE,
+        host: str = DEFAULT_OLLAMA_URL,
+    ):
+        """
+        Initialize HyDEGenerator.
+
+        Args:
+            model: Ollama model name (e.g., "gpt-oss:20b")
+            num_abstracts: Number of hypothetical abstracts to generate (default: 2)
+            max_keywords: Maximum keywords to generate (default: 10)
+            temperature: LLM temperature (lower = more deterministic)
+            host: Ollama server URL
+        """
+        self.model = model
+        self.num_abstracts = num_abstracts
+        self.max_keywords = max_keywords
+        self.temperature = temperature
+        self.host = host.rstrip("/")
+        self.client = ollama.Client(host=self.host)
+
+    def generate(
+        self,
+        original_statement: Statement,
+        counter_text: str,
+    ) -> Dict[str, Any]:
+        """
+        Generate HyDE abstracts and keywords for counter-statement.
+
+        Creates hypothetical research abstracts that would support the
+        counter-claim, along with targeted keywords for literature search.
+
+        Args:
+            original_statement: Original Statement object
+            counter_text: The counter-statement text to generate materials for
+
+        Returns:
+            Dict with 'hyde_abstracts' (List[str]) and 'keywords' (List[str])
+
+        Raises:
+            ValueError: If inputs are invalid
+            RuntimeError: If generation fails
+        """
+        logger.info("Generating HyDE materials for counter-statement")
+
+        # Validate inputs
+        if not counter_text or not counter_text.strip():
+            raise ValueError("Counter-statement text cannot be empty")
+
+        prompt = self._build_hyde_prompt(original_statement, counter_text)
+
+        try:
+            response = self._call_llm(prompt)
+            materials = self._parse_response(response)
+
+            logger.info(
+                f"Generated {len(materials['hyde_abstracts'])} HyDE abstracts, "
+                f"{len(materials['keywords'])} keywords"
+            )
+
+            return materials
+
+        except ValueError:
+            # Re-raise ValueError as-is (validation errors)
+            raise
+        except Exception as e:
+            logger.error(f"HyDE generation failed: {e}", exc_info=True)
+            raise RuntimeError(f"Failed to generate HyDE materials: {e}") from e
+
+    def _build_hyde_prompt(self, statement: Statement, counter_text: str) -> str:
+        """
+        Build prompt for HyDE generation.
+
+        Creates a comprehensive prompt that guides the LLM to generate
+        realistic hypothetical abstracts and relevant keywords.
+
+        Args:
+            statement: Original Statement object
+            counter_text: Counter-statement text
+
+        Returns:
+            Formatted prompt string
+        """
+        return f"""You are an expert medical researcher. Your task is to:
+1. Generate {self.num_abstracts} hypothetical research abstracts that would SUPPORT the counter-statement
+2. Generate up to {self.max_keywords} keywords for searching literature supporting the counter-statement
+
+**Original Statement:** {statement.text}
+
+**Counter-Statement:** {counter_text}
+
+**Instructions for Hypothetical Abstracts:**
+- Write realistic medical research abstracts (150-200 words each)
+- Each abstract should follow standard structure: Background, Methods, Results, Conclusion
+- Results should clearly support the counter-statement
+- Use realistic statistical language (p-values, confidence intervals, effect sizes)
+- Make them diverse in methodology (e.g., RCT, cohort study, meta-analysis, systematic review)
+- Use appropriate medical terminology and clinical context
+- Include realistic patient populations and sample sizes
+- The abstracts should read as if they are from real published studies
+
+**Instructions for Keywords:**
+- Generate up to {self.max_keywords} search keywords/phrases
+- Include relevant medical terminology, drug names, condition names
+- Include methodology terms if relevant (e.g., "randomized controlled trial")
+- Focus on terms that would find evidence SUPPORTING the counter-statement
+- Order by importance (most important first)
+- Mix specific terms with broader concepts
+- Include both MeSH-style terms and natural language variations
+
+**Output Format:**
+Return ONLY valid JSON in this exact format (no additional text):
+{{
+  "hyde_abstracts": [
+    "First hypothetical abstract text supporting the counter-statement...",
+    "Second hypothetical abstract text with different methodology..."
+  ],
+  "keywords": [
+    "most important keyword",
+    "second keyword",
+    "additional relevant terms..."
+  ]
+}}
+
+Return ONLY the JSON, nothing else."""
+
+    def _call_llm(
+        self,
+        prompt: str,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_delay: float = DEFAULT_RETRY_DELAY_SECONDS,
+    ) -> str:
+        """
+        Call Ollama API with prompt using the ollama library.
+
+        Args:
+            prompt: The prompt to send to the LLM
+            max_retries: Maximum number of retry attempts
+            retry_delay: Initial delay between retries in seconds
+
+        Returns:
+            LLM response text
+
+        Raises:
+            RuntimeError: If API call fails after all retries
+        """
+        last_exception: Exception | None = None
+        current_delay = retry_delay
+
+        for attempt in range(max_retries):
+            start_time = time.time()
+
+            log_msg = f"Ollama request to {self.model}"
+            if attempt > 0:
+                log_msg += f" (retry {attempt}/{max_retries - 1})"
+            logger.info(log_msg)
+
+            try:
+                response = self.client.chat(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    options={
+                        "temperature": self.temperature,
+                    },
+                )
+
+                content = response.get("message", {}).get("content", "")
+                if not content or not content.strip():
+                    raise ValueError("Empty response from model")
+
+                response_time = (time.time() - start_time) * 1000
+                logger.info(f"Ollama response received in {response_time:.2f}ms")
+                return content.strip()
+
+            except ollama.ResponseError as e:
+                last_exception = e
+                response_time = (time.time() - start_time) * 1000
+
+                is_retryable = (
+                    "timeout" in str(e).lower() or "connection" in str(e).lower()
+                )
+
+                if attempt < max_retries - 1 and is_retryable:
+                    logger.warning(
+                        f"Transient error in Ollama request after {response_time:.2f}ms, "
+                        f"retrying in {current_delay:.1f}s: {e}"
+                    )
+                    time.sleep(current_delay)
+                    current_delay *= 2
+                else:
+                    logger.error(
+                        f"Ollama request failed after {response_time:.2f}ms "
+                        f"(attempt {attempt + 1}/{max_retries}): {e}"
+                    )
+
+            except ValueError as e:
+                # Empty response - retry
+                last_exception = e
+                response_time = (time.time() - start_time) * 1000
+
+                if attempt < max_retries - 1:
+                    logger.warning(
+                        f"Empty response after {response_time:.2f}ms, "
+                        f"retrying in {current_delay:.1f}s"
+                    )
+                    time.sleep(current_delay)
+                    current_delay *= 2
+                else:
+                    logger.error(f"Empty response after {max_retries} attempts")
+
+            except Exception as e:
+                last_exception = e
+                response_time = (time.time() - start_time) * 1000
+                logger.error(
+                    f"Unexpected error in Ollama request after {response_time:.2f}ms: {e}"
+                )
+
+                # Check for connection-related errors
+                error_str = str(e).lower()
+                if "connection" in error_str or "refused" in error_str:
+                    raise RuntimeError(
+                        f"Failed to connect to Ollama server at {self.host}"
+                    ) from e
+                raise RuntimeError(f"LLM call failed: {e}") from e
+
+        # All retries exhausted
+        raise RuntimeError(
+            f"Failed to get response from Ollama after {max_retries} attempts: "
+            f"{last_exception}"
+        )
+
+    def _parse_response(self, response: str) -> Dict[str, Any]:
+        """
+        Parse HyDE response into abstracts and keywords.
+
+        Extracts JSON from the response and validates the structure.
+
+        Args:
+            response: Raw LLM response string
+
+        Returns:
+            Dict with 'hyde_abstracts' and 'keywords' lists
+
+        Raises:
+            ValueError: If response cannot be parsed or is invalid
+        """
+        try:
+            # Clean response and extract JSON
+            json_str = self._extract_json(response)
+
+            # Parse JSON
+            data = json.loads(json_str)
+
+            # Validate structure
+            if "hyde_abstracts" not in data:
+                raise ValueError("Response missing 'hyde_abstracts' key")
+            if "keywords" not in data:
+                raise ValueError("Response missing 'keywords' key")
+
+            if not isinstance(data["hyde_abstracts"], list):
+                raise ValueError("'hyde_abstracts' must be a list")
+            if not isinstance(data["keywords"], list):
+                raise ValueError("'keywords' must be a list")
+
+            # Extract and validate abstracts
+            hyde_abstracts = []
+            for i, abstract in enumerate(data["hyde_abstracts"][:self.num_abstracts]):
+                if isinstance(abstract, str) and len(abstract.strip()) >= MIN_ABSTRACT_LENGTH:
+                    hyde_abstracts.append(abstract.strip())
+                else:
+                    logger.warning(
+                        f"HyDE abstract {i+1} is too short or invalid, skipping"
+                    )
+
+            # Extract and validate keywords
+            keywords = []
+            for keyword in data["keywords"][:self.max_keywords]:
+                if isinstance(keyword, str) and len(keyword.strip()) > 0:
+                    keywords.append(keyword.strip())
+
+            # Validate we have minimum required content
+            if not hyde_abstracts:
+                raise ValueError("No valid HyDE abstracts in response")
+            if not keywords:
+                raise ValueError("No valid keywords in response")
+
+            return {
+                "hyde_abstracts": hyde_abstracts,
+                "keywords": keywords,
+            }
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse JSON: {e}")
+            logger.debug(f"Raw response: {response}")
+            raise ValueError(f"Invalid JSON in response: {e}") from e
+
+    def _extract_json(self, response: str) -> str:
+        """
+        Extract JSON from response that may contain extra text or code blocks.
+
+        Args:
+            response: Raw response string
+
+        Returns:
+            Extracted JSON string
+        """
+        response = response.strip()
+
+        # Try to find JSON in code blocks first
+        if "```json" in response:
+            match = re.search(r"```json\s*([\s\S]*?)\s*```", response)
+            if match:
+                return match.group(1).strip()
+
+        if "```" in response:
+            match = re.search(r"```\s*([\s\S]*?)\s*```", response)
+            if match:
+                content = match.group(1).strip()
+                if content.startswith("{"):
+                    return content
+
+        # Try to find JSON object directly
+        start_idx = response.find("{")
+        if start_idx != -1:
+            # Find matching closing brace
+            brace_count = 0
+            for i, char in enumerate(response[start_idx:], start_idx):
+                if char == "{":
+                    brace_count += 1
+                elif char == "}":
+                    brace_count -= 1
+                    if brace_count == 0:
+                        return response[start_idx:i + 1]
+
+        # Return original response as fallback
+        return response
+
+    def test_connection(self) -> bool:
+        """
+        Test connection to Ollama server.
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        try:
+            self.client.list()
+            return True
+        except Exception:
+            return False

--- a/src/bmlibrarian/paperchecker/components/search_coordinator.py
+++ b/src/bmlibrarian/paperchecker/components/search_coordinator.py
@@ -1,0 +1,143 @@
+"""
+Search coordination component for PaperChecker (stub implementation).
+
+This module will coordinate multi-strategy document search (semantic, HyDE, keyword)
+and combine results with deduplication and provenance tracking.
+
+Note:
+    Full implementation in Step 07 (07_MULTI_STRATEGY_SEARCH.md)
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from ..data_models import CounterStatement, SearchResults
+
+logger = logging.getLogger(__name__)
+
+# Default configuration constants
+DEFAULT_SEMANTIC_LIMIT: int = 50
+DEFAULT_HYDE_LIMIT: int = 50
+DEFAULT_KEYWORD_LIMIT: int = 50
+
+
+class SearchCoordinator:
+    """
+    Component for coordinating multi-strategy document search.
+
+    Executes three parallel search strategies (semantic, HyDE, keyword)
+    and combines results with deduplication and provenance tracking.
+
+    Attributes:
+        config: Search configuration dictionary
+        db_connection: PostgreSQL database connection
+        semantic_limit: Maximum documents from semantic search
+        hyde_limit: Maximum documents from HyDE search
+        keyword_limit: Maximum documents from keyword search
+
+    Note:
+        This is a stub implementation. Full implementation in Step 07.
+    """
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        db_connection: Optional[Any] = None
+    ):
+        """
+        Initialize SearchCoordinator.
+
+        Args:
+            config: Search configuration with limits and parameters
+            db_connection: PostgreSQL database connection for search queries
+        """
+        self.config = config
+        self.db_connection = db_connection
+
+        # Extract limits from config
+        self.semantic_limit = config.get("semantic_limit", DEFAULT_SEMANTIC_LIMIT)
+        self.hyde_limit = config.get("hyde_limit", DEFAULT_HYDE_LIMIT)
+        self.keyword_limit = config.get("keyword_limit", DEFAULT_KEYWORD_LIMIT)
+
+        logger.info(
+            f"Initialized SearchCoordinator with limits: "
+            f"semantic={self.semantic_limit}, hyde={self.hyde_limit}, "
+            f"keyword={self.keyword_limit}"
+        )
+
+    def search(self, counter_stmt: CounterStatement) -> SearchResults:
+        """
+        Execute multi-strategy search for counter-evidence.
+
+        Runs semantic, HyDE, and keyword searches, then combines
+        and deduplicates results with provenance tracking.
+
+        Args:
+            counter_stmt: Counter-statement with search materials
+
+        Returns:
+            SearchResults with documents from all strategies
+
+        Raises:
+            NotImplementedError: This is a stub implementation
+
+        Note:
+            Full implementation in Step 07 (07_MULTI_STRATEGY_SEARCH.md)
+        """
+        raise NotImplementedError(
+            "SearchCoordinator.search() will be implemented in Step 07"
+        )
+
+    def search_semantic(self, text: str, limit: int) -> List[int]:
+        """
+        Execute semantic (embedding-based) search.
+
+        Args:
+            text: Query text for embedding
+            limit: Maximum documents to return
+
+        Returns:
+            List of document IDs
+
+        Raises:
+            NotImplementedError: This is a stub implementation
+        """
+        raise NotImplementedError(
+            "SearchCoordinator.search_semantic() will be implemented in Step 07"
+        )
+
+    def search_hyde(self, hyde_abstracts: List[str], limit: int) -> List[int]:
+        """
+        Execute HyDE (hypothetical document embedding) search.
+
+        Args:
+            hyde_abstracts: Hypothetical abstracts for embedding
+            limit: Maximum documents to return
+
+        Returns:
+            List of document IDs
+
+        Raises:
+            NotImplementedError: This is a stub implementation
+        """
+        raise NotImplementedError(
+            "SearchCoordinator.search_hyde() will be implemented in Step 07"
+        )
+
+    def search_keyword(self, keywords: List[str], limit: int) -> List[int]:
+        """
+        Execute keyword (fulltext) search.
+
+        Args:
+            keywords: Search keywords
+            limit: Maximum documents to return
+
+        Returns:
+            List of document IDs
+
+        Raises:
+            NotImplementedError: This is a stub implementation
+        """
+        raise NotImplementedError(
+            "SearchCoordinator.search_keyword() will be implemented in Step 07"
+        )

--- a/src/bmlibrarian/paperchecker/components/verdict_analyzer.py
+++ b/src/bmlibrarian/paperchecker/components/verdict_analyzer.py
@@ -1,0 +1,126 @@
+"""
+Verdict analysis component for PaperChecker (stub implementation).
+
+This module will analyze counter-evidence reports and generate verdicts
+on whether evidence supports, contradicts, or is undecided about
+the original research claims.
+
+Note:
+    Full implementation in Step 11 (11_VERDICT_ANALYSIS.md)
+"""
+
+import logging
+from typing import Any, List
+
+import ollama
+
+from ..data_models import Statement, CounterReport, Verdict
+
+logger = logging.getLogger(__name__)
+
+# Default configuration constants
+DEFAULT_TEMPERATURE: float = 0.3
+DEFAULT_OLLAMA_URL: str = "http://localhost:11434"
+
+
+class VerdictAnalyzer:
+    """
+    Component for analyzing counter-evidence and generating verdicts.
+
+    Takes the original statement and counter-evidence report, then determines
+    whether the evidence supports, contradicts, or is undecided about
+    the original claim.
+
+    Attributes:
+        model: Ollama model name for verdict analysis
+        host: Ollama server host URL
+        temperature: LLM temperature for analysis
+        client: Ollama client instance
+
+    Note:
+        This is a stub implementation. Full implementation in Step 11.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        host: str = DEFAULT_OLLAMA_URL,
+        temperature: float = DEFAULT_TEMPERATURE
+    ):
+        """
+        Initialize VerdictAnalyzer.
+
+        Args:
+            model: Ollama model name for analysis
+            host: Ollama server host URL
+            temperature: LLM temperature (lower = more deterministic)
+        """
+        self.model = model
+        self.host = host.rstrip("/")
+        self.temperature = temperature
+        self.client = ollama.Client(host=self.host)
+
+        logger.info(f"Initialized VerdictAnalyzer with model={model}")
+
+    def analyze(
+        self,
+        statement: Statement,
+        counter_report: CounterReport
+    ) -> Verdict:
+        """
+        Analyze counter-evidence and generate verdict.
+
+        Args:
+            statement: Original statement being checked
+            counter_report: Counter-evidence report to analyze
+
+        Returns:
+            Verdict with classification, rationale, and confidence
+
+        Raises:
+            NotImplementedError: This is a stub implementation
+
+        Note:
+            Full implementation in Step 11 (11_VERDICT_ANALYSIS.md)
+        """
+        raise NotImplementedError(
+            "VerdictAnalyzer.analyze() will be implemented in Step 11"
+        )
+
+    def generate_overall_assessment(
+        self,
+        statements: List[Statement],
+        verdicts: List[Verdict]
+    ) -> str:
+        """
+        Generate overall assessment from individual verdicts.
+
+        Args:
+            statements: All extracted statements
+            verdicts: Verdicts for each statement
+
+        Returns:
+            Overall assessment text
+
+        Raises:
+            NotImplementedError: This is a stub implementation
+
+        Note:
+            Full implementation in Step 11 (11_VERDICT_ANALYSIS.md)
+        """
+        raise NotImplementedError(
+            "VerdictAnalyzer.generate_overall_assessment() will be implemented in Step 11"
+        )
+
+    def test_connection(self) -> bool:
+        """
+        Test connection to Ollama server.
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        try:
+            self.client.list()
+            return True
+        except Exception:
+            return False

--- a/tests/test_counter_statement_generator.py
+++ b/tests/test_counter_statement_generator.py
@@ -1,0 +1,722 @@
+"""
+Unit tests for counter-statement generation components.
+
+Tests the CounterStatementGenerator and HyDEGenerator components that implement
+Step 5 of the PaperChecker workflow.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from bmlibrarian.paperchecker.data_models import Statement
+from bmlibrarian.paperchecker.components import CounterStatementGenerator, HyDEGenerator
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def statement_comparative():
+    """Statement with comparative claim."""
+    return Statement(
+        text="Metformin is superior to GLP-1 agonists in long-term T2DM outcomes",
+        context="Prior studies have shown mixed results. Metformin is superior to GLP-1 agonists in long-term T2DM outcomes. This finding has significant implications.",
+        statement_type="finding",
+        confidence=0.9,
+        statement_order=1
+    )
+
+
+@pytest.fixture
+def statement_effect():
+    """Statement with effect claim."""
+    return Statement(
+        text="Exercise reduces cardiovascular risk by 30%",
+        context="Multiple cohort studies suggest protective effects. Exercise reduces cardiovascular risk by 30%. This effect is consistent across populations.",
+        statement_type="finding",
+        confidence=0.85,
+        statement_order=1
+    )
+
+
+@pytest.fixture
+def statement_association():
+    """Statement with association claim."""
+    return Statement(
+        text="High vitamin D levels are associated with reduced cancer risk",
+        context="Observational data support this association. High vitamin D levels are associated with reduced cancer risk. The mechanism remains unclear.",
+        statement_type="hypothesis",
+        confidence=0.75,
+        statement_order=1
+    )
+
+
+@pytest.fixture
+def statement_conclusion():
+    """Statement with conclusion type."""
+    return Statement(
+        text="Early intervention in sepsis leads to better patient outcomes",
+        context="Based on our analysis. Early intervention in sepsis leads to better patient outcomes. Clinical guidelines should be updated.",
+        statement_type="conclusion",
+        confidence=0.88,
+        statement_order=1
+    )
+
+
+@pytest.fixture
+def mock_ollama_client():
+    """Mock ollama client for testing without real API calls."""
+    with patch('bmlibrarian.paperchecker.components.counter_statement_generator.ollama.Client') as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_hyde_ollama_client():
+    """Mock ollama client for HyDE testing."""
+    with patch('bmlibrarian.paperchecker.components.hyde_generator.ollama.Client') as mock:
+        yield mock
+
+
+# =============================================================================
+# CounterStatementGenerator Tests
+# =============================================================================
+
+class TestCounterStatementGenerator:
+    """Tests for CounterStatementGenerator component."""
+
+    def test_initialization(self, mock_ollama_client):
+        """Test generator initializes with correct parameters."""
+        generator = CounterStatementGenerator(
+            model="gpt-oss:20b",
+            temperature=0.3,
+            host="http://localhost:11434"
+        )
+        assert generator.model == "gpt-oss:20b"
+        assert generator.temperature == 0.3
+        assert generator.host == "http://localhost:11434"
+
+    def test_initialization_strips_trailing_slash(self, mock_ollama_client):
+        """Test that trailing slash is stripped from host URL."""
+        generator = CounterStatementGenerator(
+            model="test-model",
+            host="http://localhost:11434/"
+        )
+        assert generator.host == "http://localhost:11434"
+
+    def test_empty_statement_raises_value_error(self, mock_ollama_client):
+        """Test that empty statement text raises ValueError."""
+        generator = CounterStatementGenerator(model="test-model")
+        empty_statement = Statement(
+            text="",
+            context="Context",
+            statement_type="finding",
+            confidence=0.9,
+            statement_order=1
+        )
+        # Statement validation should catch this, but test generator's validation too
+        with pytest.raises(ValueError, match="Statement text cannot be empty"):
+            generator.generate(empty_statement)
+
+    def test_whitespace_only_statement_raises_value_error(self, mock_ollama_client):
+        """Test that whitespace-only statement raises ValueError."""
+        generator = CounterStatementGenerator(model="test-model")
+        # Create a statement and modify text to whitespace
+        stmt = Statement(
+            text="Valid text",
+            context="Context",
+            statement_type="finding",
+            confidence=0.9,
+            statement_order=1
+        )
+        stmt.text = "   "  # Bypass validation by modifying after creation
+        with pytest.raises(ValueError, match="Statement text cannot be empty"):
+            generator.generate(stmt)
+
+    def test_parse_response_removes_common_prefixes(self, mock_ollama_client):
+        """Test that common prefixes are removed from response."""
+        generator = CounterStatementGenerator(model="test-model")
+
+        prefixes_to_test = [
+            "Counter-statement: GLP-1 agonists are superior",
+            "counter statement: GLP-1 agonists are superior",
+            "Negation: GLP-1 agonists are superior",
+            "The negated statement is: GLP-1 agonists are superior",
+            "Here is the counter-statement: GLP-1 agonists are superior",
+        ]
+
+        for response in prefixes_to_test:
+            result = generator._parse_response(response)
+            assert result == "GLP-1 agonists are superior"
+
+    def test_parse_response_removes_quotes(self, mock_ollama_client):
+        """Test that surrounding quotes are removed."""
+        generator = CounterStatementGenerator(model="test-model")
+
+        assert generator._parse_response('"Counter statement here"') == "Counter statement here"
+        assert generator._parse_response("'Counter statement here'") == "Counter statement here"
+
+    def test_parse_response_removes_bullet_prefix(self, mock_ollama_client):
+        """Test that bullet/dash prefix is removed."""
+        generator = CounterStatementGenerator(model="test-model")
+
+        result = generator._parse_response("- Counter statement here")
+        assert result == "Counter statement here"
+
+    def test_parse_response_rejects_short_response(self, mock_ollama_client):
+        """Test that too-short responses are rejected."""
+        generator = CounterStatementGenerator(model="test-model")
+
+        with pytest.raises(ValueError, match="too short or empty"):
+            generator._parse_response("Short")
+
+    def test_parse_response_rejects_empty_response(self, mock_ollama_client):
+        """Test that empty responses are rejected."""
+        generator = CounterStatementGenerator(model="test-model")
+
+        with pytest.raises(ValueError, match="too short or empty"):
+            generator._parse_response("")
+
+        with pytest.raises(ValueError, match="too short or empty"):
+            generator._parse_response("   ")
+
+    def test_build_negation_prompt_includes_statement_info(self, mock_ollama_client, statement_comparative):
+        """Test that prompt includes statement text, type, and context."""
+        generator = CounterStatementGenerator(model="test-model")
+
+        prompt = generator._build_negation_prompt(statement_comparative)
+
+        assert statement_comparative.text in prompt
+        assert statement_comparative.statement_type in prompt
+        assert statement_comparative.context in prompt
+        assert "logical opposite" in prompt.lower()
+        assert "semantically precise" in prompt.lower()
+
+    def test_build_negation_prompt_handles_empty_context(self, mock_ollama_client):
+        """Test that prompt handles empty context gracefully."""
+        generator = CounterStatementGenerator(model="test-model")
+        stmt = Statement(
+            text="Test statement",
+            context="",
+            statement_type="finding",
+            confidence=0.9,
+            statement_order=1
+        )
+
+        prompt = generator._build_negation_prompt(stmt)
+        assert "N/A" in prompt
+
+    def test_generate_success(self, mock_ollama_client, statement_comparative):
+        """Test successful counter-statement generation."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": "GLP-1 agonists are superior or equivalent to metformin in long-term T2DM outcomes"
+            }
+        }
+        mock_ollama_client.return_value = mock_client_instance
+
+        generator = CounterStatementGenerator(model="gpt-oss:20b")
+        result = generator.generate(statement_comparative)
+
+        assert len(result) > 10
+        assert "GLP-1" in result or "glp" in result.lower()
+        mock_client_instance.chat.assert_called_once()
+
+    def test_generate_handles_llm_error(self, mock_ollama_client, statement_comparative):
+        """Test that LLM errors are handled gracefully."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.side_effect = Exception("Connection failed")
+        mock_ollama_client.return_value = mock_client_instance
+
+        generator = CounterStatementGenerator(model="gpt-oss:20b")
+
+        with pytest.raises(RuntimeError, match="Failed to generate counter-statement"):
+            generator.generate(statement_comparative)
+
+    def test_test_connection_success(self, mock_ollama_client):
+        """Test connection test when successful."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.list.return_value = {"models": []}
+        mock_ollama_client.return_value = mock_client_instance
+
+        generator = CounterStatementGenerator(model="test-model")
+        assert generator.test_connection() is True
+
+    def test_test_connection_failure(self, mock_ollama_client):
+        """Test connection test when failed."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.list.side_effect = Exception("Connection refused")
+        mock_ollama_client.return_value = mock_client_instance
+
+        generator = CounterStatementGenerator(model="test-model")
+        assert generator.test_connection() is False
+
+
+# =============================================================================
+# HyDEGenerator Tests
+# =============================================================================
+
+class TestHyDEGenerator:
+    """Tests for HyDEGenerator component."""
+
+    def test_initialization(self, mock_hyde_ollama_client):
+        """Test generator initializes with correct parameters."""
+        generator = HyDEGenerator(
+            model="gpt-oss:20b",
+            num_abstracts=2,
+            max_keywords=10,
+            temperature=0.3,
+            host="http://localhost:11434"
+        )
+        assert generator.model == "gpt-oss:20b"
+        assert generator.num_abstracts == 2
+        assert generator.max_keywords == 10
+        assert generator.temperature == 0.3
+
+    def test_initialization_with_defaults(self, mock_hyde_ollama_client):
+        """Test generator uses correct defaults."""
+        generator = HyDEGenerator(model="test-model")
+        assert generator.num_abstracts == 2  # Default
+        assert generator.max_keywords == 10  # Default
+        assert generator.temperature == 0.3  # Default
+
+    def test_empty_counter_text_raises_value_error(self, mock_hyde_ollama_client, statement_comparative):
+        """Test that empty counter text raises ValueError."""
+        generator = HyDEGenerator(model="test-model")
+
+        with pytest.raises(ValueError, match="Counter-statement text cannot be empty"):
+            generator.generate(statement_comparative, "")
+
+        with pytest.raises(ValueError, match="Counter-statement text cannot be empty"):
+            generator.generate(statement_comparative, "   ")
+
+    def test_build_hyde_prompt_includes_required_info(self, mock_hyde_ollama_client, statement_comparative):
+        """Test that prompt includes original statement and counter-statement."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=2, max_keywords=10)
+        counter_text = "GLP-1 agonists are superior to metformin"
+
+        prompt = generator._build_hyde_prompt(statement_comparative, counter_text)
+
+        assert statement_comparative.text in prompt
+        assert counter_text in prompt
+        assert "2" in prompt  # num_abstracts
+        assert "10" in prompt  # max_keywords
+        assert "hypothetical" in prompt.lower()
+        assert "json" in prompt.lower()
+
+    def test_parse_response_valid_json(self, mock_hyde_ollama_client):
+        """Test parsing valid JSON response."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=2, max_keywords=5)
+
+        response = json.dumps({
+            "hyde_abstracts": [
+                "Background: This is a hypothetical abstract supporting the counter-claim with sufficient length to pass validation. Methods: We conducted a randomized trial. Results: Findings support the counter-statement. Conclusion: The evidence is clear.",
+                "Background: Second hypothetical abstract with different methodology and also sufficient length. Methods: Meta-analysis approach. Results: Strong effect observed. Conclusion: Confirms the counter-statement."
+            ],
+            "keywords": ["keyword1", "keyword2", "keyword3", "keyword4", "keyword5"]
+        })
+
+        result = generator._parse_response(response)
+
+        assert "hyde_abstracts" in result
+        assert "keywords" in result
+        assert len(result["hyde_abstracts"]) == 2
+        assert len(result["keywords"]) == 5
+
+    def test_parse_response_extracts_json_from_code_block(self, mock_hyde_ollama_client):
+        """Test parsing JSON from markdown code block."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=2, max_keywords=3)
+
+        # Abstract must be at least 100 characters
+        long_abstract = "Background: This is a hypothetical abstract. Methods: We conducted a study with many participants. Results: The findings were significant and support our hypothesis. Conclusion: The counter-claim is valid."
+        response = f"""Here is the JSON:
+```json
+{{
+  "hyde_abstracts": [
+    "{long_abstract}"
+  ],
+  "keywords": ["term1", "term2"]
+}}
+```
+"""
+        result = generator._parse_response(response)
+        assert len(result["hyde_abstracts"]) == 1
+        assert len(result["keywords"]) == 2
+
+    def test_parse_response_limits_abstracts(self, mock_hyde_ollama_client):
+        """Test that abstracts are limited to num_abstracts."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=1, max_keywords=10)
+
+        response = json.dumps({
+            "hyde_abstracts": [
+                "First abstract with sufficient length to pass the minimum character validation check that requires 100 characters.",
+                "Second abstract with sufficient length but should be ignored because num_abstracts is set to 1.",
+                "Third abstract that should also be ignored because we only want one abstract maximum."
+            ],
+            "keywords": ["kw1", "kw2"]
+        })
+
+        result = generator._parse_response(response)
+        assert len(result["hyde_abstracts"]) == 1
+
+    def test_parse_response_limits_keywords(self, mock_hyde_ollama_client):
+        """Test that keywords are limited to max_keywords."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=2, max_keywords=3)
+
+        response = json.dumps({
+            "hyde_abstracts": [
+                "Abstract with sufficient length to pass the minimum character validation check that requires 100 characters."
+            ],
+            "keywords": ["kw1", "kw2", "kw3", "kw4", "kw5"]
+        })
+
+        result = generator._parse_response(response)
+        assert len(result["keywords"]) == 3
+
+    def test_parse_response_filters_short_abstracts(self, mock_hyde_ollama_client):
+        """Test that abstracts shorter than minimum are filtered."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=2, max_keywords=5)
+
+        response = json.dumps({
+            "hyde_abstracts": [
+                "Too short",  # Should be filtered
+                "This is a sufficiently long abstract that should pass the minimum length validation check of 100 characters or more."
+            ],
+            "keywords": ["kw1", "kw2"]
+        })
+
+        result = generator._parse_response(response)
+        assert len(result["hyde_abstracts"]) == 1
+
+    def test_parse_response_filters_empty_keywords(self, mock_hyde_ollama_client):
+        """Test that empty keywords are filtered."""
+        generator = HyDEGenerator(model="test-model", num_abstracts=2, max_keywords=5)
+
+        response = json.dumps({
+            "hyde_abstracts": [
+                "This is a sufficiently long abstract that should pass the minimum length validation check of 100 characters or more."
+            ],
+            "keywords": ["kw1", "", "  ", "kw2"]
+        })
+
+        result = generator._parse_response(response)
+        assert len(result["keywords"]) == 2
+
+    def test_parse_response_missing_hyde_abstracts_raises_error(self, mock_hyde_ollama_client):
+        """Test that missing hyde_abstracts key raises error."""
+        generator = HyDEGenerator(model="test-model")
+
+        response = json.dumps({"keywords": ["kw1"]})
+
+        with pytest.raises(ValueError, match="missing 'hyde_abstracts'"):
+            generator._parse_response(response)
+
+    def test_parse_response_missing_keywords_raises_error(self, mock_hyde_ollama_client):
+        """Test that missing keywords key raises error."""
+        generator = HyDEGenerator(model="test-model")
+
+        response = json.dumps({"hyde_abstracts": ["abstract"]})
+
+        with pytest.raises(ValueError, match="missing 'keywords'"):
+            generator._parse_response(response)
+
+    def test_parse_response_no_valid_abstracts_raises_error(self, mock_hyde_ollama_client):
+        """Test that having no valid abstracts raises error."""
+        generator = HyDEGenerator(model="test-model")
+
+        response = json.dumps({
+            "hyde_abstracts": ["short", "also short"],  # All too short
+            "keywords": ["kw1", "kw2"]
+        })
+
+        with pytest.raises(ValueError, match="No valid HyDE abstracts"):
+            generator._parse_response(response)
+
+    def test_parse_response_no_valid_keywords_raises_error(self, mock_hyde_ollama_client):
+        """Test that having no valid keywords raises error."""
+        generator = HyDEGenerator(model="test-model")
+
+        response = json.dumps({
+            "hyde_abstracts": [
+                "This is a sufficiently long abstract that should pass the minimum length validation check of 100 characters or more."
+            ],
+            "keywords": ["", "  "]  # All empty
+        })
+
+        with pytest.raises(ValueError, match="No valid keywords"):
+            generator._parse_response(response)
+
+    def test_parse_response_invalid_json_raises_error(self, mock_hyde_ollama_client):
+        """Test that invalid JSON raises error."""
+        generator = HyDEGenerator(model="test-model")
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            generator._parse_response("not valid json {")
+
+    def test_generate_success(self, mock_hyde_ollama_client, statement_comparative):
+        """Test successful HyDE generation."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": json.dumps({
+                    "hyde_abstracts": [
+                        "Background: Comparative studies of diabetes medications have yielded inconsistent results. We conducted a multi-center randomized trial comparing GLP-1 agonists to metformin in type 2 diabetes mellitus. Methods: Patients were randomized to receive either treatment for 24 months. Results: GLP-1 agonists showed superior HbA1c reduction. Conclusion: GLP-1 agonists are at least equivalent to metformin.",
+                        "Background: Meta-analysis of diabetes treatment outcomes is needed. Methods: Systematic review of RCTs comparing GLP-1 agonists and metformin. Results: Pooled analysis favors GLP-1 agonists for long-term outcomes. Conclusion: Evidence supports non-inferiority of GLP-1 agonists."
+                    ],
+                    "keywords": [
+                        "GLP-1 receptor agonists",
+                        "metformin comparison",
+                        "type 2 diabetes mellitus",
+                        "long-term outcomes",
+                        "cardiovascular outcomes"
+                    ]
+                })
+            }
+        }
+        mock_hyde_ollama_client.return_value = mock_client_instance
+
+        generator = HyDEGenerator(model="gpt-oss:20b")
+        result = generator.generate(
+            statement_comparative,
+            "GLP-1 agonists are superior or equivalent to metformin"
+        )
+
+        assert "hyde_abstracts" in result
+        assert "keywords" in result
+        assert len(result["hyde_abstracts"]) == 2
+        assert len(result["keywords"]) == 5
+        mock_client_instance.chat.assert_called_once()
+
+    def test_generate_handles_llm_error(self, mock_hyde_ollama_client, statement_comparative):
+        """Test that LLM errors are handled gracefully."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.side_effect = Exception("Connection failed")
+        mock_hyde_ollama_client.return_value = mock_client_instance
+
+        generator = HyDEGenerator(model="gpt-oss:20b")
+
+        with pytest.raises(RuntimeError, match="Failed to generate HyDE materials"):
+            generator.generate(statement_comparative, "Counter statement text")
+
+    def test_test_connection_success(self, mock_hyde_ollama_client):
+        """Test connection test when successful."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.list.return_value = {"models": []}
+        mock_hyde_ollama_client.return_value = mock_client_instance
+
+        generator = HyDEGenerator(model="test-model")
+        assert generator.test_connection() is True
+
+    def test_test_connection_failure(self, mock_hyde_ollama_client):
+        """Test connection test when failed."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.list.side_effect = Exception("Connection refused")
+        mock_hyde_ollama_client.return_value = mock_client_instance
+
+        generator = HyDEGenerator(model="test-model")
+        assert generator.test_connection() is False
+
+
+# =============================================================================
+# Integration-style Tests (with mocked LLM)
+# =============================================================================
+
+class TestCounterStatementWorkflow:
+    """Integration-style tests for the counter-statement generation workflow."""
+
+    def test_comparative_claim_generates_logical_negation(self, mock_ollama_client, statement_comparative):
+        """Test that comparative claims get logical negations."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": "GLP-1 agonists are superior or equivalent to metformin in long-term T2DM outcomes"
+            }
+        }
+        mock_ollama_client.return_value = mock_client_instance
+
+        generator = CounterStatementGenerator(model="gpt-oss:20b")
+        result = generator.generate(statement_comparative)
+
+        # Should be a logical negation, not just adding "not"
+        assert result != f"not {statement_comparative.text}"
+        assert len(result) > 10
+
+    def test_effect_claim_generates_logical_negation(self, mock_ollama_client, statement_effect):
+        """Test that effect claims get appropriate negations."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": "Exercise does not significantly reduce cardiovascular risk"
+            }
+        }
+        mock_ollama_client.return_value = mock_client_instance
+
+        generator = CounterStatementGenerator(model="gpt-oss:20b")
+        result = generator.generate(statement_effect)
+
+        assert len(result) > 10
+        assert "exercise" in result.lower()
+
+    def test_hyde_abstracts_are_realistic(self, mock_hyde_ollama_client, statement_comparative):
+        """Test that HyDE abstracts have realistic structure."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": json.dumps({
+                    "hyde_abstracts": [
+                        "Background: Prior studies show mixed results. Methods: We conducted a randomized controlled trial with 500 patients over 24 months. Results: GLP-1 agonists demonstrated non-inferior glycemic control with additional weight loss benefits. Conclusion: GLP-1 agonists are a viable alternative to metformin for first-line therapy.",
+                        "Background: Systematic review of diabetes treatment. Methods: Meta-analysis of 12 RCTs. Results: Pooled data shows equivalent HbA1c reduction with improved cardiovascular outcomes for GLP-1 agonists. Conclusion: Evidence supports GLP-1 agonists as first-line treatment."
+                    ],
+                    "keywords": ["GLP-1 agonists", "metformin", "type 2 diabetes"]
+                })
+            }
+        }
+        mock_hyde_ollama_client.return_value = mock_client_instance
+
+        generator = HyDEGenerator(model="gpt-oss:20b")
+        result = generator.generate(
+            statement_comparative,
+            "GLP-1 agonists are superior or equivalent to metformin"
+        )
+
+        # Abstracts should have structure
+        for abstract in result["hyde_abstracts"]:
+            assert len(abstract) > 100
+            # Should have some common abstract terms
+            abstract_lower = abstract.lower()
+            has_structure = any(term in abstract_lower for term in
+                ["background", "methods", "results", "conclusion", "study", "trial"])
+            assert has_structure
+
+    def test_keywords_are_relevant(self, mock_hyde_ollama_client, statement_effect):
+        """Test that generated keywords are relevant to the statement."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": json.dumps({
+                    "hyde_abstracts": [
+                        "Background: The relationship between physical activity and cardiovascular disease has been extensively studied. Methods: We performed a meta-analysis of cohort studies. Results: Exercise showed no significant reduction in cardiovascular events. Conclusion: The cardioprotective effect of exercise may be overestimated."
+                    ],
+                    "keywords": [
+                        "exercise cardiovascular",
+                        "physical activity heart disease",
+                        "cardiovascular risk reduction",
+                        "exercise ineffective",
+                        "heart disease prevention"
+                    ]
+                })
+            }
+        }
+        mock_hyde_ollama_client.return_value = mock_client_instance
+
+        generator = HyDEGenerator(model="gpt-oss:20b")
+        result = generator.generate(
+            statement_effect,
+            "Exercise does not significantly reduce cardiovascular risk"
+        )
+
+        keywords = result["keywords"]
+        assert len(keywords) > 0
+
+        # At least some keywords should be relevant
+        keywords_lower = [k.lower() for k in keywords]
+        has_exercise_term = any("exercise" in k or "physical" in k for k in keywords_lower)
+        has_cardiac_term = any("cardiovascular" in k or "cardiac" in k or "heart" in k for k in keywords_lower)
+        assert has_exercise_term or has_cardiac_term
+
+
+class TestEdgeCases:
+    """Edge case tests for counter-statement generation."""
+
+    def test_statement_with_unicode_characters(self, mock_ollama_client):
+        """Test handling of unicode characters in statement."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": "α-tocopherol does not improve outcomes in β-carotene studies"
+            }
+        }
+        mock_ollama_client.return_value = mock_client_instance
+
+        stmt = Statement(
+            text="α-tocopherol improves outcomes in β-carotene studies",
+            context="Greek letter test",
+            statement_type="finding",
+            confidence=0.9,
+            statement_order=1
+        )
+
+        generator = CounterStatementGenerator(model="test-model")
+        result = generator.generate(stmt)
+
+        assert len(result) > 10
+
+    def test_very_long_statement(self, mock_ollama_client):
+        """Test handling of very long statements."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": "This counter-statement negates the very long original claim"
+            }
+        }
+        mock_ollama_client.return_value = mock_client_instance
+
+        long_text = "This is a very long statement " * 50
+        stmt = Statement(
+            text=long_text,
+            context="Long text context",
+            statement_type="finding",
+            confidence=0.9,
+            statement_order=1
+        )
+
+        generator = CounterStatementGenerator(model="test-model")
+        result = generator.generate(stmt)
+
+        assert len(result) > 10
+
+    def test_statement_with_special_medical_terminology(self, mock_ollama_client):
+        """Test handling of complex medical terminology."""
+        mock_client_instance = MagicMock()
+        mock_client_instance.chat.return_value = {
+            "message": {
+                "content": "Anti-VEGF therapy does not improve outcomes in age-related macular degeneration"
+            }
+        }
+        mock_ollama_client.return_value = mock_client_instance
+
+        stmt = Statement(
+            text="Anti-VEGF therapy improves visual acuity in age-related macular degeneration",
+            context="Ophthalmology study context",
+            statement_type="finding",
+            confidence=0.92,
+            statement_order=1
+        )
+
+        generator = CounterStatementGenerator(model="test-model")
+        result = generator.generate(stmt)
+
+        assert len(result) > 10
+        assert "VEGF" in result or "vegf" in result.lower()
+
+    def test_extract_json_handles_malformed_code_blocks(self, mock_hyde_ollama_client):
+        """Test JSON extraction with malformed code blocks."""
+        generator = HyDEGenerator(model="test-model")
+
+        # Test with unclosed code block
+        response = '```json\n{"hyde_abstracts": ["' + 'A' * 100 + '"], "keywords": ["kw"]}'
+        result = generator._extract_json(response)
+        assert "hyde_abstracts" in result
+
+    def test_extract_json_finds_json_without_code_block(self, mock_hyde_ollama_client):
+        """Test JSON extraction when no code block is present."""
+        generator = HyDEGenerator(model="test-model")
+
+        response = 'Here is the response: {"hyde_abstracts": ["' + 'A' * 100 + '"], "keywords": ["kw"]}'
+        result = generator._extract_json(response)
+
+        # Should find and extract the JSON object
+        data = json.loads(result)
+        assert "hyde_abstracts" in data


### PR DESCRIPTION
## Summary

Implements Step 5 of the PaperChecker workflow: Counter-Statement Generation.

This PR adds two key components for generating counter-statements and search materials:

- **CounterStatementGenerator**: Creates semantically precise negations of research claims (not just grammatical "not" additions)
- **HyDEGenerator**: Generates Hypothetical Document Embeddings - hypothetical abstracts that would support the counter-claim, plus targeted keywords for literature search

## Changes

### New Components (`src/bmlibrarian/paperchecker/components/`)

| File | Description |
|------|-------------|
| `counter_statement_generator.py` | LLM-based logical negation generator |
| `hyde_generator.py` | HyDE abstracts + keyword generation |
| `search_coordinator.py` | Stub for Step 7 (multi-strategy search) |
| `verdict_analyzer.py` | Stub for Step 11 (verdict analysis) |

### Modified Files

- `agent.py`: Implemented `_extract_statements()` and `_generate_counter_statements()` methods
- `components/__init__.py`: Export all components
- `__init__.py`: Enable package-level imports

### New Tests

- `tests/test_counter_statement_generator.py`: 43 comprehensive unit tests

## Implementation Details

- Uses **ollama library** (not requests) for LLM communication
- All numeric values use **named constants** (no magic numbers)
- Full **docstrings and type hints** on all classes/methods
- **Retry logic** with exponential backoff for transient failures
- **JSON parsing** with code block extraction for robust LLM output handling
- Validates abstract length (min 100 chars) and keyword content

## Test Plan

- [x] All 43 new counter-statement generator tests pass
- [x] All 63 existing paperchecker tests pass
- [x] All 141 total paperchecker-related tests pass
- [x] No magic numbers - verified constants at top of files
- [x] Using ollama library, not requests
- [x] Type hints and docstrings on all public methods