### PR TITLE
Refactor paper weight agent into smaller modules

### DIFF
--- a/src/bmlibrarian/agents/paper_weight_agent.py
+++ b/src/bmlibrarian/agents/paper_weight_agent.py
@@ -56,7 +56,6 @@ from .paper_weight_llm_assessors import (
 
 # Import database operations
 from .paper_weight_db import (
-    get_default_db_connection,
     get_cached_assessment,
     store_assessment,
     get_document,

--- a/src/bmlibrarian/agents/paper_weight_agent.py
+++ b/src/bmlibrarian/agents/paper_weight_agent.py
@@ -1,385 +1,143 @@
 """
-Paper Weight Assessment Agent - Multi-dimensional paper quality assessment
+Paper Weight Assessment Agent
 
-This module provides an AI-powered agent for assessing the evidential weight of
-biomedical research papers across five dimensions: study design, sample size,
-methodological quality, risk of bias, and replication status.
+Multi-dimensional paper quality assessment agent that coordinates:
+- Rule-based extractors for study type and sample size
+- LLM-based assessors for methodological quality and risk of bias
+- Database persistence with caching
 
-The module currently contains the data models (dataclasses) for representing
-assessments. The agent implementation will be added in later steps.
+This module provides the main PaperWeightAssessmentAgent class that orchestrates
+all assessment components. The actual implementations are in separate modules:
+- paper_weight_models.py: Data models (dataclasses)
+- paper_weight_extractors.py: Rule-based extraction functions
+- paper_weight_llm_assessors.py: LLM-based assessment functions
+- paper_weight_db.py: Database operations
 """
 
-from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Callable, Any, TYPE_CHECKING
-from datetime import datetime
-import json
-
-if TYPE_CHECKING:
-    from .orchestrator import AgentOrchestrator
-
-# Constants for formatting and display
-DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'  # Standard datetime format for reports
-
-
-@dataclass
-class AssessmentDetail:
-    """
-    Audit trail entry for a single assessment component.
-
-    Provides full reproducibility by storing:
-    - What was extracted from the paper
-    - How it contributed to the dimension score
-    - Evidence text supporting the assessment
-    - LLM reasoning (for AI-based assessments)
-
-    Attributes:
-        dimension: Name of the dimension (e.g., "study_design", "sample_size")
-        component: Specific component assessed (e.g., "randomization", "blinding_type")
-        extracted_value: Value found in the paper (e.g., "double-blind", "450")
-        score_contribution: Points contributed to dimension score (0-10)
-        evidence_text: Relevant excerpt from paper (optional)
-        reasoning: AI reasoning for this score (optional)
-
-    Example:
-        >>> detail = AssessmentDetail(
-        ...     dimension="methodological_quality",
-        ...     component="blinding_type",
-        ...     extracted_value="double-blind",
-        ...     score_contribution=3.0,
-        ...     evidence_text="Participants and investigators were masked...",
-        ...     reasoning="Double-blind design detected, contributing full 3.0 points"
-        ... )
-    """
-    dimension: str
-    component: str
-    extracted_value: Optional[str]
-    score_contribution: float
-    evidence_text: Optional[str] = None
-    reasoning: Optional[str] = None
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary for database storage."""
-        return {
-            'dimension': self.dimension,
-            'component': self.component,
-            'extracted_value': self.extracted_value,
-            'score_contribution': self.score_contribution,
-            'evidence_text': self.evidence_text,
-            'reasoning': self.reasoning
-        }
-
-
-@dataclass
-class DimensionScore:
-    """
-    Score for a single assessment dimension with full audit trail.
-
-    Each dimension (study design, sample size, etc.) has a final score
-    and a list of components that contributed to that score.
-
-    Attributes:
-        dimension_name: Name of this dimension
-        score: Final score for this dimension (0-10)
-        details: List of component assessments that contributed to the score
-
-    Example:
-        >>> sample_size_score = DimensionScore(dimension_name="sample_size", score=7.1)
-        >>> sample_size_score.add_detail(
-        ...     component="extracted_n",
-        ...     value="450",
-        ...     contribution=5.3,
-        ...     reasoning="Log10(450) * 2 = 5.3"
-        ... )
-        >>> sample_size_score.add_detail(
-        ...     component="power_calculation",
-        ...     value="yes",
-        ...     contribution=2.0,
-        ...     evidence="Sample size was calculated to provide 80% power...",
-        ...     reasoning="Power calculation mentioned, bonus +2.0"
-        ... )
-    """
-    dimension_name: str
-    score: float
-    details: List[AssessmentDetail] = field(default_factory=list)
-
-    def add_detail(self, component: str, value: str, contribution: float,
-                   evidence: Optional[str] = None, reasoning: Optional[str] = None) -> None:
-        """
-        Add an audit trail entry for a component of this dimension.
-
-        Args:
-            component: Name of the component (e.g., "randomization")
-            value: Extracted value (e.g., "proper sequence generation")
-            contribution: Points contributed to dimension score
-            evidence: Supporting text from paper (optional)
-            reasoning: AI reasoning for this score (optional)
-        """
-        self.details.append(AssessmentDetail(
-            dimension=self.dimension_name,
-            component=component,
-            extracted_value=value,
-            score_contribution=contribution,
-            evidence_text=evidence,
-            reasoning=reasoning
-        ))
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary for serialization."""
-        return {
-            'dimension_name': self.dimension_name,
-            'score': self.score,
-            'details': [d.to_dict() for d in self.details]
-        }
-
-
-@dataclass
-class PaperWeightResult:
-    """
-    Complete paper weight assessment with full audit trail.
-
-    This is the top-level result object containing all dimension scores,
-    the final weighted score, and complete reproducibility information.
-
-    Attributes:
-        document_id: Database ID of assessed document
-        assessor_version: Version of assessment methodology
-        assessed_at: Timestamp of assessment
-        study_design: Study design dimension score
-        sample_size: Sample size dimension score
-        methodological_quality: Methodological quality dimension score
-        risk_of_bias: Risk of bias dimension score (inverted: 10=low risk)
-        replication_status: Replication status dimension score
-        final_weight: Weighted combination of all dimensions (0-10)
-        dimension_weights: Weights used to compute final_weight
-        study_type: Extracted study type (e.g., "RCT", "cohort")
-        sample_size_n: Extracted sample size (number of participants)
-
-    Example:
-        >>> result = PaperWeightResult(
-        ...     document_id=12345,
-        ...     assessor_version="1.0.0",
-        ...     assessed_at=datetime.now(),
-        ...     study_design=DimensionScore("study_design", 8.0),
-        ...     sample_size=DimensionScore("sample_size", 7.5),
-        ...     methodological_quality=DimensionScore("methodological_quality", 6.5),
-        ...     risk_of_bias=DimensionScore("risk_of_bias", 7.0),
-        ...     replication_status=DimensionScore("replication_status", 5.0),
-        ...     final_weight=7.2,
-        ...     dimension_weights={
-        ...         "study_design": 0.25,
-        ...         "sample_size": 0.15,
-        ...         "methodological_quality": 0.30,
-        ...         "risk_of_bias": 0.20,
-        ...         "replication_status": 0.10
-        ...     },
-        ...     study_type="RCT",
-        ...     sample_size_n=450
-        ... )
-    """
-    document_id: int
-    assessor_version: str
-    assessed_at: datetime
-
-    # Dimension scores
-    study_design: DimensionScore
-    sample_size: DimensionScore
-    methodological_quality: DimensionScore
-    risk_of_bias: DimensionScore
-    replication_status: DimensionScore
-
-    # Final weight
-    final_weight: float
-    dimension_weights: Dict[str, float]
-
-    # Metadata
-    study_type: Optional[str] = None
-    sample_size_n: Optional[int] = None
-
-    def to_dict(self) -> dict:
-        """
-        Convert to flat dictionary for database storage.
-
-        Returns flattened structure matching paper_weights.assessments table schema.
-        """
-        return {
-            'document_id': self.document_id,
-            'assessor_version': self.assessor_version,
-            'assessed_at': self.assessed_at,
-            'study_design_score': self.study_design.score,
-            'sample_size_score': self.sample_size.score,
-            'methodological_quality_score': self.methodological_quality.score,
-            'risk_of_bias_score': self.risk_of_bias.score,
-            'replication_status_score': self.replication_status.score,
-            'final_weight': self.final_weight,
-            'dimension_weights': json.dumps(self.dimension_weights),
-            'study_type': self.study_type,
-            'sample_size': self.sample_size_n
-        }
-
-    def get_all_details(self) -> List[AssessmentDetail]:
-        """
-        Collect all audit trail entries from all dimensions.
-
-        Returns:
-            Flat list of all AssessmentDetail objects across all dimensions
-        """
-        all_details = []
-        for dimension_score in [
-            self.study_design,
-            self.sample_size,
-            self.methodological_quality,
-            self.risk_of_bias,
-            self.replication_status
-        ]:
-            all_details.extend(dimension_score.details)
-        return all_details
-
-    def to_markdown(self) -> str:
-        """
-        Format assessment as human-readable Markdown report.
-
-        Returns:
-            Markdown-formatted assessment report with all dimensions and audit trail
-        """
-        lines = [
-            f"# Paper Weight Assessment Report",
-            f"",
-            f"**Document ID:** {self.document_id}",
-            f"**Study Type:** {self.study_type or 'Unknown'}",
-            f"**Sample Size:** {self.sample_size_n or 'Not extracted'}",
-            f"**Assessed:** {self.assessed_at.strftime(DATETIME_FORMAT)}",
-            f"**Assessor Version:** {self.assessor_version}",
-            f"",
-            f"## Final Weight: {self.final_weight:.2f}/10",
-            f"",
-            f"## Dimension Scores",
-            f"",
-        ]
-
-        # Add each dimension with details
-        for dim_name, dim_score in [
-            ("Study Design", self.study_design),
-            ("Sample Size", self.sample_size),
-            ("Methodological Quality", self.methodological_quality),
-            ("Risk of Bias", self.risk_of_bias),
-            ("Replication Status", self.replication_status)
-        ]:
-            lines.append(f"### {dim_name}: {dim_score.score:.2f}/10")
-            lines.append("")
-
-            if dim_score.details:
-                for detail in dim_score.details:
-                    lines.append(f"- **{detail.component}:** {detail.extracted_value}")
-                    lines.append(f"  - Score contribution: {detail.score_contribution:.2f}")
-                    if detail.reasoning:
-                        lines.append(f"  - Reasoning: {detail.reasoning}")
-                    if detail.evidence_text:
-                        # Preserve full evidence text for audit trail integrity
-                        lines.append(f"  - Evidence: *\"{detail.evidence_text}\"*")
-                    lines.append("")
-            else:
-                lines.append("*No detailed breakdown available*")
-                lines.append("")
-
-        # Add dimension weights
-        lines.append("## Dimension Weights Used")
-        lines.append("")
-        for dim, weight in self.dimension_weights.items():
-            lines.append(f"- **{dim}:** {weight:.2f}")
-        lines.append("")
-
-        return "\n".join(lines)
-
-    @classmethod
-    def from_db_row(cls, row: dict, details: List[dict]) -> 'PaperWeightResult':
-        """
-        Reconstruct PaperWeightResult from database rows.
-
-        Args:
-            row: Row from paper_weights.assessments table
-            details: Rows from paper_weights.assessment_details table
-
-        Returns:
-            Reconstructed PaperWeightResult object
-        """
-        # Parse dimension weights from JSONB
-        dimension_weights = row['dimension_weights']
-        if isinstance(dimension_weights, str):
-            dimension_weights = json.loads(dimension_weights)
-
-        # Group details by dimension
-        dimension_details: Dict[str, List[AssessmentDetail]] = {
-            'study_design': [],
-            'sample_size': [],
-            'methodological_quality': [],
-            'risk_of_bias': [],
-            'replication_status': []
-        }
-
-        for detail in details:
-            dim = detail['dimension']
-            if dim in dimension_details:
-                dimension_details[dim].append(AssessmentDetail(
-                    dimension=detail['dimension'],
-                    component=detail['component'],
-                    extracted_value=detail['extracted_value'],
-                    score_contribution=float(detail['score_contribution']) if detail['score_contribution'] else 0.0,
-                    evidence_text=detail['evidence_text'],
-                    reasoning=detail['reasoning']
-                ))
-
-        # Create dimension scores
-        study_design = DimensionScore(
-            dimension_name='study_design',
-            score=float(row['study_design_score']),
-            details=dimension_details['study_design']
-        )
-        sample_size = DimensionScore(
-            dimension_name='sample_size',
-            score=float(row['sample_size_score']),
-            details=dimension_details['sample_size']
-        )
-        methodological_quality = DimensionScore(
-            dimension_name='methodological_quality',
-            score=float(row['methodological_quality_score']),
-            details=dimension_details['methodological_quality']
-        )
-        risk_of_bias = DimensionScore(
-            dimension_name='risk_of_bias',
-            score=float(row['risk_of_bias_score']),
-            details=dimension_details['risk_of_bias']
-        )
-        replication_status = DimensionScore(
-            dimension_name='replication_status',
-            score=float(row['replication_status_score']),
-            details=dimension_details['replication_status']
-        )
-
-        return cls(
-            document_id=row['document_id'],
-            assessor_version=row['assessor_version'],
-            assessed_at=row['assessed_at'],
-            study_design=study_design,
-            sample_size=sample_size,
-            methodological_quality=methodological_quality,
-            risk_of_bias=risk_of_bias,
-            replication_status=replication_status,
-            final_weight=float(row['final_weight']),
-            dimension_weights=dimension_weights,
-            study_type=row.get('study_type'),
-            sample_size_n=row.get('sample_size')
-        )
-
-
-# Additional imports for agent implementation
-import re
-import math
 import logging
+from datetime import datetime
+from typing import Optional, Callable, Dict, TYPE_CHECKING
 
 from .base import BaseAgent
 from ..config import get_model, get_agent_config, get_ollama_host
 
+# Import data models
+from .paper_weight_models import (
+    AssessmentDetail,
+    DimensionScore,
+    PaperWeightResult,
+    DIMENSION_STUDY_DESIGN,
+    DIMENSION_SAMPLE_SIZE,
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
+    DIMENSION_REPLICATION_STATUS,
+)
+
+# Import extractors
+from .paper_weight_extractors import (
+    STUDY_TYPE_PRIORITY,
+    extract_study_type,
+    extract_sample_size_dimension,
+    get_extracted_sample_size,
+    get_extracted_study_type,
+)
+
+# Import LLM assessors
+from .paper_weight_llm_assessors import (
+    prepare_text_for_analysis,
+    build_methodological_quality_prompt,
+    calculate_methodological_quality_score,
+    build_risk_of_bias_prompt,
+    calculate_risk_of_bias_score,
+    extract_mq_from_study_assessment,
+    extract_rob_from_study_assessment,
+    create_error_dimension_score,
+)
+
+# Import database operations
+from .paper_weight_db import (
+    get_default_db_connection,
+    get_cached_assessment,
+    store_assessment,
+    get_document,
+    check_replication_status,
+)
+
+if TYPE_CHECKING:
+    from .orchestrator import AgentOrchestrator
+
+
 logger = logging.getLogger(__name__)
+
+
+# Default configuration values
+DEFAULT_CONFIG = {
+    'temperature': 0.3,
+    'top_p': 0.9,
+    'max_tokens': 3000,
+    'version': '1.0.0',
+    'dimension_weights': {
+        'study_design': 0.25,
+        'sample_size': 0.15,
+        'methodological_quality': 0.30,
+        'risk_of_bias': 0.20,
+        'replication_status': 0.10
+    },
+    'study_type_hierarchy': {
+        'systematic_review': 10.0,
+        'meta_analysis': 10.0,
+        'rct': 8.0,
+        'cohort_prospective': 6.0,
+        'cohort_retrospective': 5.0,
+        'case_control': 4.0,
+        'cross_sectional': 3.0,
+        'case_series': 2.0,
+        'case_report': 1.0
+    },
+    'study_type_keywords': {
+        'systematic_review': ['systematic review', 'systematic literature review'],
+        'meta_analysis': ['meta-analysis', 'meta analysis', 'pooled analysis'],
+        'rct': [
+            'randomized controlled trial', 'randomised controlled trial', 'RCT',
+            'randomized trial', 'randomised trial', 'random allocation', 'randomly assigned'
+        ],
+        'cohort_prospective': ['prospective cohort', 'prospective study', 'longitudinal cohort'],
+        'cohort_retrospective': ['retrospective cohort', 'retrospective study'],
+        'case_control': ['case-control', 'case control study'],
+        'cross_sectional': ['cross-sectional', 'cross sectional study', 'prevalence study'],
+        'case_series': ['case series', 'case-series'],
+        'case_report': ['case report', 'case study']
+    },
+    'sample_size_scoring': {
+        'log_base': 10,
+        'log_multiplier': 2.0,
+        'power_calculation_bonus': 2.0,
+        'ci_reported_bonus': 0.5
+    }
+}
+
+
+def merge_config_with_defaults(config: dict, defaults: dict) -> dict:
+    """
+    Deep merge config with defaults (config takes precedence).
+
+    Args:
+        config: User configuration
+        defaults: Default configuration
+
+    Returns:
+        Merged configuration
+    """
+    result = config.copy()
+    for key, value in defaults.items():
+        if key not in result:
+            result[key] = value
+        elif isinstance(value, dict) and isinstance(result[key], dict):
+            # Deep merge for nested dicts
+            for subkey, subvalue in value.items():
+                if subkey not in result[key]:
+                    result[key][subkey] = subvalue
+    return result
 
 
 class PaperWeightAssessmentAgent(BaseAgent):
@@ -389,29 +147,16 @@ class PaperWeightAssessmentAgent(BaseAgent):
     Assesses the evidential weight of biomedical research papers across five dimensions:
     - Study design (rule-based keyword matching)
     - Sample size (rule-based regex extraction + scoring)
-    - Methodological quality (LLM-based assessment - Step 5)
-    - Risk of bias (LLM-based assessment - Step 5)
-    - Replication status (database lookup - Step 6)
+    - Methodological quality (LLM-based assessment)
+    - Risk of bias (LLM-based assessment)
+    - Replication status (database lookup)
 
-    This class implements rule-based extractors (Step 4), LLM-based assessors (Step 5),
-    and database persistence with caching (Step 6).
+    The agent coordinates rule-based extractors, LLM-based assessors, and database
+    operations to produce comprehensive paper weight assessments with full audit trails.
     """
 
-    # Priority order for study type detection (highest evidence level first)
-    STUDY_TYPE_PRIORITY = [
-        'systematic_review',
-        'meta_analysis',
-        'rct',
-        'cohort_prospective',
-        'cohort_retrospective',
-        'case_control',
-        'cross_sectional',
-        'case_series',
-        'case_report'
-    ]
-
-    # Constants for LLM assessors
-    MAX_TEXT_LENGTH = 8000  # Maximum characters to send to LLM (avoids token limits)
+    # Constants
+    MAX_TEXT_LENGTH = 8000  # Maximum characters to send to LLM
 
     def __init__(
         self,
@@ -441,11 +186,10 @@ class PaperWeightAssessmentAgent(BaseAgent):
             host = get_ollama_host()
 
         # Get agent-specific parameters
-        agent_config = self.config
-        temperature = agent_config.get('temperature', 0.3)
-        top_p = agent_config.get('top_p', 0.9)
-        self.max_tokens = agent_config.get('max_tokens', 3000)
-        self.version = agent_config.get('version', '1.0.0')
+        temperature = self.config.get('temperature', 0.3)
+        top_p = self.config.get('top_p', 0.9)
+        self.max_tokens = self.config.get('max_tokens', 3000)
+        self.version = self.config.get('version', '1.0.0')
 
         super().__init__(
             model=model,
@@ -465,375 +209,11 @@ class PaperWeightAssessmentAgent(BaseAgent):
             Configuration dictionary with all paper weight settings
         """
         config = get_agent_config('paper_weight_assessment')
-
-        # Ensure all required keys are present with defaults
-        defaults = {
-            'temperature': 0.3,
-            'top_p': 0.9,
-            'max_tokens': 3000,
-            'version': '1.0.0',
-            'dimension_weights': {
-                'study_design': 0.25,
-                'sample_size': 0.15,
-                'methodological_quality': 0.30,
-                'risk_of_bias': 0.20,
-                'replication_status': 0.10
-            },
-            'study_type_hierarchy': {
-                'systematic_review': 10.0,
-                'meta_analysis': 10.0,
-                'rct': 8.0,
-                'cohort_prospective': 6.0,
-                'cohort_retrospective': 5.0,
-                'case_control': 4.0,
-                'cross_sectional': 3.0,
-                'case_series': 2.0,
-                'case_report': 1.0
-            },
-            'study_type_keywords': {
-                'systematic_review': ['systematic review', 'systematic literature review'],
-                'meta_analysis': ['meta-analysis', 'meta analysis', 'pooled analysis'],
-                'rct': ['randomized controlled trial', 'randomised controlled trial', 'RCT',
-                       'randomized trial', 'randomised trial', 'random allocation', 'randomly assigned'],
-                'cohort_prospective': ['prospective cohort', 'prospective study', 'longitudinal cohort'],
-                'cohort_retrospective': ['retrospective cohort', 'retrospective study'],
-                'case_control': ['case-control', 'case control study'],
-                'cross_sectional': ['cross-sectional', 'cross sectional study', 'prevalence study'],
-                'case_series': ['case series', 'case-series'],
-                'case_report': ['case report', 'case study']
-            },
-            'sample_size_scoring': {
-                'log_base': 10,
-                'log_multiplier': 2.0,
-                'power_calculation_bonus': 2.0,
-                'ci_reported_bonus': 0.5
-            }
-        }
-
-        # Merge defaults with loaded config (loaded config takes precedence)
-        for key, value in defaults.items():
-            if key not in config:
-                config[key] = value
-            elif isinstance(value, dict) and isinstance(config[key], dict):
-                # Deep merge for nested dicts
-                for subkey, subvalue in value.items():
-                    if subkey not in config[key]:
-                        config[key][subkey] = subvalue
-
-        return config
+        return merge_config_with_defaults(config, DEFAULT_CONFIG)
 
     def get_agent_type(self) -> str:
         """Get the agent type identifier."""
         return "PaperWeightAssessmentAgent"
-
-    # ========================================================================
-    # Rule-Based Extractors (Step 4)
-    # ========================================================================
-
-    def _extract_study_type(self, document: dict) -> DimensionScore:
-        """
-        Extract study type using keyword matching.
-
-        Matches keywords from config against abstract and methods section.
-        Uses priority hierarchy: systematic review > RCT > cohort > etc.
-
-        Args:
-            document: Document dict with 'abstract' and optional 'methods_text' fields
-
-        Returns:
-            DimensionScore for study design with audit trail
-        """
-        # Get text to search
-        abstract = document.get('abstract', '') or ''
-        methods = document.get('methods_text', '') or ''
-        search_text = f"{abstract} {methods}".lower()
-
-        # Get config
-        keywords_config = self.config.get('study_type_keywords', {})
-        hierarchy_config = self.config.get('study_type_hierarchy', {})
-
-        # Try each study type in priority order
-        for study_type in self.STUDY_TYPE_PRIORITY:
-            keywords = keywords_config.get(study_type, [])
-            for keyword in keywords:
-                if keyword.lower() in search_text:
-                    # Found match - get score from hierarchy
-                    score = hierarchy_config.get(study_type, 5.0)
-
-                    # Create dimension score with audit trail
-                    dimension_score = DimensionScore(
-                        dimension_name='study_design',
-                        score=score
-                    )
-
-                    # Find evidence context (50 chars before/after keyword)
-                    evidence_text = self._extract_context(search_text, keyword.lower())
-
-                    dimension_score.add_detail(
-                        component='study_type',
-                        value=study_type,
-                        contribution=score,
-                        evidence=evidence_text,
-                        reasoning=f"Matched keyword '{keyword}' indicating {study_type.replace('_', ' ')}"
-                    )
-
-                    return dimension_score
-
-        # No match found - default to unknown
-        dimension_score = DimensionScore(
-            dimension_name='study_design',
-            score=5.0  # Neutral score
-        )
-        dimension_score.add_detail(
-            component='study_type',
-            value='unknown',
-            contribution=5.0,
-            reasoning='No study type keywords matched - assigned neutral score'
-        )
-
-        return dimension_score
-
-    def _extract_context(self, text: str, keyword: str, context_chars: int = 50) -> str:
-        """
-        Extract text context around a keyword.
-
-        Args:
-            text: Full text to search
-            keyword: Keyword to find
-            context_chars: Characters to include before/after keyword
-
-        Returns:
-            Text snippet with context around keyword
-        """
-        keyword_pos = text.find(keyword)
-        if keyword_pos == -1:
-            return ""
-
-        start = max(0, keyword_pos - context_chars)
-        end = min(len(text), keyword_pos + len(keyword) + context_chars)
-
-        context = text[start:end]
-
-        # Add ellipsis if truncated
-        if start > 0:
-            context = "..." + context
-        if end < len(text):
-            context = context + "..."
-
-        return context
-
-    def _extract_sample_size(self, document: dict) -> DimensionScore:
-        """
-        Extract sample size and calculate score.
-
-        Uses regex patterns to find sample size mentions, applies logarithmic
-        scoring, and adds bonuses for power calculation and CI reporting.
-
-        Args:
-            document: Document dict with 'abstract' and optional 'methods_text' fields
-
-        Returns:
-            DimensionScore for sample size with audit trail
-        """
-        # Get text to search
-        abstract = document.get('abstract', '') or ''
-        methods = document.get('methods_text', '') or ''
-        search_text = f"{abstract} {methods}"
-
-        # Extract sample size
-        sample_size = self._find_sample_size(search_text)
-
-        if sample_size is None:
-            # No sample size found
-            dimension_score = DimensionScore(
-                dimension_name='sample_size',
-                score=0.0
-            )
-            dimension_score.add_detail(
-                component='extracted_n',
-                value='not_found',
-                contribution=0.0,
-                reasoning='No sample size could be extracted from text'
-            )
-            return dimension_score
-
-        # Calculate base score using logarithmic scaling
-        base_score = self._calculate_sample_size_score(sample_size)
-
-        # Create dimension score
-        dimension_score = DimensionScore(
-            dimension_name='sample_size',
-            score=base_score
-        )
-
-        # Get scoring config
-        scoring_config = self.config.get('sample_size_scoring', {})
-        log_multiplier = scoring_config.get('log_multiplier', 2.0)
-
-        # Add base score detail
-        dimension_score.add_detail(
-            component='extracted_n',
-            value=str(sample_size),
-            contribution=base_score,
-            reasoning=f"Log10({sample_size}) * {log_multiplier} = {base_score:.2f}"
-        )
-
-        # Check for power calculation
-        if self._has_power_calculation(search_text):
-            power_bonus = scoring_config.get('power_calculation_bonus', 2.0)
-            new_score = min(10.0, dimension_score.score + power_bonus)
-            dimension_score.score = new_score
-            dimension_score.add_detail(
-                component='power_calculation',
-                value='yes',
-                contribution=power_bonus,
-                evidence=self._find_power_calc_context(search_text),
-                reasoning=f'Power calculation mentioned, bonus +{power_bonus}'
-            )
-
-        # Check for confidence interval reporting
-        if self._has_ci_reporting(search_text):
-            ci_bonus = scoring_config.get('ci_reported_bonus', 0.5)
-            new_score = min(10.0, dimension_score.score + ci_bonus)
-            dimension_score.score = new_score
-            dimension_score.add_detail(
-                component='ci_reporting',
-                value='yes',
-                contribution=ci_bonus,
-                reasoning=f'Confidence intervals reported, bonus +{ci_bonus}'
-            )
-
-        return dimension_score
-
-    def _find_sample_size(self, text: str) -> Optional[int]:
-        """
-        Find sample size in text using regex patterns.
-
-        Returns largest number found (usually total sample size).
-
-        Args:
-            text: Text to search
-
-        Returns:
-            Sample size (int) or None if not found
-        """
-        patterns = [
-            r'n\s*=\s*(\d+)',  # n = 450
-            r'N\s*=\s*(\d+)',  # N = 450
-            r'(\d+)\s+participants',  # 450 participants
-            r'(\d+)\s+subjects',  # 450 subjects
-            r'(\d+)\s+patients',  # 450 patients
-            r'sample\s+size\s+of\s+(\d+)',  # sample size of 450
-            r'total\s+of\s+(\d+)\s+(?:participants|subjects|patients)',  # total of 450 participants
-            r'enrolled\s+(\d+)\s+(?:participants|subjects|patients)',  # enrolled 450 participants
-            r'recruited\s+(\d+)\s+(?:participants|subjects|patients)',  # recruited 450 participants
-        ]
-
-        found_sizes = []
-
-        for pattern in patterns:
-            matches = re.finditer(pattern, text, re.IGNORECASE)
-            for match in matches:
-                size = int(match.group(1))
-                # Filter out unrealistic values (too small or too large)
-                if 5 <= size <= 1000000:  # Reasonable range
-                    found_sizes.append(size)
-
-        if not found_sizes:
-            return None
-
-        # Return largest (usually total sample size)
-        return max(found_sizes)
-
-    def _calculate_sample_size_score(self, n: int) -> float:
-        """
-        Calculate sample size score using logarithmic scaling.
-
-        Formula: min(10, log10(n) * log_multiplier)
-
-        Args:
-            n: Sample size
-
-        Returns:
-            Score (0-10)
-        """
-        scoring_config = self.config.get('sample_size_scoring', {})
-        log_multiplier = scoring_config.get('log_multiplier', 2.0)
-
-        if n <= 0:
-            return 0.0
-
-        score = math.log10(n) * log_multiplier
-        return min(10.0, max(0.0, score))
-
-    def _has_power_calculation(self, text: str) -> bool:
-        """
-        Check if text mentions power calculation.
-
-        Args:
-            text: Text to search
-
-        Returns:
-            True if power calculation mentioned
-        """
-        keywords = [
-            'power calculation',
-            'power analysis',
-            'sample size calculation',
-            'calculated sample size',
-            'statistical power',
-            'power to detect'
-        ]
-
-        text_lower = text.lower()
-        return any(keyword in text_lower for keyword in keywords)
-
-    def _find_power_calc_context(self, text: str) -> str:
-        """
-        Find context around power calculation mention.
-
-        Args:
-            text: Text to search
-
-        Returns:
-            Context string around power calculation mention
-        """
-        keywords = [
-            'power calculation',
-            'power analysis',
-            'sample size calculation'
-        ]
-
-        text_lower = text.lower()
-        for keyword in keywords:
-            if keyword in text_lower:
-                return self._extract_context(text_lower, keyword)
-
-        return ""
-
-    def _has_ci_reporting(self, text: str) -> bool:
-        """
-        Check if text reports confidence intervals.
-
-        Args:
-            text: Text to search
-
-        Returns:
-            True if confidence intervals are reported
-        """
-        patterns = [
-            r'confidence interval',
-            r'\bCI\b',
-            r'95%\s*CI',
-            r'\[\s*\d+\.?\d*\s*,\s*\d+\.?\d*\s*\]',  # [1.2, 3.4]
-            r'\(\s*\d+\.?\d*\s*-\s*\d+\.?\d*\s*\)',  # (1.2-3.4)
-        ]
-
-        for pattern in patterns:
-            if re.search(pattern, text, re.IGNORECASE):
-                return True
-
-        return False
 
     def get_dimension_weights(self) -> Dict[str, float]:
         """
@@ -842,197 +222,15 @@ class PaperWeightAssessmentAgent(BaseAgent):
         Returns:
             Dictionary mapping dimension names to their weights
         """
-        return self.config.get('dimension_weights', {
-            'study_design': 0.25,
-            'sample_size': 0.15,
-            'methodological_quality': 0.30,
-            'risk_of_bias': 0.20,
-            'replication_status': 0.10
-        })
-
-    # ========================================================================
-    # LLM-Based Assessors (Step 5)
-    # ========================================================================
-
-    def _prepare_text_for_analysis(self, document: Dict[str, Any]) -> str:
-        """
-        Prepare document text for LLM analysis.
-
-        Combines title, abstract and full text (if available), limits length
-        to avoid token limits.
-
-        Args:
-            document: Document dict with 'title', 'abstract', 'full_text' fields
-
-        Returns:
-            Prepared text string suitable for LLM prompt
-        """
-        title = document.get('title', '') or ''
-        abstract = document.get('abstract', '') or ''
-        full_text = document.get('full_text', '') or ''
-
-        # Prefer full text if available, otherwise use abstract
-        if full_text:
-            text = f"TITLE: {title}\n\nFULL TEXT:\n{full_text}"
-        else:
-            text = f"TITLE: {title}\n\nABSTRACT:\n{abstract}"
-
-        # Limit to MAX_TEXT_LENGTH characters to avoid token limits
-        if len(text) > self.MAX_TEXT_LENGTH:
-            text = text[:self.MAX_TEXT_LENGTH] + "\n\n[Text truncated...]"
-            logger.debug(f"Truncated text to {self.MAX_TEXT_LENGTH} characters")
-
-        return text
-
-    def _build_methodological_quality_prompt(self, text: str) -> str:
-        """
-        Build prompt for methodological quality assessment.
-
-        Args:
-            text: Prepared document text
-
-        Returns:
-            Prompt string for LLM
-        """
-        return f"""You are an expert in biomedical research methodology. Analyze the following research paper and assess its methodological quality across six components.
-
-PAPER TEXT:
-{text}
-
-TASK:
-Analyze the methodological quality and provide assessments for each component:
-
-1. RANDOMIZATION (0-2 points):
-   - 0: No randomization or inadequate sequence generation
-   - 1: Randomization mentioned but method unclear
-   - 2: Proper random sequence generation (e.g., computer-generated, random number table)
-
-2. BLINDING (0-3 points):
-   - 0: No blinding
-   - 1: Single-blind (participants OR assessors)
-   - 2: Double-blind (participants AND assessors)
-   - 3: Triple-blind (participants, assessors, AND data analysts)
-
-3. ALLOCATION CONCEALMENT (0-1.5 points):
-   - 0: No allocation concealment or inadequate
-   - 0.75: Unclear or partially described
-   - 1.5: Proper allocation concealment (e.g., sealed envelopes, central randomization)
-
-4. PROTOCOL PREREGISTRATION (0-1.5 points):
-   - 0: No protocol registration mentioned
-   - 0.75: Protocol mentioned but not verified
-   - 1.5: Protocol clearly registered before study (e.g., ClinicalTrials.gov, registry number provided)
-
-5. ITT ANALYSIS (0-1 points):
-   - 0: No ITT analysis or per-protocol only
-   - 0.5: Modified ITT or unclear
-   - 1: Clear intention-to-treat analysis
-
-6. ATTRITION HANDLING (0-1 points):
-   - Extract dropout/attrition rate
-   - Assess quality of handling (imputation methods, sensitivity analysis)
-   - Score based on rate and handling quality
-
-OUTPUT FORMAT (JSON):
-{{
-  "randomization": {{
-    "score": <0-2>,
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "blinding": {{
-    "score": <0-3>,
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "allocation_concealment": {{
-    "score": <0-1.5>,
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "protocol_preregistration": {{
-    "score": <0-1.5>,
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "itt_analysis": {{
-    "score": <0-1>,
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "attrition_handling": {{
-    "score": <0-1>,
-    "attrition_rate": <decimal or null>,
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }}
-}}
-
-CRITICAL REQUIREMENTS:
-- Extract ONLY information that is ACTUALLY PRESENT in the text
-- DO NOT invent, assume, or fabricate any information
-- If information is unclear or not mentioned, score it as 0 and explain why
-- Be specific and evidence-based in your assessment
-- Provide exact quotes from the paper as evidence when available
-
-Provide ONLY the JSON output, no additional text."""
-
-    def _calculate_methodological_quality_score(self, components: Dict[str, Any]) -> DimensionScore:
-        """
-        Calculate methodological quality score from component assessments.
-
-        Args:
-            components: Parsed component assessments from LLM
-
-        Returns:
-            DimensionScore with full audit trail
-        """
-        dimension_score = DimensionScore(
-            dimension_name='methodological_quality',
-            score=0.0
-        )
-
-        # Add each component
-        for component_name, component_data in components.items():
-            if not isinstance(component_data, dict):
-                continue
-
-            score_contribution = float(component_data.get('score', 0.0))
-            evidence = component_data.get('evidence', '')
-            reasoning = component_data.get('reasoning', '')
-
-            # Handle attrition_rate if present
-            value = str(score_contribution)
-            if component_name == 'attrition_handling':
-                attrition_rate = component_data.get('attrition_rate')
-                if attrition_rate is not None:
-                    value = f"{score_contribution} (attrition rate: {attrition_rate})"
-
-            dimension_score.add_detail(
-                component=component_name,
-                value=value,
-                contribution=score_contribution,
-                evidence=evidence,
-                reasoning=reasoning
-            )
-
-            dimension_score.score += score_contribution
-
-        # Cap at 10.0
-        dimension_score.score = min(10.0, dimension_score.score)
-
-        return dimension_score
+        return self.config.get('dimension_weights', DEFAULT_CONFIG['dimension_weights'])
 
     def _assess_methodological_quality(
         self,
-        document: Dict[str, Any],
-        study_assessment: Optional[Dict[str, Any]] = None
+        document: dict,
+        study_assessment: Optional[dict] = None
     ) -> DimensionScore:
         """
         Assess methodological quality using LLM analysis.
-
-        Evaluates: randomization, blinding, allocation concealment,
-        protocol preregistration, ITT analysis, attrition handling.
 
         Args:
             document: Document dict with 'abstract', 'full_text' fields
@@ -1041,18 +239,18 @@ Provide ONLY the JSON output, no additional text."""
         Returns:
             DimensionScore for methodological quality with detailed audit trail
         """
-        # Check if we can leverage StudyAssessmentAgent output
+        # Try to leverage StudyAssessmentAgent output first
         if study_assessment:
-            result = self._extract_mq_from_study_assessment(study_assessment, document)
+            result = extract_mq_from_study_assessment(study_assessment)
             if result is not None:
                 return result
 
         try:
             # Prepare text for analysis
-            text = self._prepare_text_for_analysis(document)
+            text = prepare_text_for_analysis(document, self.MAX_TEXT_LENGTH)
 
             # Build LLM prompt
-            prompt = self._build_methodological_quality_prompt(text)
+            prompt = build_methodological_quality_prompt(text)
 
             # Call LLM with JSON parsing and retry logic
             components = self._generate_and_parse_json(
@@ -1063,7 +261,7 @@ Provide ONLY the JSON output, no additional text."""
             )
 
             # Calculate score
-            dimension_score = self._calculate_methodological_quality_score(components)
+            dimension_score = calculate_methodological_quality_score(components)
 
             logger.info(
                 f"Methodological quality assessment complete: score={dimension_score.score:.2f}/10"
@@ -1072,146 +270,19 @@ Provide ONLY the JSON output, no additional text."""
             return dimension_score
 
         except Exception as e:
-            # Log error and return degraded score
             logger.error(f"Error in methodological quality assessment: {e}")
-
-            dimension_score = DimensionScore(
-                dimension_name='methodological_quality',
-                score=5.0  # Neutral score on error
+            return create_error_dimension_score(
+                DIMENSION_METHODOLOGICAL_QUALITY,
+                str(e)
             )
-            dimension_score.add_detail(
-                component='error',
-                value='assessment_failed',
-                contribution=5.0,
-                reasoning=f'LLM assessment failed: {str(e)}'
-            )
-            return dimension_score
-
-    def _build_risk_of_bias_prompt(self, text: str) -> str:
-        """
-        Build prompt for risk of bias assessment.
-
-        Args:
-            text: Prepared document text
-
-        Returns:
-            Prompt string for LLM
-        """
-        return f"""You are an expert in biomedical research methodology and bias assessment. Analyze the following research paper and assess its risk of bias across four domains.
-
-PAPER TEXT:
-{text}
-
-TASK:
-Assess risk of bias using INVERTED SCALE (higher score = lower risk of bias):
-
-1. SELECTION BIAS (0-2.5 points):
-   - 0: High risk (convenience sampling, no clear criteria)
-   - 1.25: Moderate risk (some limitations in sampling)
-   - 2.5: Low risk (random/consecutive sampling, clear inclusion/exclusion criteria)
-
-2. PERFORMANCE BIAS (0-2.5 points):
-   - 0: High risk (no blinding, unstandardized interventions)
-   - 1.25: Moderate risk (partial blinding or standardization)
-   - 2.5: Low risk (proper blinding, standardized protocols)
-
-3. DETECTION BIAS (0-2.5 points):
-   - 0: High risk (unblinded outcome assessment)
-   - 1.25: Moderate risk (partially blinded or objective outcomes only)
-   - 2.5: Low risk (blinded outcome assessment for all outcomes)
-
-4. REPORTING BIAS (0-2.5 points):
-   - 0: High risk (selective reporting, outcomes not pre-specified)
-   - 1.25: Moderate risk (some evidence of selective reporting)
-   - 2.5: Low risk (all pre-specified outcomes reported, protocol available)
-
-OUTPUT FORMAT (JSON):
-{{
-  "selection_bias": {{
-    "score": <0-2.5>,
-    "risk_level": "<high|moderate|low>",
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "performance_bias": {{
-    "score": <0-2.5>,
-    "risk_level": "<high|moderate|low>",
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "detection_bias": {{
-    "score": <0-2.5>,
-    "risk_level": "<high|moderate|low>",
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }},
-  "reporting_bias": {{
-    "score": <0-2.5>,
-    "risk_level": "<high|moderate|low>",
-    "evidence": "<quote from paper>",
-    "reasoning": "<explanation>"
-  }}
-}}
-
-CRITICAL REQUIREMENTS:
-- Extract ONLY information that is ACTUALLY PRESENT in the text
-- DO NOT invent, assume, or fabricate any information
-- If information is unclear or not mentioned, assume high risk (score 0) and explain why
-- Be specific and evidence-based in your assessment
-- Provide exact quotes from the paper as evidence when available
-
-Provide ONLY the JSON output, no additional text."""
-
-    def _calculate_risk_of_bias_score(self, components: Dict[str, Any]) -> DimensionScore:
-        """
-        Calculate risk of bias score from component assessments.
-
-        Args:
-            components: Parsed component assessments from LLM
-
-        Returns:
-            DimensionScore with full audit trail
-        """
-        dimension_score = DimensionScore(
-            dimension_name='risk_of_bias',
-            score=0.0
-        )
-
-        # Add each component
-        for component_name, component_data in components.items():
-            if not isinstance(component_data, dict):
-                continue
-
-            score_contribution = float(component_data.get('score', 0.0))
-            risk_level = component_data.get('risk_level', 'unknown')
-            evidence = component_data.get('evidence', '')
-            reasoning = component_data.get('reasoning', '')
-
-            dimension_score.add_detail(
-                component=component_name,
-                value=f"{risk_level} risk ({score_contribution})",
-                contribution=score_contribution,
-                evidence=evidence,
-                reasoning=reasoning
-            )
-
-            dimension_score.score += score_contribution
-
-        # Cap at 10.0
-        dimension_score.score = min(10.0, dimension_score.score)
-
-        return dimension_score
 
     def _assess_risk_of_bias(
         self,
-        document: Dict[str, Any],
-        study_assessment: Optional[Dict[str, Any]] = None
+        document: dict,
+        study_assessment: Optional[dict] = None
     ) -> DimensionScore:
         """
         Assess risk of bias using LLM analysis.
-
-        Evaluates: selection bias, performance bias, detection bias, reporting bias.
-        Uses INVERTED SCALE: 10 = low risk, 0 = high risk.
 
         Args:
             document: Document dict with 'abstract', 'full_text' fields
@@ -1220,18 +291,18 @@ Provide ONLY the JSON output, no additional text."""
         Returns:
             DimensionScore for risk of bias with detailed audit trail
         """
-        # Check if we can leverage StudyAssessmentAgent output
+        # Try to leverage StudyAssessmentAgent output first
         if study_assessment:
-            result = self._extract_rob_from_study_assessment(study_assessment, document)
+            result = extract_rob_from_study_assessment(study_assessment)
             if result is not None:
                 return result
 
         try:
             # Prepare text
-            text = self._prepare_text_for_analysis(document)
+            text = prepare_text_for_analysis(document, self.MAX_TEXT_LENGTH)
 
             # Build LLM prompt
-            prompt = self._build_risk_of_bias_prompt(text)
+            prompt = build_risk_of_bias_prompt(text)
 
             # Call LLM with JSON parsing and retry logic
             components = self._generate_and_parse_json(
@@ -1242,7 +313,7 @@ Provide ONLY the JSON output, no additional text."""
             )
 
             # Calculate score
-            dimension_score = self._calculate_risk_of_bias_score(components)
+            dimension_score = calculate_risk_of_bias_score(components)
 
             logger.info(
                 f"Risk of bias assessment complete: score={dimension_score.score:.2f}/10 (higher=lower risk)"
@@ -1251,632 +322,11 @@ Provide ONLY the JSON output, no additional text."""
             return dimension_score
 
         except Exception as e:
-            # Log error and return degraded score
             logger.error(f"Error in risk of bias assessment: {e}")
-
-            dimension_score = DimensionScore(
-                dimension_name='risk_of_bias',
-                score=5.0  # Neutral score on error
+            return create_error_dimension_score(
+                DIMENSION_RISK_OF_BIAS,
+                str(e)
             )
-            dimension_score.add_detail(
-                component='error',
-                value='assessment_failed',
-                contribution=5.0,
-                reasoning=f'LLM assessment failed: {str(e)}'
-            )
-            return dimension_score
-
-    # ========================================================================
-    # StudyAssessmentAgent Integration (Step 5)
-    # ========================================================================
-
-    def _extract_mq_from_study_assessment(
-        self,
-        study_assessment: Dict[str, Any],
-        document: Dict[str, Any]
-    ) -> Optional[DimensionScore]:
-        """
-        Extract methodological quality from StudyAssessmentAgent output.
-
-        If StudyAssessmentAgent has already analyzed the paper, reuse
-        relevant assessments to avoid duplicate LLM calls.
-
-        Args:
-            study_assessment: Output from StudyAssessmentAgent (as dict)
-            document: Document dict (for fallback if needed)
-
-        Returns:
-            DimensionScore for methodological quality, or None if extraction fails
-        """
-        try:
-            dimension_score = DimensionScore(
-                dimension_name='methodological_quality',
-                score=0.0
-            )
-
-            total_score = 0.0
-
-            # Extract randomization from is_randomized
-            is_randomized = study_assessment.get('is_randomized', False)
-            if is_randomized:
-                randomization_score = 2.0
-                dimension_score.add_detail(
-                    component='randomization',
-                    value='yes',
-                    contribution=randomization_score,
-                    reasoning='Extracted from StudyAssessmentAgent: is_randomized=True'
-                )
-                total_score += randomization_score
-            else:
-                dimension_score.add_detail(
-                    component='randomization',
-                    value='no',
-                    contribution=0.0,
-                    reasoning='Extracted from StudyAssessmentAgent: is_randomized=False or not specified'
-                )
-
-            # Extract blinding
-            is_double_blinded = study_assessment.get('is_double_blinded', False)
-            is_blinded = study_assessment.get('is_blinded', False)
-            if is_double_blinded:
-                blinding_score = 2.0  # Double-blind
-                dimension_score.add_detail(
-                    component='blinding',
-                    value='double-blind',
-                    contribution=blinding_score,
-                    reasoning='Extracted from StudyAssessmentAgent: is_double_blinded=True'
-                )
-                total_score += blinding_score
-            elif is_blinded:
-                blinding_score = 1.0  # Single-blind
-                dimension_score.add_detail(
-                    component='blinding',
-                    value='single-blind',
-                    contribution=blinding_score,
-                    reasoning='Extracted from StudyAssessmentAgent: is_blinded=True (not double)'
-                )
-                total_score += blinding_score
-            else:
-                dimension_score.add_detail(
-                    component='blinding',
-                    value='no blinding',
-                    contribution=0.0,
-                    reasoning='Extracted from StudyAssessmentAgent: no blinding detected'
-                )
-
-            # Check quality_score to estimate remaining components
-            quality_score_raw = study_assessment.get('quality_score', 5.0)
-            # Handle None or invalid values
-            quality_score = float(quality_score_raw) if quality_score_raw is not None else 5.0
-            # Clamp to valid range
-            quality_score = max(0.0, min(10.0, quality_score))
-
-            # Map quality_score (0-10) to remaining components estimate
-            # quality_score reflects overall methodological quality
-            # We allocate remaining 5 points (allocation_concealment + protocol + ITT + attrition)
-            # based on quality_score proportion
-            remaining_max = 5.0  # Max remaining points
-            remaining_proportion = quality_score / 10.0
-            remaining_estimate = remaining_max * remaining_proportion
-
-            dimension_score.add_detail(
-                component='other_components',
-                value=f'estimated from quality_score={quality_score:.1f}',
-                contribution=remaining_estimate,
-                reasoning=f'Estimated from StudyAssessmentAgent quality_score ({quality_score:.1f}/10) - covers allocation concealment, protocol registration, ITT analysis, and attrition handling'
-            )
-            total_score += remaining_estimate
-
-            dimension_score.score = min(10.0, total_score)
-
-            logger.info(
-                f"Extracted methodological quality from StudyAssessmentAgent: score={dimension_score.score:.2f}/10"
-            )
-
-            return dimension_score
-
-        except Exception as e:
-            logger.warning(f"Failed to extract MQ from StudyAssessmentAgent: {e}")
-            return None  # Fall back to direct LLM assessment
-
-    def _extract_rob_from_study_assessment(
-        self,
-        study_assessment: Dict[str, Any],
-        document: Dict[str, Any]
-    ) -> Optional[DimensionScore]:
-        """
-        Extract risk of bias from StudyAssessmentAgent output.
-
-        Similar to methodological quality extraction.
-
-        Args:
-            study_assessment: Output from StudyAssessmentAgent (as dict)
-            document: Document dict (for fallback if needed)
-
-        Returns:
-            DimensionScore for risk of bias, or None if extraction fails
-        """
-        try:
-            dimension_score = DimensionScore(
-                dimension_name='risk_of_bias',
-                score=0.0
-            )
-
-            total_score = 0.0
-
-            # Risk level mapping to scores (inverted: high risk = low score)
-            risk_level_scores = {
-                'low': 2.5,
-                'moderate': 1.25,
-                'high': 0.0,
-                'unclear': 0.625  # Between moderate and high
-            }
-
-            # Extract selection bias
-            selection_risk = study_assessment.get('selection_bias_risk', 'unclear')
-            if selection_risk:
-                selection_score = risk_level_scores.get(selection_risk.lower(), 0.625)
-                dimension_score.add_detail(
-                    component='selection_bias',
-                    value=f'{selection_risk} risk ({selection_score})',
-                    contribution=selection_score,
-                    reasoning=f'Extracted from StudyAssessmentAgent: selection_bias_risk={selection_risk}'
-                )
-                total_score += selection_score
-
-            # Extract performance bias
-            performance_risk = study_assessment.get('performance_bias_risk', 'unclear')
-            if performance_risk:
-                performance_score = risk_level_scores.get(performance_risk.lower(), 0.625)
-                dimension_score.add_detail(
-                    component='performance_bias',
-                    value=f'{performance_risk} risk ({performance_score})',
-                    contribution=performance_score,
-                    reasoning=f'Extracted from StudyAssessmentAgent: performance_bias_risk={performance_risk}'
-                )
-                total_score += performance_score
-
-            # Extract detection bias
-            detection_risk = study_assessment.get('detection_bias_risk', 'unclear')
-            if detection_risk:
-                detection_score = risk_level_scores.get(detection_risk.lower(), 0.625)
-                dimension_score.add_detail(
-                    component='detection_bias',
-                    value=f'{detection_risk} risk ({detection_score})',
-                    contribution=detection_score,
-                    reasoning=f'Extracted from StudyAssessmentAgent: detection_bias_risk={detection_risk}'
-                )
-                total_score += detection_score
-
-            # Extract reporting bias
-            reporting_risk = study_assessment.get('reporting_bias_risk', 'unclear')
-            if reporting_risk:
-                reporting_score = risk_level_scores.get(reporting_risk.lower(), 0.625)
-                dimension_score.add_detail(
-                    component='reporting_bias',
-                    value=f'{reporting_risk} risk ({reporting_score})',
-                    contribution=reporting_score,
-                    reasoning=f'Extracted from StudyAssessmentAgent: reporting_bias_risk={reporting_risk}'
-                )
-                total_score += reporting_score
-
-            dimension_score.score = min(10.0, total_score)
-
-            logger.info(
-                f"Extracted risk of bias from StudyAssessmentAgent: score={dimension_score.score:.2f}/10"
-            )
-
-            return dimension_score
-
-        except Exception as e:
-            logger.warning(f"Failed to extract RoB from StudyAssessmentAgent: {e}")
-            return None  # Fall back to direct LLM assessment
-
-    # ========================================================================
-    # Database Persistence and Caching (Step 6)
-    # ========================================================================
-
-    def _get_db_connection(self):
-        """
-        Create database connection using environment variables.
-
-        Returns:
-            psycopg connection object
-        """
-        import psycopg
-        import os
-
-        return psycopg.connect(
-            dbname=os.getenv('POSTGRES_DB', 'knowledgebase'),
-            user=os.getenv('POSTGRES_USER'),
-            password=os.getenv('POSTGRES_PASSWORD'),
-            host=os.getenv('POSTGRES_HOST', 'localhost'),
-            port=os.getenv('POSTGRES_PORT', '5432')
-        )
-
-    def _get_cached_assessment(self, document_id: int) -> Optional[PaperWeightResult]:
-        """
-        Retrieve cached assessment from database.
-
-        Checks for existing assessment with matching document_id and assessor_version.
-
-        Args:
-            document_id: Database ID of document
-
-        Returns:
-            PaperWeightResult if cached, None otherwise
-        """
-        version = self.config.get('version', '1.0.0')
-
-        try:
-            with self._get_db_connection() as conn:
-                with conn.cursor() as cur:
-                    # Fetch assessment
-                    cur.execute("""
-                        SELECT
-                            assessment_id,
-                            document_id,
-                            assessed_at,
-                            assessor_version,
-                            study_design_score,
-                            sample_size_score,
-                            methodological_quality_score,
-                            risk_of_bias_score,
-                            replication_status_score,
-                            final_weight,
-                            dimension_weights,
-                            study_type,
-                            sample_size
-                        FROM paper_weights.assessments
-                        WHERE document_id = %s AND assessor_version = %s
-                    """, (document_id, version))
-
-                    row = cur.fetchone()
-                    if not row:
-                        return None
-
-                    assessment_id = row[0]
-
-                    # Fetch assessment details
-                    cur.execute("""
-                        SELECT
-                            dimension,
-                            component,
-                            extracted_value,
-                            score_contribution,
-                            evidence_text,
-                            reasoning
-                        FROM paper_weights.assessment_details
-                        WHERE assessment_id = %s
-                        ORDER BY detail_id
-                    """, (assessment_id,))
-
-                    details = cur.fetchall()
-
-                    # Convert to PaperWeightResult
-                    return self._reconstruct_result_from_db(row, details)
-
-        except Exception as e:
-            logger.error(f"Error fetching cached assessment: {e}")
-            return None
-
-    def _reconstruct_result_from_db(self, assessment_row: tuple, detail_rows: list) -> PaperWeightResult:
-        """
-        Reconstruct PaperWeightResult from database rows.
-
-        Args:
-            assessment_row: Row from paper_weights.assessments
-            detail_rows: Rows from paper_weights.assessment_details
-
-        Returns:
-            Reconstructed PaperWeightResult
-        """
-        # Unpack assessment row
-        (assessment_id, document_id, assessed_at, assessor_version,
-         study_design_score, sample_size_score, methodological_quality_score,
-         risk_of_bias_score, replication_status_score, final_weight,
-         dimension_weights, study_type, sample_size_n) = assessment_row
-
-        # Parse dimension weights (JSONB)
-        if isinstance(dimension_weights, str):
-            dimension_weights = json.loads(dimension_weights)
-
-        # Group details by dimension
-        dimension_details: Dict[str, List[AssessmentDetail]] = {
-            'study_design': [],
-            'sample_size': [],
-            'methodological_quality': [],
-            'risk_of_bias': [],
-            'replication_status': []
-        }
-
-        for detail_row in detail_rows:
-            (dimension, component, extracted_value, score_contribution,
-             evidence_text, reasoning) = detail_row
-
-            if dimension in dimension_details:
-                dimension_details[dimension].append(AssessmentDetail(
-                    dimension=dimension,
-                    component=component,
-                    extracted_value=extracted_value,
-                    score_contribution=float(score_contribution) if score_contribution else 0.0,
-                    evidence_text=evidence_text,
-                    reasoning=reasoning
-                ))
-
-        # Create dimension scores
-        study_design = DimensionScore(
-            dimension_name='study_design',
-            score=float(study_design_score),
-            details=dimension_details['study_design']
-        )
-
-        sample_size_dim = DimensionScore(
-            dimension_name='sample_size',
-            score=float(sample_size_score),
-            details=dimension_details['sample_size']
-        )
-
-        methodological_quality = DimensionScore(
-            dimension_name='methodological_quality',
-            score=float(methodological_quality_score),
-            details=dimension_details['methodological_quality']
-        )
-
-        risk_of_bias = DimensionScore(
-            dimension_name='risk_of_bias',
-            score=float(risk_of_bias_score),
-            details=dimension_details['risk_of_bias']
-        )
-
-        replication_status = DimensionScore(
-            dimension_name='replication_status',
-            score=float(replication_status_score),
-            details=dimension_details['replication_status']
-        )
-
-        # Create result
-        return PaperWeightResult(
-            document_id=document_id,
-            assessor_version=assessor_version,
-            assessed_at=assessed_at,
-            study_design=study_design,
-            sample_size=sample_size_dim,
-            methodological_quality=methodological_quality,
-            risk_of_bias=risk_of_bias,
-            replication_status=replication_status,
-            final_weight=float(final_weight),
-            dimension_weights=dimension_weights,
-            study_type=study_type,
-            sample_size_n=sample_size_n
-        )
-
-    def _store_assessment(self, result: PaperWeightResult) -> None:
-        """
-        Store assessment in database with full audit trail.
-
-        Inserts into both paper_weights.assessments and paper_weights.assessment_details.
-        Uses ON CONFLICT to handle re-assessments with same version.
-
-        Args:
-            result: PaperWeightResult to store
-        """
-        try:
-            with self._get_db_connection() as conn:
-                with conn.cursor() as cur:
-                    # Insert/update assessment
-                    cur.execute("""
-                        INSERT INTO paper_weights.assessments (
-                            document_id,
-                            assessor_version,
-                            assessed_at,
-                            study_design_score,
-                            sample_size_score,
-                            methodological_quality_score,
-                            risk_of_bias_score,
-                            replication_status_score,
-                            final_weight,
-                            dimension_weights,
-                            study_type,
-                            sample_size
-                        ) VALUES (
-                            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
-                        )
-                        ON CONFLICT (document_id, assessor_version)
-                        DO UPDATE SET
-                            assessed_at = EXCLUDED.assessed_at,
-                            study_design_score = EXCLUDED.study_design_score,
-                            sample_size_score = EXCLUDED.sample_size_score,
-                            methodological_quality_score = EXCLUDED.methodological_quality_score,
-                            risk_of_bias_score = EXCLUDED.risk_of_bias_score,
-                            replication_status_score = EXCLUDED.replication_status_score,
-                            final_weight = EXCLUDED.final_weight,
-                            dimension_weights = EXCLUDED.dimension_weights,
-                            study_type = EXCLUDED.study_type,
-                            sample_size = EXCLUDED.sample_size
-                        RETURNING assessment_id
-                    """, (
-                        result.document_id,
-                        result.assessor_version,
-                        result.assessed_at,
-                        result.study_design.score,
-                        result.sample_size.score,
-                        result.methodological_quality.score,
-                        result.risk_of_bias.score,
-                        result.replication_status.score,
-                        result.final_weight,
-                        json.dumps(result.dimension_weights),
-                        result.study_type,
-                        result.sample_size_n
-                    ))
-
-                    assessment_id = cur.fetchone()[0]
-
-                    # Delete old details (if updating)
-                    cur.execute("""
-                        DELETE FROM paper_weights.assessment_details
-                        WHERE assessment_id = %s
-                    """, (assessment_id,))
-
-                    # Insert new details
-                    all_details = result.get_all_details()
-                    for detail in all_details:
-                        cur.execute("""
-                            INSERT INTO paper_weights.assessment_details (
-                                assessment_id,
-                                dimension,
-                                component,
-                                extracted_value,
-                                score_contribution,
-                                evidence_text,
-                                reasoning
-                            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
-                        """, (
-                            assessment_id,
-                            detail.dimension,
-                            detail.component,
-                            detail.extracted_value,
-                            detail.score_contribution,
-                            detail.evidence_text,
-                            detail.reasoning
-                        ))
-
-                    conn.commit()
-
-        except Exception as e:
-            logger.error(f"Error storing assessment: {e}")
-            raise
-
-    def _get_document(self, document_id: int) -> dict:
-        """
-        Fetch document from database by ID.
-
-        Args:
-            document_id: Database ID of document
-
-        Returns:
-            Document dict with title, abstract, and full_text fields
-
-        Raises:
-            ValueError: If document not found
-        """
-        try:
-            with self._get_db_connection() as conn:
-                with conn.cursor() as cur:
-                    cur.execute("""
-                        SELECT
-                            id,
-                            title,
-                            abstract,
-                            full_text
-                        FROM public.document
-                        WHERE id = %s
-                    """, (document_id,))
-
-                    row = cur.fetchone()
-                    if not row:
-                        raise ValueError(f"Document {document_id} not found")
-
-                    return {
-                        'id': row[0],
-                        'title': row[1],
-                        'abstract': row[2],
-                        'full_text': row[3]
-                    }
-
-        except Exception as e:
-            logger.error(f"Error fetching document {document_id}: {e}")
-            raise
-
-    def _check_replication_status(self, document_id: int) -> DimensionScore:
-        """
-        Check replication status from database.
-
-        Queries paper_weights.replications table for this document.
-        Initially manual entry only - automated discovery is future work.
-
-        Args:
-            document_id: Database ID of document
-
-        Returns:
-            DimensionScore for replication status
-        """
-        try:
-            with self._get_db_connection() as conn:
-                with conn.cursor() as cur:
-                    # Check for replications
-                    cur.execute("""
-                        SELECT
-                            replication_id,
-                            replication_type,
-                            quality_comparison,
-                            confidence
-                        FROM paper_weights.replications
-                        WHERE source_document_id = %s
-                        AND replication_type = 'confirms'
-                    """, (document_id,))
-
-                    replications = cur.fetchall()
-
-                    if not replications:
-                        # No replications found
-                        dimension_score = DimensionScore(
-                            dimension_name='replication_status',
-                            score=0.0
-                        )
-                        dimension_score.add_detail(
-                            component='replication_count',
-                            value='0',
-                            contribution=0.0,
-                            reasoning='No confirming replications found in database'
-                        )
-                        return dimension_score
-
-                    # Calculate score based on replications
-                    replication_count = len(replications)
-                    quality_comparison = replications[0][2]  # First replication quality
-
-                    # Scoring logic
-                    if replication_count == 1 and quality_comparison == 'comparable':
-                        score = 5.0
-                    elif replication_count == 1 and quality_comparison == 'higher':
-                        score = 8.0
-                    elif replication_count >= 2 and quality_comparison == 'comparable':
-                        score = 8.0
-                    elif replication_count >= 2 and quality_comparison == 'higher':
-                        score = 10.0
-                    else:
-                        score = 3.0  # Lower quality replications
-
-                    dimension_score = DimensionScore(
-                        dimension_name='replication_status',
-                        score=score
-                    )
-
-                    dimension_score.add_detail(
-                        component='replication_count',
-                        value=str(replication_count),
-                        contribution=score,
-                        reasoning=f'{replication_count} confirming replications found (quality: {quality_comparison})'
-                    )
-
-                    return dimension_score
-
-        except Exception as e:
-            logger.error(f"Error checking replication status: {e}")
-
-            # Return zero score on error
-            dimension_score = DimensionScore(
-                dimension_name='replication_status',
-                score=0.0
-            )
-            dimension_score.add_detail(
-                component='error',
-                value='query_failed',
-                contribution=0.0,
-                reasoning=f'Database query failed: {str(e)}'
-            )
-            return dimension_score
 
     def _compute_final_weight(self, dimension_scores: Dict[str, DimensionScore]) -> float:
         """
@@ -1915,7 +365,7 @@ Provide ONLY the JSON output, no additional text."""
 
         return PaperWeightResult(
             document_id=document_id,
-            assessor_version=self.config.get('version', '1.0.0'),
+            assessor_version=self.version,
             assessed_at=datetime.now(),
             study_design=error_score,
             sample_size=error_score,
@@ -1925,10 +375,6 @@ Provide ONLY the JSON output, no additional text."""
             final_weight=0.0,
             dimension_weights=self.get_dimension_weights()
         )
-
-    # ========================================================================
-    # Main Entry Point (Step 6)
-    # ========================================================================
 
     def assess_paper(
         self,
@@ -1955,7 +401,7 @@ Provide ONLY the JSON output, no additional text."""
             3. Otherwise, perform full assessment:
                a. Fetch document from database
                b. Extract study type (rule-based)
-               c. Extract sample size (rule-based + LLM)
+               c. Extract sample size (rule-based)
                d. Assess methodological quality (LLM)
                e. Assess risk of bias (LLM)
                f. Check replication status (database query)
@@ -1963,54 +409,51 @@ Provide ONLY the JSON output, no additional text."""
                h. Store in database
             4. Return result
         """
-        version = self.config.get('version', '1.0.0')
-
         try:
             # Check cache
             if not force_reassess:
-                cached = self._get_cached_assessment(document_id)
+                cached = get_cached_assessment(document_id, self.version)
                 if cached:
-                    logger.info(f"Using cached assessment for document {document_id} (version {version})")
+                    logger.info(f"Using cached assessment for document {document_id} (version {self.version})")
                     return cached
 
             logger.info(f"Performing fresh assessment for document {document_id}...")
 
             # Fetch document
-            document = self._get_document(document_id)
+            document = get_document(document_id)
+
+            # Get config values for extractors
+            keywords_config = self.config.get('study_type_keywords')
+            hierarchy_config = self.config.get('study_type_hierarchy')
+            scoring_config = self.config.get('sample_size_scoring')
 
             # Perform assessments
-            study_design_score = self._extract_study_type(document)
-            sample_size_score = self._extract_sample_size(document)
+            study_design_score = extract_study_type(
+                document, keywords_config, hierarchy_config, STUDY_TYPE_PRIORITY
+            )
+            sample_size_score = extract_sample_size_dimension(document, scoring_config)
             methodological_quality_score = self._assess_methodological_quality(document, study_assessment)
             risk_of_bias_score = self._assess_risk_of_bias(document, study_assessment)
-            replication_status_score = self._check_replication_status(document_id)
+            replication_status_score = check_replication_status(document_id)
 
             # Compute final weight
             dimension_scores = {
-                'study_design': study_design_score,
-                'sample_size': sample_size_score,
-                'methodological_quality': methodological_quality_score,
-                'risk_of_bias': risk_of_bias_score,
-                'replication_status': replication_status_score
+                DIMENSION_STUDY_DESIGN: study_design_score,
+                DIMENSION_SAMPLE_SIZE: sample_size_score,
+                DIMENSION_METHODOLOGICAL_QUALITY: methodological_quality_score,
+                DIMENSION_RISK_OF_BIAS: risk_of_bias_score,
+                DIMENSION_REPLICATION_STATUS: replication_status_score
             }
             final_weight = self._compute_final_weight(dimension_scores)
 
-            # Extract study type and sample size from dimension scores
-            study_type = None
-            sample_size_n = None
-
-            if study_design_score.details:
-                study_type = study_design_score.details[0].extracted_value
-
-            if sample_size_score.details:
-                extracted_value = sample_size_score.details[0].extracted_value
-                if extracted_value and extracted_value.isdigit():
-                    sample_size_n = int(extracted_value)
+            # Extract metadata from dimension scores
+            study_type = get_extracted_study_type(study_design_score)
+            sample_size_n = get_extracted_sample_size(sample_size_score)
 
             # Create result
             result = PaperWeightResult(
                 document_id=document_id,
-                assessor_version=version,
+                assessor_version=self.version,
                 assessed_at=datetime.now(),
                 study_design=study_design_score,
                 sample_size=sample_size_score,
@@ -2024,15 +467,19 @@ Provide ONLY the JSON output, no additional text."""
             )
 
             # Store in database
-            self._store_assessment(result)
+            store_assessment(result)
 
             return result
 
         except Exception as e:
             logger.error(f"Error assessing paper {document_id}: {e}")
-            # Return degraded assessment with error noted
             return self._create_error_result(document_id, str(e))
 
 
-# Export all dataclasses and the agent class
-__all__ = ['AssessmentDetail', 'DimensionScore', 'PaperWeightResult', 'PaperWeightAssessmentAgent']
+# Re-export models for backward compatibility
+__all__ = [
+    'AssessmentDetail',
+    'DimensionScore',
+    'PaperWeightResult',
+    'PaperWeightAssessmentAgent',
+]

--- a/src/bmlibrarian/agents/paper_weight_db.py
+++ b/src/bmlibrarian/agents/paper_weight_db.py
@@ -1,0 +1,493 @@
+"""
+Paper Weight Database Operations
+
+Functions for database persistence and caching of paper weight assessments:
+- Caching: retrieve cached assessments by document_id and version
+- Storage: store assessments with full audit trail
+- Document retrieval: fetch documents from database
+- Replication status: query replication information
+
+Uses psycopg for PostgreSQL connectivity.
+"""
+
+import json
+import logging
+import os
+from typing import Optional, Callable, Dict, List
+
+from .paper_weight_models import (
+    AssessmentDetail,
+    DimensionScore,
+    PaperWeightResult,
+    DIMENSION_STUDY_DESIGN,
+    DIMENSION_SAMPLE_SIZE,
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
+    DIMENSION_REPLICATION_STATUS,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_default_db_connection():
+    """
+    Create database connection using environment variables.
+
+    Returns:
+        psycopg connection object
+    """
+    import psycopg
+
+    return psycopg.connect(
+        dbname=os.getenv('POSTGRES_DB', 'knowledgebase'),
+        user=os.getenv('POSTGRES_USER'),
+        password=os.getenv('POSTGRES_PASSWORD'),
+        host=os.getenv('POSTGRES_HOST', 'localhost'),
+        port=os.getenv('POSTGRES_PORT', '5432')
+    )
+
+
+def get_cached_assessment(
+    document_id: int,
+    version: str,
+    conn_factory: Optional[Callable] = None
+) -> Optional[PaperWeightResult]:
+    """
+    Retrieve cached assessment from database.
+
+    Checks for existing assessment with matching document_id and assessor_version.
+
+    Args:
+        document_id: Database ID of document
+        version: Assessor version to match
+        conn_factory: Optional factory function to create database connection
+
+    Returns:
+        PaperWeightResult if cached, None otherwise
+    """
+    if conn_factory is None:
+        conn_factory = get_default_db_connection
+
+    try:
+        with conn_factory() as conn:
+            with conn.cursor() as cur:
+                # Fetch assessment
+                cur.execute("""
+                    SELECT
+                        assessment_id,
+                        document_id,
+                        assessed_at,
+                        assessor_version,
+                        study_design_score,
+                        sample_size_score,
+                        methodological_quality_score,
+                        risk_of_bias_score,
+                        replication_status_score,
+                        final_weight,
+                        dimension_weights,
+                        study_type,
+                        sample_size
+                    FROM paper_weights.assessments
+                    WHERE document_id = %s AND assessor_version = %s
+                """, (document_id, version))
+
+                row = cur.fetchone()
+                if not row:
+                    return None
+
+                assessment_id = row[0]
+
+                # Fetch assessment details
+                cur.execute("""
+                    SELECT
+                        dimension,
+                        component,
+                        extracted_value,
+                        score_contribution,
+                        evidence_text,
+                        reasoning
+                    FROM paper_weights.assessment_details
+                    WHERE assessment_id = %s
+                    ORDER BY detail_id
+                """, (assessment_id,))
+
+                details = cur.fetchall()
+
+                # Convert to PaperWeightResult
+                return _reconstruct_result_from_db(row, details)
+
+    except Exception as e:
+        logger.error(f"Error fetching cached assessment: {e}")
+        return None
+
+
+def _reconstruct_result_from_db(
+    assessment_row: tuple,
+    detail_rows: List[tuple]
+) -> PaperWeightResult:
+    """
+    Reconstruct PaperWeightResult from database rows.
+
+    Args:
+        assessment_row: Row from paper_weights.assessments
+        detail_rows: Rows from paper_weights.assessment_details
+
+    Returns:
+        Reconstructed PaperWeightResult
+    """
+    # Unpack assessment row
+    (assessment_id, document_id, assessed_at, assessor_version,
+     study_design_score, sample_size_score, methodological_quality_score,
+     risk_of_bias_score, replication_status_score, final_weight,
+     dimension_weights, study_type, sample_size_n) = assessment_row
+
+    # Parse dimension weights (JSONB)
+    if isinstance(dimension_weights, str):
+        dimension_weights = json.loads(dimension_weights)
+
+    # Group details by dimension
+    dimension_details: Dict[str, List[AssessmentDetail]] = {
+        DIMENSION_STUDY_DESIGN: [],
+        DIMENSION_SAMPLE_SIZE: [],
+        DIMENSION_METHODOLOGICAL_QUALITY: [],
+        DIMENSION_RISK_OF_BIAS: [],
+        DIMENSION_REPLICATION_STATUS: []
+    }
+
+    for detail_row in detail_rows:
+        (dimension, component, extracted_value, score_contribution,
+         evidence_text, reasoning) = detail_row
+
+        if dimension in dimension_details:
+            dimension_details[dimension].append(AssessmentDetail(
+                dimension=dimension,
+                component=component,
+                extracted_value=extracted_value,
+                score_contribution=float(score_contribution) if score_contribution else 0.0,
+                evidence_text=evidence_text,
+                reasoning=reasoning
+            ))
+
+    # Create dimension scores
+    study_design = DimensionScore(
+        dimension_name=DIMENSION_STUDY_DESIGN,
+        score=float(study_design_score),
+        details=dimension_details[DIMENSION_STUDY_DESIGN]
+    )
+
+    sample_size_dim = DimensionScore(
+        dimension_name=DIMENSION_SAMPLE_SIZE,
+        score=float(sample_size_score),
+        details=dimension_details[DIMENSION_SAMPLE_SIZE]
+    )
+
+    methodological_quality = DimensionScore(
+        dimension_name=DIMENSION_METHODOLOGICAL_QUALITY,
+        score=float(methodological_quality_score),
+        details=dimension_details[DIMENSION_METHODOLOGICAL_QUALITY]
+    )
+
+    risk_of_bias = DimensionScore(
+        dimension_name=DIMENSION_RISK_OF_BIAS,
+        score=float(risk_of_bias_score),
+        details=dimension_details[DIMENSION_RISK_OF_BIAS]
+    )
+
+    replication_status = DimensionScore(
+        dimension_name=DIMENSION_REPLICATION_STATUS,
+        score=float(replication_status_score),
+        details=dimension_details[DIMENSION_REPLICATION_STATUS]
+    )
+
+    # Create result
+    return PaperWeightResult(
+        document_id=document_id,
+        assessor_version=assessor_version,
+        assessed_at=assessed_at,
+        study_design=study_design,
+        sample_size=sample_size_dim,
+        methodological_quality=methodological_quality,
+        risk_of_bias=risk_of_bias,
+        replication_status=replication_status,
+        final_weight=float(final_weight),
+        dimension_weights=dimension_weights,
+        study_type=study_type,
+        sample_size_n=sample_size_n
+    )
+
+
+def store_assessment(
+    result: PaperWeightResult,
+    conn_factory: Optional[Callable] = None
+) -> None:
+    """
+    Store assessment in database with full audit trail.
+
+    Inserts into both paper_weights.assessments and paper_weights.assessment_details.
+    Uses ON CONFLICT to handle re-assessments with same version.
+
+    Args:
+        result: PaperWeightResult to store
+        conn_factory: Optional factory function to create database connection
+    """
+    if conn_factory is None:
+        conn_factory = get_default_db_connection
+
+    try:
+        with conn_factory() as conn:
+            with conn.cursor() as cur:
+                # Insert/update assessment
+                cur.execute("""
+                    INSERT INTO paper_weights.assessments (
+                        document_id,
+                        assessor_version,
+                        assessed_at,
+                        study_design_score,
+                        sample_size_score,
+                        methodological_quality_score,
+                        risk_of_bias_score,
+                        replication_status_score,
+                        final_weight,
+                        dimension_weights,
+                        study_type,
+                        sample_size
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT (document_id, assessor_version)
+                    DO UPDATE SET
+                        assessed_at = EXCLUDED.assessed_at,
+                        study_design_score = EXCLUDED.study_design_score,
+                        sample_size_score = EXCLUDED.sample_size_score,
+                        methodological_quality_score = EXCLUDED.methodological_quality_score,
+                        risk_of_bias_score = EXCLUDED.risk_of_bias_score,
+                        replication_status_score = EXCLUDED.replication_status_score,
+                        final_weight = EXCLUDED.final_weight,
+                        dimension_weights = EXCLUDED.dimension_weights,
+                        study_type = EXCLUDED.study_type,
+                        sample_size = EXCLUDED.sample_size
+                    RETURNING assessment_id
+                """, (
+                    result.document_id,
+                    result.assessor_version,
+                    result.assessed_at,
+                    result.study_design.score,
+                    result.sample_size.score,
+                    result.methodological_quality.score,
+                    result.risk_of_bias.score,
+                    result.replication_status.score,
+                    result.final_weight,
+                    json.dumps(result.dimension_weights),
+                    result.study_type,
+                    result.sample_size_n
+                ))
+
+                assessment_id = cur.fetchone()[0]
+
+                # Delete old details (if updating)
+                cur.execute("""
+                    DELETE FROM paper_weights.assessment_details
+                    WHERE assessment_id = %s
+                """, (assessment_id,))
+
+                # Insert new details
+                all_details = result.get_all_details()
+                for detail in all_details:
+                    cur.execute("""
+                        INSERT INTO paper_weights.assessment_details (
+                            assessment_id,
+                            dimension,
+                            component,
+                            extracted_value,
+                            score_contribution,
+                            evidence_text,
+                            reasoning
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """, (
+                        assessment_id,
+                        detail.dimension,
+                        detail.component,
+                        detail.extracted_value,
+                        detail.score_contribution,
+                        detail.evidence_text,
+                        detail.reasoning
+                    ))
+
+                conn.commit()
+
+    except Exception as e:
+        logger.error(f"Error storing assessment: {e}")
+        raise
+
+
+def get_document(
+    document_id: int,
+    conn_factory: Optional[Callable] = None
+) -> dict:
+    """
+    Fetch document from database by ID.
+
+    Args:
+        document_id: Database ID of document
+        conn_factory: Optional factory function to create database connection
+
+    Returns:
+        Document dict with title, abstract, and full_text fields
+
+    Raises:
+        ValueError: If document not found
+    """
+    if conn_factory is None:
+        conn_factory = get_default_db_connection
+
+    try:
+        with conn_factory() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT
+                        id,
+                        title,
+                        abstract,
+                        full_text
+                    FROM public.document
+                    WHERE id = %s
+                """, (document_id,))
+
+                row = cur.fetchone()
+                if not row:
+                    raise ValueError(f"Document {document_id} not found")
+
+                return {
+                    'id': row[0],
+                    'title': row[1],
+                    'abstract': row[2],
+                    'full_text': row[3]
+                }
+
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching document {document_id}: {e}")
+        raise
+
+
+def check_replication_status(
+    document_id: int,
+    conn_factory: Optional[Callable] = None
+) -> DimensionScore:
+    """
+    Check replication status from database.
+
+    Queries paper_weights.replications table for this document.
+    Initially manual entry only - automated discovery is future work.
+
+    Args:
+        document_id: Database ID of document
+        conn_factory: Optional factory function to create database connection
+
+    Returns:
+        DimensionScore for replication status
+    """
+    if conn_factory is None:
+        conn_factory = get_default_db_connection
+
+    try:
+        with conn_factory() as conn:
+            with conn.cursor() as cur:
+                # Check for replications
+                cur.execute("""
+                    SELECT
+                        replication_id,
+                        replication_type,
+                        quality_comparison,
+                        confidence
+                    FROM paper_weights.replications
+                    WHERE source_document_id = %s
+                    AND replication_type = 'confirms'
+                """, (document_id,))
+
+                replications = cur.fetchall()
+
+                if not replications:
+                    # No replications found
+                    dimension_score = DimensionScore(
+                        dimension_name=DIMENSION_REPLICATION_STATUS,
+                        score=0.0
+                    )
+                    dimension_score.add_detail(
+                        component='replication_count',
+                        value='0',
+                        contribution=0.0,
+                        reasoning='No confirming replications found in database'
+                    )
+                    return dimension_score
+
+                # Calculate score based on replications
+                replication_count = len(replications)
+                quality_comparison = replications[0][2]  # First replication quality
+
+                # Scoring logic
+                score = _calculate_replication_score(replication_count, quality_comparison)
+
+                dimension_score = DimensionScore(
+                    dimension_name=DIMENSION_REPLICATION_STATUS,
+                    score=score
+                )
+
+                dimension_score.add_detail(
+                    component='replication_count',
+                    value=str(replication_count),
+                    contribution=score,
+                    reasoning=f'{replication_count} confirming replications found (quality: {quality_comparison})'
+                )
+
+                return dimension_score
+
+    except Exception as e:
+        logger.error(f"Error checking replication status: {e}")
+
+        # Return zero score on error
+        dimension_score = DimensionScore(
+            dimension_name=DIMENSION_REPLICATION_STATUS,
+            score=0.0
+        )
+        dimension_score.add_detail(
+            component='error',
+            value='query_failed',
+            contribution=0.0,
+            reasoning=f'Database query failed: {str(e)}'
+        )
+        return dimension_score
+
+
+def _calculate_replication_score(replication_count: int, quality_comparison: str) -> float:
+    """
+    Calculate replication status score based on count and quality.
+
+    Args:
+        replication_count: Number of confirming replications
+        quality_comparison: Quality comparison ('higher', 'comparable', 'lower')
+
+    Returns:
+        Score (0-10)
+    """
+    if replication_count == 1 and quality_comparison == 'comparable':
+        return 5.0
+    elif replication_count == 1 and quality_comparison == 'higher':
+        return 8.0
+    elif replication_count >= 2 and quality_comparison == 'comparable':
+        return 8.0
+    elif replication_count >= 2 and quality_comparison == 'higher':
+        return 10.0
+    else:
+        return 3.0  # Lower quality replications
+
+
+__all__ = [
+    'get_default_db_connection',
+    'get_cached_assessment',
+    'store_assessment',
+    'get_document',
+    'check_replication_status',
+]

--- a/src/bmlibrarian/agents/paper_weight_db.py
+++ b/src/bmlibrarian/agents/paper_weight_db.py
@@ -29,6 +29,14 @@ from .paper_weight_models import (
 
 logger = logging.getLogger(__name__)
 
+# Replication scoring constants
+# Score depends on number of replications and their quality relative to the original
+REPLICATION_SCORE_SINGLE_COMPARABLE = 5.0   # One replication of comparable quality
+REPLICATION_SCORE_SINGLE_HIGHER = 8.0       # One replication of higher quality
+REPLICATION_SCORE_MULTIPLE_COMPARABLE = 8.0  # 2+ replications of comparable quality
+REPLICATION_SCORE_MULTIPLE_HIGHER = 10.0     # 2+ replications of higher quality
+REPLICATION_SCORE_LOWER_QUALITY = 3.0        # Lower quality replications
+
 
 def get_default_db_connection():
     """
@@ -465,6 +473,13 @@ def _calculate_replication_score(replication_count: int, quality_comparison: str
     """
     Calculate replication status score based on count and quality.
 
+    Scoring rubric:
+    - Single replication of comparable quality: 5.0
+    - Single replication of higher quality: 8.0
+    - Multiple (2+) replications of comparable quality: 8.0
+    - Multiple (2+) replications of higher quality: 10.0
+    - Lower quality replications: 3.0
+
     Args:
         replication_count: Number of confirming replications
         quality_comparison: Quality comparison ('higher', 'comparable', 'lower')
@@ -473,15 +488,15 @@ def _calculate_replication_score(replication_count: int, quality_comparison: str
         Score (0-10)
     """
     if replication_count == 1 and quality_comparison == 'comparable':
-        return 5.0
+        return REPLICATION_SCORE_SINGLE_COMPARABLE
     elif replication_count == 1 and quality_comparison == 'higher':
-        return 8.0
+        return REPLICATION_SCORE_SINGLE_HIGHER
     elif replication_count >= 2 and quality_comparison == 'comparable':
-        return 8.0
+        return REPLICATION_SCORE_MULTIPLE_COMPARABLE
     elif replication_count >= 2 and quality_comparison == 'higher':
-        return 10.0
+        return REPLICATION_SCORE_MULTIPLE_HIGHER
     else:
-        return 3.0  # Lower quality replications
+        return REPLICATION_SCORE_LOWER_QUALITY
 
 
 __all__ = [

--- a/src/bmlibrarian/agents/paper_weight_extractors.py
+++ b/src/bmlibrarian/agents/paper_weight_extractors.py
@@ -1,0 +1,448 @@
+"""
+Paper Weight Rule-Based Extractors
+
+Pure functions for extracting paper characteristics using rule-based methods:
+- Study type extraction via keyword matching
+- Sample size extraction via regex patterns
+- Power calculation and confidence interval detection
+
+All functions are stateless and can be tested in isolation.
+"""
+
+import re
+import math
+from typing import Optional, Dict, List, Any
+
+from .paper_weight_models import (
+    DimensionScore,
+    DIMENSION_STUDY_DESIGN,
+    DIMENSION_SAMPLE_SIZE,
+)
+
+
+# Priority order for study type detection (highest evidence level first)
+STUDY_TYPE_PRIORITY = [
+    'systematic_review',
+    'meta_analysis',
+    'rct',
+    'cohort_prospective',
+    'cohort_retrospective',
+    'case_control',
+    'cross_sectional',
+    'case_series',
+    'case_report'
+]
+
+# Default study type keywords
+DEFAULT_STUDY_TYPE_KEYWORDS = {
+    'systematic_review': ['systematic review', 'systematic literature review'],
+    'meta_analysis': ['meta-analysis', 'meta analysis', 'pooled analysis'],
+    'rct': [
+        'randomized controlled trial', 'randomised controlled trial', 'RCT',
+        'randomized trial', 'randomised trial', 'random allocation', 'randomly assigned'
+    ],
+    'cohort_prospective': ['prospective cohort', 'prospective study', 'longitudinal cohort'],
+    'cohort_retrospective': ['retrospective cohort', 'retrospective study'],
+    'case_control': ['case-control', 'case control study'],
+    'cross_sectional': ['cross-sectional', 'cross sectional study', 'prevalence study'],
+    'case_series': ['case series', 'case-series'],
+    'case_report': ['case report', 'case study']
+}
+
+# Default study type hierarchy scores
+DEFAULT_STUDY_TYPE_HIERARCHY = {
+    'systematic_review': 10.0,
+    'meta_analysis': 10.0,
+    'rct': 8.0,
+    'cohort_prospective': 6.0,
+    'cohort_retrospective': 5.0,
+    'case_control': 4.0,
+    'cross_sectional': 3.0,
+    'case_series': 2.0,
+    'case_report': 1.0
+}
+
+# Sample size regex patterns
+SAMPLE_SIZE_PATTERNS = [
+    r'n\s*=\s*(\d+)',  # n = 450
+    r'N\s*=\s*(\d+)',  # N = 450
+    r'(\d+)\s+participants',  # 450 participants
+    r'(\d+)\s+subjects',  # 450 subjects
+    r'(\d+)\s+patients',  # 450 patients
+    r'sample\s+size\s+of\s+(\d+)',  # sample size of 450
+    r'total\s+of\s+(\d+)\s+(?:participants|subjects|patients)',  # total of 450 participants
+    r'enrolled\s+(\d+)\s+(?:participants|subjects|patients)',  # enrolled 450 participants
+    r'recruited\s+(\d+)\s+(?:participants|subjects|patients)',  # recruited 450 participants
+]
+
+# Power calculation keywords
+POWER_CALCULATION_KEYWORDS = [
+    'power calculation',
+    'power analysis',
+    'sample size calculation',
+    'calculated sample size',
+    'statistical power',
+    'power to detect'
+]
+
+# Confidence interval patterns
+CI_PATTERNS = [
+    r'confidence interval',
+    r'\bCI\b',
+    r'95%\s*CI',
+    r'\[\s*\d+\.?\d*\s*,\s*\d+\.?\d*\s*\]',  # [1.2, 3.4]
+    r'\(\s*\d+\.?\d*\s*-\s*\d+\.?\d*\s*\)',  # (1.2-3.4)
+]
+
+
+def extract_text_context(text: str, keyword: str, context_chars: int = 50) -> str:
+    """
+    Extract text context around a keyword.
+
+    Args:
+        text: Full text to search
+        keyword: Keyword to find
+        context_chars: Characters to include before/after keyword
+
+    Returns:
+        Text snippet with context around keyword, empty string if not found
+    """
+    keyword_pos = text.find(keyword)
+    if keyword_pos == -1:
+        return ""
+
+    start = max(0, keyword_pos - context_chars)
+    end = min(len(text), keyword_pos + len(keyword) + context_chars)
+
+    context = text[start:end]
+
+    # Add ellipsis if truncated
+    if start > 0:
+        context = "..." + context
+    if end < len(text):
+        context = context + "..."
+
+    return context
+
+
+def find_sample_size(text: str, min_n: int = 5, max_n: int = 1000000) -> Optional[int]:
+    """
+    Find sample size in text using regex patterns.
+
+    Returns largest number found (usually total sample size).
+
+    Args:
+        text: Text to search
+        min_n: Minimum valid sample size (default: 5)
+        max_n: Maximum valid sample size (default: 1,000,000)
+
+    Returns:
+        Sample size (int) or None if not found
+    """
+    found_sizes = []
+
+    for pattern in SAMPLE_SIZE_PATTERNS:
+        matches = re.finditer(pattern, text, re.IGNORECASE)
+        for match in matches:
+            size = int(match.group(1))
+            # Filter out unrealistic values
+            if min_n <= size <= max_n:
+                found_sizes.append(size)
+
+    if not found_sizes:
+        return None
+
+    # Return largest (usually total sample size)
+    return max(found_sizes)
+
+
+def calculate_sample_size_score(n: int, log_multiplier: float = 2.0) -> float:
+    """
+    Calculate sample size score using logarithmic scaling.
+
+    Formula: min(10, log10(n) * log_multiplier)
+
+    Args:
+        n: Sample size
+        log_multiplier: Multiplier for log10 score (default: 2.0)
+
+    Returns:
+        Score (0-10)
+    """
+    if n <= 0:
+        return 0.0
+
+    score = math.log10(n) * log_multiplier
+    return min(10.0, max(0.0, score))
+
+
+def has_power_calculation(text: str) -> bool:
+    """
+    Check if text mentions power calculation.
+
+    Args:
+        text: Text to search
+
+    Returns:
+        True if power calculation mentioned
+    """
+    text_lower = text.lower()
+    return any(keyword in text_lower for keyword in POWER_CALCULATION_KEYWORDS)
+
+
+def find_power_calc_context(text: str) -> str:
+    """
+    Find context around power calculation mention.
+
+    Args:
+        text: Text to search
+
+    Returns:
+        Context string around power calculation mention
+    """
+    text_lower = text.lower()
+    for keyword in POWER_CALCULATION_KEYWORDS[:3]:  # Check first 3 most common
+        if keyword in text_lower:
+            return extract_text_context(text_lower, keyword)
+    return ""
+
+
+def has_ci_reporting(text: str) -> bool:
+    """
+    Check if text reports confidence intervals.
+
+    Args:
+        text: Text to search
+
+    Returns:
+        True if confidence intervals are reported
+    """
+    for pattern in CI_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            return True
+    return False
+
+
+def extract_study_type(
+    document: Dict[str, Any],
+    keywords_config: Optional[Dict[str, List[str]]] = None,
+    hierarchy_config: Optional[Dict[str, float]] = None,
+    priority_order: Optional[List[str]] = None
+) -> DimensionScore:
+    """
+    Extract study type using keyword matching.
+
+    Matches keywords against abstract and methods section.
+    Uses priority hierarchy: systematic review > RCT > cohort > etc.
+
+    Args:
+        document: Document dict with 'abstract' and optional 'methods_text' fields
+        keywords_config: Dict mapping study types to keyword lists (optional)
+        hierarchy_config: Dict mapping study types to scores (optional)
+        priority_order: List of study types in priority order (optional)
+
+    Returns:
+        DimensionScore for study design with audit trail
+    """
+    # Use defaults if not provided
+    if keywords_config is None:
+        keywords_config = DEFAULT_STUDY_TYPE_KEYWORDS
+    if hierarchy_config is None:
+        hierarchy_config = DEFAULT_STUDY_TYPE_HIERARCHY
+    if priority_order is None:
+        priority_order = STUDY_TYPE_PRIORITY
+
+    # Get text to search
+    abstract = document.get('abstract', '') or ''
+    methods = document.get('methods_text', '') or ''
+    search_text = f"{abstract} {methods}".lower()
+
+    # Try each study type in priority order
+    for study_type in priority_order:
+        keywords = keywords_config.get(study_type, [])
+        for keyword in keywords:
+            if keyword.lower() in search_text:
+                # Found match - get score from hierarchy
+                score = hierarchy_config.get(study_type, 5.0)
+
+                # Create dimension score with audit trail
+                dimension_score = DimensionScore(
+                    dimension_name=DIMENSION_STUDY_DESIGN,
+                    score=score
+                )
+
+                # Find evidence context
+                evidence_text = extract_text_context(search_text, keyword.lower())
+
+                dimension_score.add_detail(
+                    component='study_type',
+                    value=study_type,
+                    contribution=score,
+                    evidence=evidence_text,
+                    reasoning=f"Matched keyword '{keyword}' indicating {study_type.replace('_', ' ')}"
+                )
+
+                return dimension_score
+
+    # No match found - default to unknown
+    dimension_score = DimensionScore(
+        dimension_name=DIMENSION_STUDY_DESIGN,
+        score=5.0  # Neutral score
+    )
+    dimension_score.add_detail(
+        component='study_type',
+        value='unknown',
+        contribution=5.0,
+        reasoning='No study type keywords matched - assigned neutral score'
+    )
+
+    return dimension_score
+
+
+def extract_sample_size_dimension(
+    document: Dict[str, Any],
+    scoring_config: Optional[Dict[str, float]] = None
+) -> DimensionScore:
+    """
+    Extract sample size and calculate dimension score.
+
+    Uses regex patterns to find sample size mentions, applies logarithmic
+    scoring, and adds bonuses for power calculation and CI reporting.
+
+    Args:
+        document: Document dict with 'abstract' and optional 'methods_text' fields
+        scoring_config: Dict with 'log_multiplier', 'power_calculation_bonus',
+                       'ci_reported_bonus' keys (optional)
+
+    Returns:
+        DimensionScore for sample size with audit trail
+    """
+    # Default scoring config
+    if scoring_config is None:
+        scoring_config = {
+            'log_multiplier': 2.0,
+            'power_calculation_bonus': 2.0,
+            'ci_reported_bonus': 0.5
+        }
+
+    log_multiplier = scoring_config.get('log_multiplier', 2.0)
+    power_bonus = scoring_config.get('power_calculation_bonus', 2.0)
+    ci_bonus = scoring_config.get('ci_reported_bonus', 0.5)
+
+    # Get text to search
+    abstract = document.get('abstract', '') or ''
+    methods = document.get('methods_text', '') or ''
+    search_text = f"{abstract} {methods}"
+
+    # Extract sample size
+    sample_size = find_sample_size(search_text)
+
+    if sample_size is None:
+        # No sample size found
+        dimension_score = DimensionScore(
+            dimension_name=DIMENSION_SAMPLE_SIZE,
+            score=0.0
+        )
+        dimension_score.add_detail(
+            component='extracted_n',
+            value='not_found',
+            contribution=0.0,
+            reasoning='No sample size could be extracted from text'
+        )
+        return dimension_score
+
+    # Calculate base score using logarithmic scaling
+    base_score = calculate_sample_size_score(sample_size, log_multiplier)
+
+    # Create dimension score
+    dimension_score = DimensionScore(
+        dimension_name=DIMENSION_SAMPLE_SIZE,
+        score=base_score
+    )
+
+    # Add base score detail
+    dimension_score.add_detail(
+        component='extracted_n',
+        value=str(sample_size),
+        contribution=base_score,
+        reasoning=f"Log10({sample_size}) * {log_multiplier} = {base_score:.2f}"
+    )
+
+    # Check for power calculation
+    if has_power_calculation(search_text):
+        new_score = min(10.0, dimension_score.score + power_bonus)
+        dimension_score.score = new_score
+        dimension_score.add_detail(
+            component='power_calculation',
+            value='yes',
+            contribution=power_bonus,
+            evidence=find_power_calc_context(search_text),
+            reasoning=f'Power calculation mentioned, bonus +{power_bonus}'
+        )
+
+    # Check for confidence interval reporting
+    if has_ci_reporting(search_text):
+        new_score = min(10.0, dimension_score.score + ci_bonus)
+        dimension_score.score = new_score
+        dimension_score.add_detail(
+            component='ci_reporting',
+            value='yes',
+            contribution=ci_bonus,
+            reasoning=f'Confidence intervals reported, bonus +{ci_bonus}'
+        )
+
+    return dimension_score
+
+
+def get_extracted_sample_size(dimension_score: DimensionScore) -> Optional[int]:
+    """
+    Extract the numeric sample size from a sample size DimensionScore.
+
+    Args:
+        dimension_score: DimensionScore from extract_sample_size_dimension
+
+    Returns:
+        Sample size as integer, or None if not found/not numeric
+    """
+    if not dimension_score.details:
+        return None
+
+    extracted_value = dimension_score.details[0].extracted_value
+    if extracted_value and extracted_value.isdigit():
+        return int(extracted_value)
+    return None
+
+
+def get_extracted_study_type(dimension_score: DimensionScore) -> Optional[str]:
+    """
+    Extract the study type string from a study design DimensionScore.
+
+    Args:
+        dimension_score: DimensionScore from extract_study_type
+
+    Returns:
+        Study type string, or None if not found
+    """
+    if not dimension_score.details:
+        return None
+    return dimension_score.details[0].extracted_value
+
+
+__all__ = [
+    'STUDY_TYPE_PRIORITY',
+    'DEFAULT_STUDY_TYPE_KEYWORDS',
+    'DEFAULT_STUDY_TYPE_HIERARCHY',
+    'SAMPLE_SIZE_PATTERNS',
+    'POWER_CALCULATION_KEYWORDS',
+    'CI_PATTERNS',
+    'extract_text_context',
+    'find_sample_size',
+    'calculate_sample_size_score',
+    'has_power_calculation',
+    'find_power_calc_context',
+    'has_ci_reporting',
+    'extract_study_type',
+    'extract_sample_size_dimension',
+    'get_extracted_sample_size',
+    'get_extracted_study_type',
+]

--- a/src/bmlibrarian/agents/paper_weight_llm_assessors.py
+++ b/src/bmlibrarian/agents/paper_weight_llm_assessors.py
@@ -1,0 +1,393 @@
+"""
+Paper Weight LLM-Based Assessors
+
+Functions for LLM-based assessment of paper quality:
+- Methodological quality assessment (randomization, blinding, etc.)
+- Risk of bias assessment (selection, performance, detection, reporting)
+- Integration with existing StudyAssessmentAgent output
+
+All score calculators are stateless pure functions.
+Prompts are imported from paper_weight_prompts module.
+"""
+
+import logging
+from typing import Dict, Any, Optional
+
+from .paper_weight_models import (
+    DimensionScore,
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
+)
+from .paper_weight_prompts import (
+    build_methodological_quality_prompt,
+    build_risk_of_bias_prompt,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Maximum text length for LLM prompts
+DEFAULT_MAX_TEXT_LENGTH = 8000
+
+
+def prepare_text_for_analysis(
+    document: Dict[str, Any],
+    max_length: int = DEFAULT_MAX_TEXT_LENGTH
+) -> str:
+    """
+    Prepare document text for LLM analysis.
+
+    Combines title, abstract and full text (if available), limits length
+    to avoid token limits.
+
+    Args:
+        document: Document dict with 'title', 'abstract', 'full_text' fields
+        max_length: Maximum characters to include (default: 8000)
+
+    Returns:
+        Prepared text string suitable for LLM prompt
+    """
+    title = document.get('title', '') or ''
+    abstract = document.get('abstract', '') or ''
+    full_text = document.get('full_text', '') or ''
+
+    # Prefer full text if available, otherwise use abstract
+    if full_text:
+        text = f"TITLE: {title}\n\nFULL TEXT:\n{full_text}"
+    else:
+        text = f"TITLE: {title}\n\nABSTRACT:\n{abstract}"
+
+    # Limit to max_length characters to avoid token limits
+    if len(text) > max_length:
+        text = text[:max_length] + "\n\n[Text truncated...]"
+        logger.debug(f"Truncated text to {max_length} characters")
+
+    return text
+
+
+def calculate_methodological_quality_score(components: Dict[str, Any]) -> DimensionScore:
+    """
+    Calculate methodological quality score from component assessments.
+
+    Args:
+        components: Parsed component assessments from LLM (dict with component names as keys)
+
+    Returns:
+        DimensionScore with full audit trail
+    """
+    dimension_score = DimensionScore(
+        dimension_name=DIMENSION_METHODOLOGICAL_QUALITY,
+        score=0.0
+    )
+
+    for component_name, component_data in components.items():
+        if not isinstance(component_data, dict):
+            continue
+
+        score_contribution = float(component_data.get('score', 0.0))
+        evidence = component_data.get('evidence', '')
+        reasoning = component_data.get('reasoning', '')
+
+        # Handle attrition_rate if present
+        value = str(score_contribution)
+        if component_name == 'attrition_handling':
+            attrition_rate = component_data.get('attrition_rate')
+            if attrition_rate is not None:
+                value = f"{score_contribution} (attrition rate: {attrition_rate})"
+
+        dimension_score.add_detail(
+            component=component_name,
+            value=value,
+            contribution=score_contribution,
+            evidence=evidence,
+            reasoning=reasoning
+        )
+
+        dimension_score.score += score_contribution
+
+    # Cap at 10.0
+    dimension_score.score = min(10.0, dimension_score.score)
+
+    return dimension_score
+
+
+def calculate_risk_of_bias_score(components: Dict[str, Any]) -> DimensionScore:
+    """
+    Calculate risk of bias score from component assessments.
+
+    Args:
+        components: Parsed component assessments from LLM
+
+    Returns:
+        DimensionScore with full audit trail
+    """
+    dimension_score = DimensionScore(
+        dimension_name=DIMENSION_RISK_OF_BIAS,
+        score=0.0
+    )
+
+    for component_name, component_data in components.items():
+        if not isinstance(component_data, dict):
+            continue
+
+        score_contribution = float(component_data.get('score', 0.0))
+        risk_level = component_data.get('risk_level', 'unknown')
+        evidence = component_data.get('evidence', '')
+        reasoning = component_data.get('reasoning', '')
+
+        dimension_score.add_detail(
+            component=component_name,
+            value=f"{risk_level} risk ({score_contribution})",
+            contribution=score_contribution,
+            evidence=evidence,
+            reasoning=reasoning
+        )
+
+        dimension_score.score += score_contribution
+
+    # Cap at 10.0
+    dimension_score.score = min(10.0, dimension_score.score)
+
+    return dimension_score
+
+
+# =============================================================================
+# StudyAssessmentAgent Integration Functions
+# =============================================================================
+
+# Risk level to score mapping (inverted: high risk = low score)
+RISK_LEVEL_SCORES = {
+    'low': 2.5,
+    'moderate': 1.25,
+    'high': 0.0,
+    'unclear': 0.625  # Between moderate and high
+}
+
+
+def extract_mq_from_study_assessment(
+    study_assessment: Dict[str, Any]
+) -> Optional[DimensionScore]:
+    """
+    Extract methodological quality from StudyAssessmentAgent output.
+
+    If StudyAssessmentAgent has already analyzed the paper, reuse
+    relevant assessments to avoid duplicate LLM calls.
+
+    Args:
+        study_assessment: Output from StudyAssessmentAgent (as dict)
+
+    Returns:
+        DimensionScore for methodological quality, or None if extraction fails
+    """
+    try:
+        dimension_score = DimensionScore(
+            dimension_name=DIMENSION_METHODOLOGICAL_QUALITY,
+            score=0.0
+        )
+
+        total_score = 0.0
+
+        # Extract randomization from is_randomized
+        is_randomized = study_assessment.get('is_randomized', False)
+        if is_randomized:
+            randomization_score = 2.0
+            dimension_score.add_detail(
+                component='randomization',
+                value='yes',
+                contribution=randomization_score,
+                reasoning='Extracted from StudyAssessmentAgent: is_randomized=True'
+            )
+            total_score += randomization_score
+        else:
+            dimension_score.add_detail(
+                component='randomization',
+                value='no',
+                contribution=0.0,
+                reasoning='Extracted from StudyAssessmentAgent: is_randomized=False or not specified'
+            )
+
+        # Extract blinding
+        is_double_blinded = study_assessment.get('is_double_blinded', False)
+        is_blinded = study_assessment.get('is_blinded', False)
+        if is_double_blinded:
+            blinding_score = 2.0
+            dimension_score.add_detail(
+                component='blinding',
+                value='double-blind',
+                contribution=blinding_score,
+                reasoning='Extracted from StudyAssessmentAgent: is_double_blinded=True'
+            )
+            total_score += blinding_score
+        elif is_blinded:
+            blinding_score = 1.0
+            dimension_score.add_detail(
+                component='blinding',
+                value='single-blind',
+                contribution=blinding_score,
+                reasoning='Extracted from StudyAssessmentAgent: is_blinded=True (not double)'
+            )
+            total_score += blinding_score
+        else:
+            dimension_score.add_detail(
+                component='blinding',
+                value='no blinding',
+                contribution=0.0,
+                reasoning='Extracted from StudyAssessmentAgent: no blinding detected'
+            )
+
+        # Check quality_score to estimate remaining components
+        quality_score_raw = study_assessment.get('quality_score', 5.0)
+        quality_score = float(quality_score_raw) if quality_score_raw is not None else 5.0
+        quality_score = max(0.0, min(10.0, quality_score))
+
+        # Map quality_score (0-10) to remaining components estimate
+        remaining_max = 5.0
+        remaining_proportion = quality_score / 10.0
+        remaining_estimate = remaining_max * remaining_proportion
+
+        dimension_score.add_detail(
+            component='other_components',
+            value=f'estimated from quality_score={quality_score:.1f}',
+            contribution=remaining_estimate,
+            reasoning=(
+                f'Estimated from StudyAssessmentAgent quality_score ({quality_score:.1f}/10) - '
+                'covers allocation concealment, protocol registration, ITT analysis, and attrition handling'
+            )
+        )
+        total_score += remaining_estimate
+
+        dimension_score.score = min(10.0, total_score)
+
+        logger.info(
+            f"Extracted methodological quality from StudyAssessmentAgent: score={dimension_score.score:.2f}/10"
+        )
+
+        return dimension_score
+
+    except Exception as e:
+        logger.warning(f"Failed to extract MQ from StudyAssessmentAgent: {e}")
+        return None
+
+
+def extract_rob_from_study_assessment(
+    study_assessment: Dict[str, Any]
+) -> Optional[DimensionScore]:
+    """
+    Extract risk of bias from StudyAssessmentAgent output.
+
+    Args:
+        study_assessment: Output from StudyAssessmentAgent (as dict)
+
+    Returns:
+        DimensionScore for risk of bias, or None if extraction fails
+    """
+    try:
+        dimension_score = DimensionScore(
+            dimension_name=DIMENSION_RISK_OF_BIAS,
+            score=0.0
+        )
+
+        total_score = 0.0
+
+        # Extract selection bias
+        selection_risk = study_assessment.get('selection_bias_risk', 'unclear')
+        if selection_risk:
+            selection_score = RISK_LEVEL_SCORES.get(selection_risk.lower(), 0.625)
+            dimension_score.add_detail(
+                component='selection_bias',
+                value=f'{selection_risk} risk ({selection_score})',
+                contribution=selection_score,
+                reasoning=f'Extracted from StudyAssessmentAgent: selection_bias_risk={selection_risk}'
+            )
+            total_score += selection_score
+
+        # Extract performance bias
+        performance_risk = study_assessment.get('performance_bias_risk', 'unclear')
+        if performance_risk:
+            performance_score = RISK_LEVEL_SCORES.get(performance_risk.lower(), 0.625)
+            dimension_score.add_detail(
+                component='performance_bias',
+                value=f'{performance_risk} risk ({performance_score})',
+                contribution=performance_score,
+                reasoning=f'Extracted from StudyAssessmentAgent: performance_bias_risk={performance_risk}'
+            )
+            total_score += performance_score
+
+        # Extract detection bias
+        detection_risk = study_assessment.get('detection_bias_risk', 'unclear')
+        if detection_risk:
+            detection_score = RISK_LEVEL_SCORES.get(detection_risk.lower(), 0.625)
+            dimension_score.add_detail(
+                component='detection_bias',
+                value=f'{detection_risk} risk ({detection_score})',
+                contribution=detection_score,
+                reasoning=f'Extracted from StudyAssessmentAgent: detection_bias_risk={detection_risk}'
+            )
+            total_score += detection_score
+
+        # Extract reporting bias
+        reporting_risk = study_assessment.get('reporting_bias_risk', 'unclear')
+        if reporting_risk:
+            reporting_score = RISK_LEVEL_SCORES.get(reporting_risk.lower(), 0.625)
+            dimension_score.add_detail(
+                component='reporting_bias',
+                value=f'{reporting_risk} risk ({reporting_score})',
+                contribution=reporting_score,
+                reasoning=f'Extracted from StudyAssessmentAgent: reporting_bias_risk={reporting_risk}'
+            )
+            total_score += reporting_score
+
+        dimension_score.score = min(10.0, total_score)
+
+        logger.info(
+            f"Extracted risk of bias from StudyAssessmentAgent: score={dimension_score.score:.2f}/10"
+        )
+
+        return dimension_score
+
+    except Exception as e:
+        logger.warning(f"Failed to extract RoB from StudyAssessmentAgent: {e}")
+        return None
+
+
+def create_error_dimension_score(
+    dimension_name: str,
+    error_message: str,
+    default_score: float = 5.0
+) -> DimensionScore:
+    """
+    Create a dimension score indicating an error occurred.
+
+    Args:
+        dimension_name: Name of the dimension
+        error_message: Error message to include
+        default_score: Default score to assign (default: 5.0 neutral)
+
+    Returns:
+        DimensionScore with error information
+    """
+    dimension_score = DimensionScore(
+        dimension_name=dimension_name,
+        score=default_score
+    )
+    dimension_score.add_detail(
+        component='error',
+        value='assessment_failed',
+        contribution=default_score,
+        reasoning=f'LLM assessment failed: {error_message}'
+    )
+    return dimension_score
+
+
+__all__ = [
+    'DEFAULT_MAX_TEXT_LENGTH',
+    'RISK_LEVEL_SCORES',
+    'prepare_text_for_analysis',
+    'build_methodological_quality_prompt',
+    'build_risk_of_bias_prompt',
+    'calculate_methodological_quality_score',
+    'calculate_risk_of_bias_score',
+    'extract_mq_from_study_assessment',
+    'extract_rob_from_study_assessment',
+    'create_error_dimension_score',
+]

--- a/src/bmlibrarian/agents/paper_weight_models.py
+++ b/src/bmlibrarian/agents/paper_weight_models.py
@@ -1,0 +1,355 @@
+"""
+Paper Weight Assessment Data Models
+
+This module contains the dataclasses for representing paper weight assessments:
+- AssessmentDetail: Audit trail entry for a single component
+- DimensionScore: Score for a single dimension with audit trail
+- PaperWeightResult: Complete assessment with all dimensions
+
+These models are used by PaperWeightAssessmentAgent and related modules.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+import json
+
+
+# Constants for formatting and display
+DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'  # Standard datetime format for reports
+
+# Dimension names as constants
+DIMENSION_STUDY_DESIGN = 'study_design'
+DIMENSION_SAMPLE_SIZE = 'sample_size'
+DIMENSION_METHODOLOGICAL_QUALITY = 'methodological_quality'
+DIMENSION_RISK_OF_BIAS = 'risk_of_bias'
+DIMENSION_REPLICATION_STATUS = 'replication_status'
+
+ALL_DIMENSIONS = [
+    DIMENSION_STUDY_DESIGN,
+    DIMENSION_SAMPLE_SIZE,
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
+    DIMENSION_REPLICATION_STATUS,
+]
+
+
+@dataclass
+class AssessmentDetail:
+    """
+    Audit trail entry for a single assessment component.
+
+    Provides full reproducibility by storing:
+    - What was extracted from the paper
+    - How it contributed to the dimension score
+    - Evidence text supporting the assessment
+    - LLM reasoning (for AI-based assessments)
+
+    Attributes:
+        dimension: Name of the dimension (e.g., "study_design", "sample_size")
+        component: Specific component assessed (e.g., "randomization", "blinding_type")
+        extracted_value: Value found in the paper (e.g., "double-blind", "450")
+        score_contribution: Points contributed to dimension score (0-10)
+        evidence_text: Relevant excerpt from paper (optional)
+        reasoning: AI reasoning for this score (optional)
+    """
+    dimension: str
+    component: str
+    extracted_value: Optional[str]
+    score_contribution: float
+    evidence_text: Optional[str] = None
+    reasoning: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for database storage."""
+        return {
+            'dimension': self.dimension,
+            'component': self.component,
+            'extracted_value': self.extracted_value,
+            'score_contribution': self.score_contribution,
+            'evidence_text': self.evidence_text,
+            'reasoning': self.reasoning
+        }
+
+
+@dataclass
+class DimensionScore:
+    """
+    Score for a single assessment dimension with full audit trail.
+
+    Each dimension (study design, sample size, etc.) has a final score
+    and a list of components that contributed to that score.
+
+    Attributes:
+        dimension_name: Name of this dimension
+        score: Final score for this dimension (0-10)
+        details: List of component assessments that contributed to the score
+    """
+    dimension_name: str
+    score: float
+    details: List[AssessmentDetail] = field(default_factory=list)
+
+    def add_detail(
+        self,
+        component: str,
+        value: str,
+        contribution: float,
+        evidence: Optional[str] = None,
+        reasoning: Optional[str] = None
+    ) -> None:
+        """
+        Add an audit trail entry for a component of this dimension.
+
+        Args:
+            component: Name of the component (e.g., "randomization")
+            value: Extracted value (e.g., "proper sequence generation")
+            contribution: Points contributed to dimension score
+            evidence: Supporting text from paper (optional)
+            reasoning: AI reasoning for this score (optional)
+        """
+        self.details.append(AssessmentDetail(
+            dimension=self.dimension_name,
+            component=component,
+            extracted_value=value,
+            score_contribution=contribution,
+            evidence_text=evidence,
+            reasoning=reasoning
+        ))
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            'dimension_name': self.dimension_name,
+            'score': self.score,
+            'details': [d.to_dict() for d in self.details]
+        }
+
+
+@dataclass
+class PaperWeightResult:
+    """
+    Complete paper weight assessment with full audit trail.
+
+    This is the top-level result object containing all dimension scores,
+    the final weighted score, and complete reproducibility information.
+
+    Attributes:
+        document_id: Database ID of assessed document
+        assessor_version: Version of assessment methodology
+        assessed_at: Timestamp of assessment
+        study_design: Study design dimension score
+        sample_size: Sample size dimension score
+        methodological_quality: Methodological quality dimension score
+        risk_of_bias: Risk of bias dimension score (inverted: 10=low risk)
+        replication_status: Replication status dimension score
+        final_weight: Weighted combination of all dimensions (0-10)
+        dimension_weights: Weights used to compute final_weight
+        study_type: Extracted study type (e.g., "RCT", "cohort")
+        sample_size_n: Extracted sample size (number of participants)
+    """
+    document_id: int
+    assessor_version: str
+    assessed_at: datetime
+
+    # Dimension scores
+    study_design: DimensionScore
+    sample_size: DimensionScore
+    methodological_quality: DimensionScore
+    risk_of_bias: DimensionScore
+    replication_status: DimensionScore
+
+    # Final weight
+    final_weight: float
+    dimension_weights: Dict[str, float]
+
+    # Metadata
+    study_type: Optional[str] = None
+    sample_size_n: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        """
+        Convert to flat dictionary for database storage.
+
+        Returns flattened structure matching paper_weights.assessments table schema.
+        """
+        return {
+            'document_id': self.document_id,
+            'assessor_version': self.assessor_version,
+            'assessed_at': self.assessed_at,
+            'study_design_score': self.study_design.score,
+            'sample_size_score': self.sample_size.score,
+            'methodological_quality_score': self.methodological_quality.score,
+            'risk_of_bias_score': self.risk_of_bias.score,
+            'replication_status_score': self.replication_status.score,
+            'final_weight': self.final_weight,
+            'dimension_weights': json.dumps(self.dimension_weights),
+            'study_type': self.study_type,
+            'sample_size': self.sample_size_n
+        }
+
+    def get_all_details(self) -> List[AssessmentDetail]:
+        """
+        Collect all audit trail entries from all dimensions.
+
+        Returns:
+            Flat list of all AssessmentDetail objects across all dimensions
+        """
+        all_details = []
+        for dimension_score in [
+            self.study_design,
+            self.sample_size,
+            self.methodological_quality,
+            self.risk_of_bias,
+            self.replication_status
+        ]:
+            all_details.extend(dimension_score.details)
+        return all_details
+
+    def to_markdown(self) -> str:
+        """
+        Format assessment as human-readable Markdown report.
+
+        Returns:
+            Markdown-formatted assessment report with all dimensions and audit trail
+        """
+        lines = [
+            "# Paper Weight Assessment Report",
+            "",
+            f"**Document ID:** {self.document_id}",
+            f"**Study Type:** {self.study_type or 'Unknown'}",
+            f"**Sample Size:** {self.sample_size_n or 'Not extracted'}",
+            f"**Assessed:** {self.assessed_at.strftime(DATETIME_FORMAT)}",
+            f"**Assessor Version:** {self.assessor_version}",
+            "",
+            f"## Final Weight: {self.final_weight:.2f}/10",
+            "",
+            "## Dimension Scores",
+            "",
+        ]
+
+        # Add each dimension with details
+        for dim_name, dim_score in [
+            ("Study Design", self.study_design),
+            ("Sample Size", self.sample_size),
+            ("Methodological Quality", self.methodological_quality),
+            ("Risk of Bias", self.risk_of_bias),
+            ("Replication Status", self.replication_status)
+        ]:
+            lines.append(f"### {dim_name}: {dim_score.score:.2f}/10")
+            lines.append("")
+
+            if dim_score.details:
+                for detail in dim_score.details:
+                    lines.append(f"- **{detail.component}:** {detail.extracted_value}")
+                    lines.append(f"  - Score contribution: {detail.score_contribution:.2f}")
+                    if detail.reasoning:
+                        lines.append(f"  - Reasoning: {detail.reasoning}")
+                    if detail.evidence_text:
+                        lines.append(f"  - Evidence: *\"{detail.evidence_text}\"*")
+                    lines.append("")
+            else:
+                lines.append("*No detailed breakdown available*")
+                lines.append("")
+
+        # Add dimension weights
+        lines.append("## Dimension Weights Used")
+        lines.append("")
+        for dim, weight in self.dimension_weights.items():
+            lines.append(f"- **{dim}:** {weight:.2f}")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    @classmethod
+    def from_db_row(cls, row: dict, details: List[dict]) -> 'PaperWeightResult':
+        """
+        Reconstruct PaperWeightResult from database rows.
+
+        Args:
+            row: Row from paper_weights.assessments table
+            details: Rows from paper_weights.assessment_details table
+
+        Returns:
+            Reconstructed PaperWeightResult object
+        """
+        # Parse dimension weights from JSONB
+        dimension_weights = row['dimension_weights']
+        if isinstance(dimension_weights, str):
+            dimension_weights = json.loads(dimension_weights)
+
+        # Group details by dimension
+        dimension_details: Dict[str, List[AssessmentDetail]] = {
+            DIMENSION_STUDY_DESIGN: [],
+            DIMENSION_SAMPLE_SIZE: [],
+            DIMENSION_METHODOLOGICAL_QUALITY: [],
+            DIMENSION_RISK_OF_BIAS: [],
+            DIMENSION_REPLICATION_STATUS: []
+        }
+
+        for detail in details:
+            dim = detail['dimension']
+            if dim in dimension_details:
+                dimension_details[dim].append(AssessmentDetail(
+                    dimension=detail['dimension'],
+                    component=detail['component'],
+                    extracted_value=detail['extracted_value'],
+                    score_contribution=float(detail['score_contribution']) if detail['score_contribution'] else 0.0,
+                    evidence_text=detail['evidence_text'],
+                    reasoning=detail['reasoning']
+                ))
+
+        # Create dimension scores
+        study_design = DimensionScore(
+            dimension_name=DIMENSION_STUDY_DESIGN,
+            score=float(row['study_design_score']),
+            details=dimension_details[DIMENSION_STUDY_DESIGN]
+        )
+        sample_size = DimensionScore(
+            dimension_name=DIMENSION_SAMPLE_SIZE,
+            score=float(row['sample_size_score']),
+            details=dimension_details[DIMENSION_SAMPLE_SIZE]
+        )
+        methodological_quality = DimensionScore(
+            dimension_name=DIMENSION_METHODOLOGICAL_QUALITY,
+            score=float(row['methodological_quality_score']),
+            details=dimension_details[DIMENSION_METHODOLOGICAL_QUALITY]
+        )
+        risk_of_bias = DimensionScore(
+            dimension_name=DIMENSION_RISK_OF_BIAS,
+            score=float(row['risk_of_bias_score']),
+            details=dimension_details[DIMENSION_RISK_OF_BIAS]
+        )
+        replication_status = DimensionScore(
+            dimension_name=DIMENSION_REPLICATION_STATUS,
+            score=float(row['replication_status_score']),
+            details=dimension_details[DIMENSION_REPLICATION_STATUS]
+        )
+
+        return cls(
+            document_id=row['document_id'],
+            assessor_version=row['assessor_version'],
+            assessed_at=row['assessed_at'],
+            study_design=study_design,
+            sample_size=sample_size,
+            methodological_quality=methodological_quality,
+            risk_of_bias=risk_of_bias,
+            replication_status=replication_status,
+            final_weight=float(row['final_weight']),
+            dimension_weights=dimension_weights,
+            study_type=row.get('study_type'),
+            sample_size_n=row.get('sample_size')
+        )
+
+
+__all__ = [
+    'AssessmentDetail',
+    'DimensionScore',
+    'PaperWeightResult',
+    'DATETIME_FORMAT',
+    'DIMENSION_STUDY_DESIGN',
+    'DIMENSION_SAMPLE_SIZE',
+    'DIMENSION_METHODOLOGICAL_QUALITY',
+    'DIMENSION_RISK_OF_BIAS',
+    'DIMENSION_REPLICATION_STATUS',
+    'ALL_DIMENSIONS',
+]

--- a/src/bmlibrarian/agents/paper_weight_prompts.py
+++ b/src/bmlibrarian/agents/paper_weight_prompts.py
@@ -1,0 +1,182 @@
+"""
+Paper Weight Assessment Prompts
+
+LLM prompts for methodological quality and risk of bias assessment.
+Separated from the assessor logic for maintainability.
+"""
+
+
+def build_methodological_quality_prompt(text: str) -> str:
+    """
+    Build prompt for methodological quality assessment.
+
+    Args:
+        text: Prepared document text
+
+    Returns:
+        Prompt string for LLM
+    """
+    return f"""You are an expert in biomedical research methodology. Analyze the following research paper and assess its methodological quality across six components.
+
+PAPER TEXT:
+{text}
+
+TASK:
+Analyze the methodological quality and provide assessments for each component:
+
+1. RANDOMIZATION (0-2 points):
+   - 0: No randomization or inadequate sequence generation
+   - 1: Randomization mentioned but method unclear
+   - 2: Proper random sequence generation (e.g., computer-generated, random number table)
+
+2. BLINDING (0-3 points):
+   - 0: No blinding
+   - 1: Single-blind (participants OR assessors)
+   - 2: Double-blind (participants AND assessors)
+   - 3: Triple-blind (participants, assessors, AND data analysts)
+
+3. ALLOCATION CONCEALMENT (0-1.5 points):
+   - 0: No allocation concealment or inadequate
+   - 0.75: Unclear or partially described
+   - 1.5: Proper allocation concealment (e.g., sealed envelopes, central randomization)
+
+4. PROTOCOL PREREGISTRATION (0-1.5 points):
+   - 0: No protocol registration mentioned
+   - 0.75: Protocol mentioned but not verified
+   - 1.5: Protocol clearly registered before study (e.g., ClinicalTrials.gov, registry number provided)
+
+5. ITT ANALYSIS (0-1 points):
+   - 0: No ITT analysis or per-protocol only
+   - 0.5: Modified ITT or unclear
+   - 1: Clear intention-to-treat analysis
+
+6. ATTRITION HANDLING (0-1 points):
+   - Extract dropout/attrition rate
+   - Assess quality of handling (imputation methods, sensitivity analysis)
+   - Score based on rate and handling quality
+
+OUTPUT FORMAT (JSON):
+{{
+  "randomization": {{
+    "score": <0-2>,
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "blinding": {{
+    "score": <0-3>,
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "allocation_concealment": {{
+    "score": <0-1.5>,
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "protocol_preregistration": {{
+    "score": <0-1.5>,
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "itt_analysis": {{
+    "score": <0-1>,
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "attrition_handling": {{
+    "score": <0-1>,
+    "attrition_rate": <decimal or null>,
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }}
+}}
+
+CRITICAL REQUIREMENTS:
+- Extract ONLY information that is ACTUALLY PRESENT in the text
+- DO NOT invent, assume, or fabricate any information
+- If information is unclear or not mentioned, score it as 0 and explain why
+- Be specific and evidence-based in your assessment
+- Provide exact quotes from the paper as evidence when available
+
+Provide ONLY the JSON output, no additional text."""
+
+
+def build_risk_of_bias_prompt(text: str) -> str:
+    """
+    Build prompt for risk of bias assessment.
+
+    Args:
+        text: Prepared document text
+
+    Returns:
+        Prompt string for LLM
+    """
+    return f"""You are an expert in biomedical research methodology and bias assessment. Analyze the following research paper and assess its risk of bias across four domains.
+
+PAPER TEXT:
+{text}
+
+TASK:
+Assess risk of bias using INVERTED SCALE (higher score = lower risk of bias):
+
+1. SELECTION BIAS (0-2.5 points):
+   - 0: High risk (convenience sampling, no clear criteria)
+   - 1.25: Moderate risk (some limitations in sampling)
+   - 2.5: Low risk (random/consecutive sampling, clear inclusion/exclusion criteria)
+
+2. PERFORMANCE BIAS (0-2.5 points):
+   - 0: High risk (no blinding, unstandardized interventions)
+   - 1.25: Moderate risk (partial blinding or standardization)
+   - 2.5: Low risk (proper blinding, standardized protocols)
+
+3. DETECTION BIAS (0-2.5 points):
+   - 0: High risk (unblinded outcome assessment)
+   - 1.25: Moderate risk (partially blinded or objective outcomes only)
+   - 2.5: Low risk (blinded outcome assessment for all outcomes)
+
+4. REPORTING BIAS (0-2.5 points):
+   - 0: High risk (selective reporting, outcomes not pre-specified)
+   - 1.25: Moderate risk (some evidence of selective reporting)
+   - 2.5: Low risk (all pre-specified outcomes reported, protocol available)
+
+OUTPUT FORMAT (JSON):
+{{
+  "selection_bias": {{
+    "score": <0-2.5>,
+    "risk_level": "<high|moderate|low>",
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "performance_bias": {{
+    "score": <0-2.5>,
+    "risk_level": "<high|moderate|low>",
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "detection_bias": {{
+    "score": <0-2.5>,
+    "risk_level": "<high|moderate|low>",
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }},
+  "reporting_bias": {{
+    "score": <0-2.5>,
+    "risk_level": "<high|moderate|low>",
+    "evidence": "<quote from paper>",
+    "reasoning": "<explanation>"
+  }}
+}}
+
+CRITICAL REQUIREMENTS:
+- Extract ONLY information that is ACTUALLY PRESENT in the text
+- DO NOT invent, assume, or fabricate any information
+- If information is unclear or not mentioned, assume high risk (score 0) and explain why
+- Be specific and evidence-based in your assessment
+- Provide exact quotes from the paper as evidence when available
+
+Provide ONLY the JSON output, no additional text."""
+
+
+__all__ = [
+    'build_methodological_quality_prompt',
+    'build_risk_of_bias_prompt',
+]

--- a/tests/test_paper_weight_db.py
+++ b/tests/test_paper_weight_db.py
@@ -1,0 +1,210 @@
+"""
+Tests for paper_weight_db.py
+
+Tests cover:
+- Replication score calculation
+- Database function signatures (mocked)
+- Edge cases for scoring logic
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+
+from bmlibrarian.agents.paper_weight_db import (
+    REPLICATION_SCORE_SINGLE_COMPARABLE,
+    REPLICATION_SCORE_SINGLE_HIGHER,
+    REPLICATION_SCORE_MULTIPLE_COMPARABLE,
+    REPLICATION_SCORE_MULTIPLE_HIGHER,
+    REPLICATION_SCORE_LOWER_QUALITY,
+    _calculate_replication_score,
+    _reconstruct_result_from_db,
+)
+from bmlibrarian.agents.paper_weight_models import (
+    DimensionScore,
+    PaperWeightResult,
+    DIMENSION_STUDY_DESIGN,
+    DIMENSION_SAMPLE_SIZE,
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
+    DIMENSION_REPLICATION_STATUS,
+)
+
+
+class TestCalculateReplicationScore:
+    """Tests for _calculate_replication_score function."""
+
+    def test_single_replication_comparable(self):
+        """Test score for single replication of comparable quality."""
+        score = _calculate_replication_score(1, 'comparable')
+        assert score == REPLICATION_SCORE_SINGLE_COMPARABLE
+        assert score == 5.0
+
+    def test_single_replication_higher(self):
+        """Test score for single replication of higher quality."""
+        score = _calculate_replication_score(1, 'higher')
+        assert score == REPLICATION_SCORE_SINGLE_HIGHER
+        assert score == 8.0
+
+    def test_multiple_replications_comparable(self):
+        """Test score for multiple replications of comparable quality."""
+        score = _calculate_replication_score(2, 'comparable')
+        assert score == REPLICATION_SCORE_MULTIPLE_COMPARABLE
+        assert score == 8.0
+
+        # Test with more than 2
+        score = _calculate_replication_score(5, 'comparable')
+        assert score == REPLICATION_SCORE_MULTIPLE_COMPARABLE
+
+    def test_multiple_replications_higher(self):
+        """Test score for multiple replications of higher quality."""
+        score = _calculate_replication_score(2, 'higher')
+        assert score == REPLICATION_SCORE_MULTIPLE_HIGHER
+        assert score == 10.0
+
+        # Test with more than 2
+        score = _calculate_replication_score(10, 'higher')
+        assert score == REPLICATION_SCORE_MULTIPLE_HIGHER
+
+    def test_lower_quality_replications(self):
+        """Test score for lower quality replications."""
+        score = _calculate_replication_score(1, 'lower')
+        assert score == REPLICATION_SCORE_LOWER_QUALITY
+        assert score == 3.0
+
+        score = _calculate_replication_score(3, 'lower')
+        assert score == REPLICATION_SCORE_LOWER_QUALITY
+
+    def test_unknown_quality(self):
+        """Test score for unknown quality (defaults to lower)."""
+        score = _calculate_replication_score(1, 'unknown')
+        assert score == REPLICATION_SCORE_LOWER_QUALITY
+
+
+class TestReconstructResultFromDb:
+    """Tests for _reconstruct_result_from_db function."""
+
+    def test_basic_reconstruction(self):
+        """Test basic reconstruction from database rows."""
+        assessment_row = (
+            1,  # assessment_id
+            12345,  # document_id
+            datetime(2024, 1, 15, 10, 30, 0),  # assessed_at
+            '1.0.0',  # assessor_version
+            8.0,  # study_design_score
+            7.5,  # sample_size_score
+            6.5,  # methodological_quality_score
+            7.0,  # risk_of_bias_score
+            5.0,  # replication_status_score
+            7.2,  # final_weight
+            '{"study_design": 0.25, "sample_size": 0.15}',  # dimension_weights (JSON string)
+            'rct',  # study_type
+            450  # sample_size
+        )
+        
+        detail_rows = [
+            (DIMENSION_STUDY_DESIGN, 'study_type', 'rct', 8.0, 'evidence', 'reasoning'),
+            (DIMENSION_SAMPLE_SIZE, 'extracted_n', '450', 5.3, 'n=450', 'log calculation'),
+        ]
+        
+        result = _reconstruct_result_from_db(assessment_row, detail_rows)
+        
+        assert isinstance(result, PaperWeightResult)
+        assert result.document_id == 12345
+        assert result.assessor_version == '1.0.0'
+        assert result.study_design.score == 8.0
+        assert result.sample_size.score == 7.5
+        assert result.final_weight == 7.2
+        assert result.study_type == 'rct'
+        assert result.sample_size_n == 450
+        
+        # Check details were reconstructed
+        assert len(result.study_design.details) == 1
+        assert result.study_design.details[0].extracted_value == 'rct'
+        assert len(result.sample_size.details) == 1
+
+    def test_reconstruction_with_dict_weights(self):
+        """Test reconstruction when dimension_weights is already a dict."""
+        assessment_row = (
+            1, 12345, datetime.now(), '1.0.0',
+            8.0, 7.5, 6.5, 7.0, 5.0, 7.2,
+            {'study_design': 0.25},  # Already a dict
+            'rct', 450
+        )
+        
+        result = _reconstruct_result_from_db(assessment_row, [])
+        
+        assert result.dimension_weights == {'study_design': 0.25}
+
+    def test_reconstruction_with_no_details(self):
+        """Test reconstruction with empty details."""
+        assessment_row = (
+            1, 12345, datetime.now(), '1.0.0',
+            5.0, 5.0, 5.0, 5.0, 0.0, 4.0,
+            '{}', None, None
+        )
+        
+        result = _reconstruct_result_from_db(assessment_row, [])
+        
+        assert result.study_type is None
+        assert result.sample_size_n is None
+        assert len(result.study_design.details) == 0
+
+    def test_reconstruction_filters_unknown_dimensions(self):
+        """Test that unknown dimension details are filtered out."""
+        assessment_row = (
+            1, 12345, datetime.now(), '1.0.0',
+            5.0, 5.0, 5.0, 5.0, 0.0, 4.0,
+            '{}', None, None
+        )
+        
+        detail_rows = [
+            (DIMENSION_STUDY_DESIGN, 'study_type', 'rct', 8.0, '', ''),
+            ('unknown_dimension', 'component', 'value', 1.0, '', ''),  # Should be ignored
+        ]
+        
+        result = _reconstruct_result_from_db(assessment_row, detail_rows)
+        
+        # Only study_design should have details
+        total_details = len(result.get_all_details())
+        assert total_details == 1
+
+    def test_reconstruction_handles_none_score_contribution(self):
+        """Test that None score_contribution is handled."""
+        assessment_row = (
+            1, 12345, datetime.now(), '1.0.0',
+            5.0, 5.0, 5.0, 5.0, 0.0, 4.0,
+            '{}', None, None
+        )
+        
+        detail_rows = [
+            (DIMENSION_STUDY_DESIGN, 'study_type', 'unknown', None, '', ''),  # None score
+        ]
+        
+        result = _reconstruct_result_from_db(assessment_row, detail_rows)
+        
+        assert result.study_design.details[0].score_contribution == 0.0
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_replication_score_constants(self):
+        """Test replication score constant values."""
+        assert REPLICATION_SCORE_SINGLE_COMPARABLE == 5.0
+        assert REPLICATION_SCORE_SINGLE_HIGHER == 8.0
+        assert REPLICATION_SCORE_MULTIPLE_COMPARABLE == 8.0
+        assert REPLICATION_SCORE_MULTIPLE_HIGHER == 10.0
+        assert REPLICATION_SCORE_LOWER_QUALITY == 3.0
+
+    def test_score_constants_are_in_valid_range(self):
+        """Test that all score constants are in 0-10 range."""
+        constants = [
+            REPLICATION_SCORE_SINGLE_COMPARABLE,
+            REPLICATION_SCORE_SINGLE_HIGHER,
+            REPLICATION_SCORE_MULTIPLE_COMPARABLE,
+            REPLICATION_SCORE_MULTIPLE_HIGHER,
+            REPLICATION_SCORE_LOWER_QUALITY,
+        ]
+        for const in constants:
+            assert 0.0 <= const <= 10.0

--- a/tests/test_paper_weight_extractors.py
+++ b/tests/test_paper_weight_extractors.py
@@ -1,624 +1,430 @@
-"""Tests for rule-based extractors in PaperWeightAssessmentAgent.
+"""
+Tests for paper_weight_extractors.py
 
-This module tests the study type detection and sample size extraction
-functionality implemented in Step 4 of the PaperWeight system.
+Tests cover:
+- Study type extraction from various document formats
+- Sample size extraction with different patterns
+- Power calculation detection
+- Confidence interval detection
+- Edge cases: empty text, no matches, multiple matches
 """
 
 import pytest
 import math
-from unittest.mock import patch, MagicMock
 
-
-# Mock the config loading before importing the agent
-@pytest.fixture(autouse=True)
-def mock_config():
-    """Mock configuration to avoid needing actual config files."""
-    mock_agent_config = {
-        'temperature': 0.3,
-        'top_p': 0.9,
-        'max_tokens': 3000,
-        'version': '1.0.0',
-        'dimension_weights': {
-            'study_design': 0.25,
-            'sample_size': 0.15,
-            'methodological_quality': 0.30,
-            'risk_of_bias': 0.20,
-            'replication_status': 0.10
-        },
-        'study_type_hierarchy': {
-            'systematic_review': 10.0,
-            'meta_analysis': 10.0,
-            'rct': 8.0,
-            'cohort_prospective': 6.0,
-            'cohort_retrospective': 5.0,
-            'case_control': 4.0,
-            'cross_sectional': 3.0,
-            'case_series': 2.0,
-            'case_report': 1.0
-        },
-        'study_type_keywords': {
-            'systematic_review': ['systematic review', 'systematic literature review'],
-            'meta_analysis': ['meta-analysis', 'meta analysis', 'pooled analysis'],
-            'rct': ['randomized controlled trial', 'randomised controlled trial', 'RCT',
-                   'randomized trial', 'randomised trial', 'random allocation', 'randomly assigned'],
-            'cohort_prospective': ['prospective cohort', 'prospective study', 'longitudinal cohort'],
-            'cohort_retrospective': ['retrospective cohort', 'retrospective study'],
-            'case_control': ['case-control', 'case control study'],
-            'cross_sectional': ['cross-sectional', 'cross sectional study', 'prevalence study'],
-            'case_series': ['case series', 'case-series'],
-            'case_report': ['case report', 'case study']
-        },
-        'sample_size_scoring': {
-            'log_base': 10,
-            'log_multiplier': 2.0,
-            'power_calculation_bonus': 2.0,
-            'ci_reported_bonus': 0.5
-        }
-    }
-
-    with patch('bmlibrarian.agents.paper_weight_agent.get_agent_config', return_value=mock_agent_config):
-        with patch('bmlibrarian.agents.paper_weight_agent.get_model', return_value='gpt-oss:20b'):
-            with patch('bmlibrarian.agents.paper_weight_agent.get_ollama_host', return_value='http://localhost:11434'):
-                with patch('bmlibrarian.agents.base.ollama.Client'):
-                    yield
-
-
-@pytest.fixture
-def agent(mock_config):
-    """Create agent instance for testing."""
-    from bmlibrarian.agents.paper_weight_agent import PaperWeightAssessmentAgent
-    return PaperWeightAssessmentAgent(show_model_info=False)
-
-
-class TestStudyTypeExtraction:
-    """Tests for study type extraction."""
-
-    def test_extract_study_type_rct(self, agent):
-        """Test RCT detection."""
-        document = {
-            'abstract': 'This randomized controlled trial examined the effect of...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.dimension_name == 'study_design'
-        assert result.score == 8.0  # RCT baseline
-        assert len(result.details) > 0
-        assert result.details[0].extracted_value == 'rct'
-
-    def test_extract_study_type_systematic_review(self, agent):
-        """Test systematic review detection."""
-        document = {
-            'abstract': 'This systematic review analyzed 25 studies on...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 10.0  # Systematic review
-        assert result.details[0].extracted_value == 'systematic_review'
-
-    def test_extract_study_type_meta_analysis(self, agent):
-        """Test meta-analysis detection."""
-        document = {
-            'abstract': 'We conducted a meta-analysis of 12 RCTs...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 10.0  # Meta-analysis
-        assert result.details[0].extracted_value == 'meta_analysis'
-
-    def test_extract_study_type_priority(self, agent):
-        """Test that systematic review takes priority over RCT."""
-        document = {
-            'abstract': 'This systematic review of randomized controlled trials...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 10.0  # Systematic review, not RCT
-        assert result.details[0].extracted_value == 'systematic_review'
-
-    def test_extract_study_type_prospective_cohort(self, agent):
-        """Test prospective cohort study detection."""
-        document = {
-            'abstract': 'This prospective cohort study followed 500 patients...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 6.0  # Prospective cohort
-        assert result.details[0].extracted_value == 'cohort_prospective'
-
-    def test_extract_study_type_retrospective_cohort(self, agent):
-        """Test retrospective cohort study detection."""
-        document = {
-            'abstract': 'In this retrospective study, we analyzed medical records...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 5.0  # Retrospective cohort
-        assert result.details[0].extracted_value == 'cohort_retrospective'
-
-    def test_extract_study_type_case_control(self, agent):
-        """Test case-control study detection."""
-        document = {
-            'abstract': 'A case-control study was performed to investigate...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 4.0  # Case-control
-        assert result.details[0].extracted_value == 'case_control'
-
-    def test_extract_study_type_cross_sectional(self, agent):
-        """Test cross-sectional study detection."""
-        document = {
-            'abstract': 'This cross-sectional study surveyed 1000 adults...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 3.0  # Cross-sectional
-        assert result.details[0].extracted_value == 'cross_sectional'
-
-    def test_extract_study_type_case_series(self, agent):
-        """Test case series detection."""
-        document = {
-            'abstract': 'We present a case series of 10 patients with...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 2.0  # Case series
-        assert result.details[0].extracted_value == 'case_series'
-
-    def test_extract_study_type_case_report(self, agent):
-        """Test case report detection."""
-        document = {
-            'abstract': 'This case report describes a rare presentation of...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 1.0  # Case report
-        assert result.details[0].extracted_value == 'case_report'
-
-    def test_extract_study_type_unknown(self, agent):
-        """Test handling of unknown study type."""
-        document = {
-            'abstract': 'We examined some data and found interesting results.'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.details[0].extracted_value == 'unknown'
-        assert result.score == 5.0  # Neutral score
-
-    def test_extract_study_type_from_methods(self, agent):
-        """Test study type extraction from methods section."""
-        document = {
-            'abstract': 'This study evaluated treatment outcomes.',
-            'methods_text': 'This was a randomized controlled trial with parallel groups.'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 8.0  # RCT
-        assert result.details[0].extracted_value == 'rct'
-
-    def test_extract_study_type_case_insensitive(self, agent):
-        """Test case-insensitive keyword matching."""
-        document = {
-            'abstract': 'This RANDOMIZED CONTROLLED TRIAL examined...'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.score == 8.0  # RCT
-        assert result.details[0].extracted_value == 'rct'
-
-    def test_extract_study_type_with_evidence(self, agent):
-        """Test that evidence context is extracted."""
-        document = {
-            'abstract': 'Background: Cardiovascular disease is common. Methods: This randomized controlled trial enrolled patients from 3 centers.'
-        }
-
-        result = agent._extract_study_type(document)
-
-        assert result.details[0].evidence_text is not None
-        assert 'randomized controlled trial' in result.details[0].evidence_text
-
-
-class TestSampleSizeExtraction:
-    """Tests for sample size extraction."""
-
-    def test_extract_sample_size_basic(self, agent):
-        """Test basic sample size extraction."""
-        document = {
-            'abstract': 'We enrolled n=450 participants in this study.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.dimension_name == 'sample_size'
-        assert result.details[0].extracted_value == '450'
-        # log10(450) * 2 ≈ 5.3
-        assert 5.0 <= result.score <= 6.0
-
-    def test_extract_sample_size_uppercase_n(self, agent):
-        """Test sample size extraction with uppercase N."""
-        document = {
-            'abstract': 'The total sample size was N=1000 patients.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.details[0].extracted_value == '1000'
-        # log10(1000) * 2 = 6.0
-        assert result.score == pytest.approx(6.0, abs=0.1)
-
-    def test_extract_sample_size_participants(self, agent):
-        """Test sample size extraction with 'participants' keyword."""
-        document = {
-            'abstract': 'A total of 250 participants completed the study.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.details[0].extracted_value == '250'
-
-    def test_extract_sample_size_patients(self, agent):
-        """Test sample size extraction with 'patients' keyword."""
-        document = {
-            'abstract': 'We recruited 500 patients from local clinics.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.details[0].extracted_value == '500'
-
-    def test_extract_sample_size_subjects(self, agent):
-        """Test sample size extraction with 'subjects' keyword."""
-        document = {
-            'abstract': 'The study included 300 subjects aged 18-65.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.details[0].extracted_value == '300'
-
-    def test_extract_sample_size_with_power_calc(self, agent):
-        """Test sample size extraction with power calculation bonus."""
-        document = {
-            'abstract': 'Sample size was calculated using power analysis. We enrolled n=450 participants.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        # Base score + power calculation bonus (2.0)
-        assert result.score > 7.0  # Should be ~7.3
-        assert any(d.component == 'power_calculation' for d in result.details)
-
-    def test_extract_sample_size_with_ci(self, agent):
-        """Test sample size extraction with CI reporting bonus."""
-        document = {
-            'abstract': 'We enrolled n=450 participants. The mean difference was 2.5 (95% CI: 1.2-3.8).'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        # Base score + CI bonus (0.5)
-        assert result.score > 5.3  # Base is ~5.3, should have CI bonus
-        assert any(d.component == 'ci_reporting' for d in result.details)
-
-    def test_extract_sample_size_with_both_bonuses(self, agent):
-        """Test sample size extraction with both bonuses."""
-        document = {
-            'abstract': 'Power analysis determined that n=450 participants were needed. '
-                       'Results showed significant improvement (95% CI: 1.2-3.8).'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        # Base (~5.3) + power (2.0) + CI (0.5) = ~7.8
-        assert result.score > 7.5
-        assert any(d.component == 'power_calculation' for d in result.details)
-        assert any(d.component == 'ci_reporting' for d in result.details)
-
-    def test_extract_sample_size_not_found(self, agent):
-        """Test handling when sample size not found."""
-        document = {
-            'abstract': 'We studied many participants.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.score == 0.0
-        assert result.details[0].extracted_value == 'not_found'
-
-    def test_extract_sample_size_multiple_mentions(self, agent):
-        """Test that largest sample size is selected."""
-        document = {
-            'abstract': 'We screened 1000 participants and enrolled 450 participants in the final analysis.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        # Should extract 1000, not 450
-        assert result.details[0].extracted_value == '1000'
-
-    def test_extract_sample_size_from_methods(self, agent):
-        """Test sample size extraction from methods section."""
-        document = {
-            'abstract': 'This was a clinical trial.',
-            'methods_text': 'We enrolled n=750 participants from 5 sites.'
-        }
-
-        result = agent._extract_sample_size(document)
-
-        assert result.details[0].extracted_value == '750'
-
-
-class TestSampleSizeScoring:
-    """Tests for logarithmic sample size scoring."""
-
-    def test_calculate_sample_size_score_10(self, agent):
-        """Test score for n=10."""
-        # log10(10) * 2 = 2.0
-        assert agent._calculate_sample_size_score(10) == pytest.approx(2.0, abs=0.1)
-
-    def test_calculate_sample_size_score_100(self, agent):
-        """Test score for n=100."""
-        # log10(100) * 2 = 4.0
-        assert agent._calculate_sample_size_score(100) == pytest.approx(4.0, abs=0.1)
-
-    def test_calculate_sample_size_score_1000(self, agent):
-        """Test score for n=1000."""
-        # log10(1000) * 2 = 6.0
-        assert agent._calculate_sample_size_score(1000) == pytest.approx(6.0, abs=0.1)
-
-    def test_calculate_sample_size_score_10000(self, agent):
-        """Test score for n=10000."""
-        # log10(10000) * 2 = 8.0
-        assert agent._calculate_sample_size_score(10000) == pytest.approx(8.0, abs=0.1)
-
-    def test_calculate_sample_size_score_100000(self, agent):
-        """Test score for n=100000."""
-        # log10(100000) * 2 = 10.0
-        assert agent._calculate_sample_size_score(100000) == pytest.approx(10.0, abs=0.1)
-
-    def test_calculate_sample_size_score_max_capped(self, agent):
-        """Test score is capped at 10.0 for very large n."""
-        # log10(10000000) * 2 = 14.0 -> capped to 10.0
-        assert agent._calculate_sample_size_score(10000000) == 10.0
-
-    def test_calculate_sample_size_score_zero(self, agent):
-        """Test score for n=0."""
-        assert agent._calculate_sample_size_score(0) == 0.0
-
-    def test_calculate_sample_size_score_negative(self, agent):
-        """Test score for negative n."""
-        assert agent._calculate_sample_size_score(-100) == 0.0
-
-
-class TestPowerCalculationDetection:
-    """Tests for power calculation detection."""
-
-    def test_has_power_calculation_true(self, agent):
-        """Test power calculation detection with various keywords."""
-        texts = [
-            "Sample size was determined using power calculation to detect...",
-            "A power analysis was performed...",
-            "The sample size calculation determined that...",
-            "We calculated sample size based on statistical power of 80%...",
-            "The study had 80% power to detect a 10% difference."
-        ]
-
-        for text in texts:
-            assert agent._has_power_calculation(text) is True, f"Failed for: {text}"
-
-    def test_has_power_calculation_false(self, agent):
-        """Test power calculation detection returns false for non-matching text."""
-        text_without_power = "We enrolled participants between 2020 and 2022."
-        assert agent._has_power_calculation(text_without_power) is False
-
-
-class TestCIReportingDetection:
-    """Tests for confidence interval detection."""
-
-    def test_has_ci_reporting_keyword(self, agent):
-        """Test CI detection with 'confidence interval' keyword."""
-        text = "The 95% confidence interval was [1.2, 3.4]"
-        assert agent._has_ci_reporting(text) is True
-
-    def test_has_ci_reporting_abbreviation(self, agent):
-        """Test CI detection with 'CI' abbreviation."""
-        text = "The mean difference was 2.5 (95% CI: 1.2-3.8)"
-        assert agent._has_ci_reporting(text) is True
-
-    def test_has_ci_reporting_bracket_format(self, agent):
-        """Test CI detection with bracket format."""
-        text = "The odds ratio was 1.5 [1.2, 1.8]"
-        assert agent._has_ci_reporting(text) is True
-
-    def test_has_ci_reporting_parenthesis_format(self, agent):
-        """Test CI detection with parenthesis format."""
-        text = "The hazard ratio was 0.75 (0.60-0.90)"
-        assert agent._has_ci_reporting(text) is True
-
-    def test_has_ci_reporting_false(self, agent):
-        """Test CI detection returns false when no CI present."""
-        text = "The mean difference was 2.5"
-        assert agent._has_ci_reporting(text) is False
-
-
-class TestContextExtraction:
-    """Tests for context extraction around keywords."""
-
-    def test_extract_context_basic(self, agent):
-        """Test basic context extraction."""
-        text = "This is some text before the keyword and some text after."
-        context = agent._extract_context(text, "keyword", context_chars=10)
-
-        assert "keyword" in context
-        assert context.startswith("...")
-        assert context.endswith("...")
-
-    def test_extract_context_at_start(self, agent):
-        """Test context extraction when keyword at start."""
-        text = "keyword is at the beginning of this text."
-        context = agent._extract_context(text, "keyword", context_chars=20)
-
-        assert "keyword" in context
-        assert not context.startswith("...")  # No ellipsis at start
-        assert context.endswith("...")
-
-    def test_extract_context_at_end(self, agent):
-        """Test context extraction when keyword at end."""
-        text = "This text ends with the keyword"
-        context = agent._extract_context(text, "keyword", context_chars=20)
-
-        assert "keyword" in context
-        assert context.startswith("...")
-        assert not context.endswith("...")  # No ellipsis at end
-
-    def test_extract_context_not_found(self, agent):
-        """Test context extraction when keyword not found."""
-        text = "This text does not contain the search term."
-        context = agent._extract_context(text, "missing", context_chars=20)
-
+from bmlibrarian.agents.paper_weight_extractors import (
+    STUDY_TYPE_PRIORITY,
+    DEFAULT_STUDY_TYPE_KEYWORDS,
+    DEFAULT_STUDY_TYPE_HIERARCHY,
+    SAMPLE_SIZE_PATTERNS,
+    POWER_CALCULATION_KEYWORDS,
+    CI_PATTERNS,
+    extract_text_context,
+    find_sample_size,
+    calculate_sample_size_score,
+    has_power_calculation,
+    find_power_calc_context,
+    has_ci_reporting,
+    extract_study_type,
+    extract_sample_size_dimension,
+    get_extracted_sample_size,
+    get_extracted_study_type,
+)
+from bmlibrarian.agents.paper_weight_models import DIMENSION_STUDY_DESIGN, DIMENSION_SAMPLE_SIZE
+
+
+class TestExtractTextContext:
+    """Tests for extract_text_context function."""
+
+    def test_basic_context_extraction(self):
+        """Test basic context extraction around keyword."""
+        text = "This is a randomized controlled trial with 100 participants."
+        context = extract_text_context(text, "randomized", context_chars=10)
+        
+        assert "randomized" in context
+        assert len(context) < len(text)
+
+    def test_keyword_at_start(self):
+        """Test context when keyword is at start of text."""
+        text = "RCT study design was used for this research project."
+        context = extract_text_context(text, "RCT", context_chars=20)
+        
+        assert context.startswith("RCT")
+        assert "..." in context  # Should have ellipsis at end
+
+    def test_keyword_at_end(self):
+        """Test context when keyword is at end of text."""
+        text = "The study was conducted as a double-blind RCT"
+        context = extract_text_context(text, "RCT", context_chars=20)
+        
+        assert context.endswith("RCT")
+        assert "..." in context  # Should have ellipsis at start
+
+    def test_keyword_not_found(self):
+        """Test when keyword is not found."""
+        text = "This is a cohort study."
+        context = extract_text_context(text, "randomized", context_chars=20)
+        
+        assert context == ""
+
+    def test_empty_text(self):
+        """Test with empty text."""
+        context = extract_text_context("", "keyword", context_chars=20)
         assert context == ""
 
 
-class TestAgentConfiguration:
-    """Tests for agent configuration loading."""
+class TestFindSampleSize:
+    """Tests for find_sample_size function."""
 
-    def test_agent_has_config(self, agent):
-        """Test agent has configuration loaded."""
-        assert agent.config is not None
-        assert 'dimension_weights' in agent.config
-        assert 'study_type_hierarchy' in agent.config
-        assert 'study_type_keywords' in agent.config
-        assert 'sample_size_scoring' in agent.config
+    def test_n_equals_pattern(self):
+        """Test n = 450 pattern."""
+        text = "We enrolled n = 450 participants in the study."
+        size = find_sample_size(text)
+        assert size == 450
 
-    def test_get_dimension_weights(self, agent):
-        """Test dimension weights retrieval."""
-        weights = agent.get_dimension_weights()
+    def test_N_equals_pattern(self):
+        """Test N = 450 pattern."""
+        text = "The total sample size was N = 1000."
+        size = find_sample_size(text)
+        assert size == 1000
 
-        assert weights['study_design'] == 0.25
-        assert weights['sample_size'] == 0.15
-        assert weights['methodological_quality'] == 0.30
-        assert weights['risk_of_bias'] == 0.20
-        assert weights['replication_status'] == 0.10
+    def test_participants_pattern(self):
+        """Test '450 participants' pattern."""
+        text = "A total of 250 participants were recruited."
+        size = find_sample_size(text)
+        assert size == 250
 
-    def test_dimension_weights_sum_to_one(self, agent):
-        """Test dimension weights sum to 1.0."""
-        weights = agent.get_dimension_weights()
-        total = sum(weights.values())
+    def test_patients_pattern(self):
+        """Test '450 patients' pattern."""
+        text = "We analyzed data from 300 patients."
+        size = find_sample_size(text)
+        assert size == 300
 
-        assert total == pytest.approx(1.0, abs=0.01)
+    def test_sample_size_of_pattern(self):
+        """Test 'sample size of 450' pattern."""
+        text = "The study had a sample size of 500."
+        size = find_sample_size(text)
+        assert size == 500
 
-    def test_agent_version(self, agent):
-        """Test agent has version attribute."""
-        assert hasattr(agent, 'version')
-        assert agent.version == '1.0.0'
+    def test_multiple_matches_returns_largest(self):
+        """Test that largest value is returned when multiple matches."""
+        text = "We enrolled 100 participants in group A and 150 participants in group B, for a total of 250 participants."
+        size = find_sample_size(text)
+        assert size == 250
 
-    def test_agent_type(self, agent):
-        """Test agent type identifier."""
-        assert agent.get_agent_type() == "PaperWeightAssessmentAgent"
+    def test_no_match(self):
+        """Test when no sample size found."""
+        text = "This study examined the effects of treatment."
+        size = find_sample_size(text)
+        assert size is None
+
+    def test_filter_unrealistic_values(self):
+        """Test that unrealistic values are filtered."""
+        text = "The year 2020 and n = 50 participants."
+        size = find_sample_size(text)
+        assert size == 50  # 2020 should be filtered out by patterns
+
+    def test_min_n_filter(self):
+        """Test minimum sample size filter."""
+        text = "n = 3 patients were examined."
+        size = find_sample_size(text, min_n=5)
+        assert size is None
+
+    def test_max_n_filter(self):
+        """Test maximum sample size filter."""
+        text = "n = 5000000 records."
+        size = find_sample_size(text, max_n=1000000)
+        assert size is None
 
 
-class TestEdgeCases:
-    """Tests for edge cases and boundary conditions."""
+class TestCalculateSampleSizeScore:
+    """Tests for calculate_sample_size_score function."""
 
-    def test_empty_abstract(self, agent):
-        """Test handling of empty abstract."""
-        document = {'abstract': ''}
+    def test_basic_calculation(self):
+        """Test basic logarithmic calculation."""
+        # log10(100) = 2, * 2.0 = 4.0
+        score = calculate_sample_size_score(100, log_multiplier=2.0)
+        assert abs(score - 4.0) < 0.01
 
-        study_result = agent._extract_study_type(document)
-        sample_result = agent._extract_sample_size(document)
+    def test_large_sample(self):
+        """Test with large sample size (should cap at 10)."""
+        # log10(100000) = 5, * 2.0 = 10.0
+        score = calculate_sample_size_score(100000, log_multiplier=2.0)
+        assert score == 10.0
 
-        assert study_result.details[0].extracted_value == 'unknown'
-        assert sample_result.details[0].extracted_value == 'not_found'
+    def test_very_large_sample_caps_at_10(self):
+        """Test that score caps at 10."""
+        score = calculate_sample_size_score(1000000, log_multiplier=2.0)
+        assert score == 10.0
 
-    def test_none_abstract(self, agent):
-        """Test handling of None abstract."""
-        document = {'abstract': None}
+    def test_zero_sample(self):
+        """Test with zero sample size."""
+        score = calculate_sample_size_score(0)
+        assert score == 0.0
 
-        study_result = agent._extract_study_type(document)
-        sample_result = agent._extract_sample_size(document)
+    def test_negative_sample(self):
+        """Test with negative sample size."""
+        score = calculate_sample_size_score(-10)
+        assert score == 0.0
 
-        assert study_result.details[0].extracted_value == 'unknown'
-        assert sample_result.details[0].extracted_value == 'not_found'
+    def test_custom_multiplier(self):
+        """Test with custom multiplier."""
+        # log10(100) = 2, * 3.0 = 6.0
+        score = calculate_sample_size_score(100, log_multiplier=3.0)
+        assert abs(score - 6.0) < 0.01
 
-    def test_missing_abstract_key(self, agent):
-        """Test handling of missing abstract key."""
-        document = {}
 
-        study_result = agent._extract_study_type(document)
-        sample_result = agent._extract_sample_size(document)
+class TestHasPowerCalculation:
+    """Tests for has_power_calculation function."""
 
-        assert study_result.details[0].extracted_value == 'unknown'
-        assert sample_result.details[0].extracted_value == 'not_found'
+    def test_power_calculation_present(self):
+        """Test detection of power calculation."""
+        text = "A power calculation was performed to determine the sample size."
+        assert has_power_calculation(text) is True
 
-    def test_very_small_sample_size(self, agent):
-        """Test sample sizes below threshold are ignored."""
+    def test_power_analysis_present(self):
+        """Test detection of power analysis."""
+        text = "Power analysis indicated we needed 200 participants."
+        assert has_power_calculation(text) is True
+
+    def test_sample_size_calculation_present(self):
+        """Test detection of sample size calculation."""
+        text = "The sample size calculation showed 150 patients were required."
+        assert has_power_calculation(text) is True
+
+    def test_case_insensitive(self):
+        """Test case insensitive matching."""
+        text = "POWER CALCULATION was done a priori."
+        assert has_power_calculation(text) is True
+
+    def test_not_present(self):
+        """Test when power calculation not mentioned."""
+        text = "We enrolled 100 participants in the study."
+        assert has_power_calculation(text) is False
+
+
+class TestHasCiReporting:
+    """Tests for has_ci_reporting function."""
+
+    def test_confidence_interval_text(self):
+        """Test detection of 'confidence interval'."""
+        text = "The 95% confidence interval was 1.2 to 3.4."
+        assert has_ci_reporting(text) is True
+
+    def test_ci_abbreviation(self):
+        """Test detection of CI abbreviation."""
+        text = "HR 1.5 (95% CI 1.1-2.0)"
+        assert has_ci_reporting(text) is True
+
+    def test_bracket_notation(self):
+        """Test detection of bracket notation [1.2, 3.4]."""
+        text = "The mean was 5.0 [3.2, 6.8]."
+        assert has_ci_reporting(text) is True
+
+    def test_not_present(self):
+        """Test when CI not reported."""
+        text = "The mean was 5.0 with SD of 1.2."
+        assert has_ci_reporting(text) is False
+
+
+class TestExtractStudyType:
+    """Tests for extract_study_type function."""
+
+    def test_rct_detection(self):
+        """Test RCT detection."""
+        document = {'abstract': 'This was a randomized controlled trial of aspirin.'}
+        result = extract_study_type(document)
+        
+        assert result.dimension_name == DIMENSION_STUDY_DESIGN
+        assert result.score == 8.0  # RCT score from hierarchy
+        assert len(result.details) == 1
+        assert result.details[0].extracted_value == 'rct'
+
+    def test_systematic_review_detection(self):
+        """Test systematic review detection (highest priority)."""
+        document = {'abstract': 'This systematic review examines evidence from RCTs.'}
+        result = extract_study_type(document)
+        
+        assert result.score == 10.0
+        assert result.details[0].extracted_value == 'systematic_review'
+
+    def test_meta_analysis_detection(self):
+        """Test meta-analysis detection."""
+        document = {'abstract': 'We conducted a meta-analysis of 15 studies.'}
+        result = extract_study_type(document)
+        
+        assert result.score == 10.0
+        assert result.details[0].extracted_value == 'meta_analysis'
+
+    def test_cohort_prospective_detection(self):
+        """Test prospective cohort detection."""
+        document = {'abstract': 'This prospective cohort study followed 1000 patients.'}
+        result = extract_study_type(document)
+        
+        assert result.score == 6.0
+        assert result.details[0].extracted_value == 'cohort_prospective'
+
+    def test_case_control_detection(self):
+        """Test case-control detection."""
+        document = {'abstract': 'We conducted a case-control study.'}
+        result = extract_study_type(document)
+        
+        assert result.score == 4.0
+        assert result.details[0].extracted_value == 'case_control'
+
+    def test_unknown_study_type(self):
+        """Test when no study type detected."""
+        document = {'abstract': 'We examined the effects of treatment.'}
+        result = extract_study_type(document)
+        
+        assert result.score == 5.0  # Neutral score
+        assert result.details[0].extracted_value == 'unknown'
+
+    def test_priority_order(self):
+        """Test that higher priority study types are detected first."""
+        # Both RCT and meta-analysis mentioned, meta-analysis should win
+        document = {'abstract': 'This meta-analysis included 10 randomized controlled trials.'}
+        result = extract_study_type(document)
+        
+        # meta_analysis comes before rct in priority
+        assert result.details[0].extracted_value in ['systematic_review', 'meta_analysis']
+
+    def test_methods_text_searched(self):
+        """Test that methods_text is also searched."""
         document = {
-            'abstract': 'We studied n=3 patients in this pilot study.'
+            'abstract': 'We studied 100 patients.',
+            'methods_text': 'This was a randomized controlled trial.'
         }
+        result = extract_study_type(document)
+        
+        assert result.details[0].extracted_value == 'rct'
 
-        result = agent._extract_sample_size(document)
+    def test_empty_document(self):
+        """Test with empty document."""
+        document = {'abstract': ''}
+        result = extract_study_type(document)
+        
+        assert result.score == 5.0
+        assert result.details[0].extracted_value == 'unknown'
 
-        # n=3 is below threshold of 5
+    def test_none_abstract(self):
+        """Test with None abstract."""
+        document = {'abstract': None}
+        result = extract_study_type(document)
+        
+        assert result.score == 5.0
+
+
+class TestExtractSampleSizeDimension:
+    """Tests for extract_sample_size_dimension function."""
+
+    def test_basic_extraction(self):
+        """Test basic sample size extraction."""
+        document = {'abstract': 'We enrolled n = 450 participants.'}
+        result = extract_sample_size_dimension(document)
+        
+        assert result.dimension_name == DIMENSION_SAMPLE_SIZE
+        assert result.score > 0
+        assert len(result.details) >= 1
+        assert result.details[0].extracted_value == '450'
+
+    def test_with_power_calculation_bonus(self):
+        """Test that power calculation adds bonus."""
+        document = {
+            'abstract': 'We enrolled n = 100 participants. A power calculation showed 80% power.'
+        }
+        result = extract_sample_size_dimension(document)
+        
+        # Should have both extracted_n and power_calculation details
+        components = [d.component for d in result.details]
+        assert 'extracted_n' in components
+        assert 'power_calculation' in components
+
+    def test_with_ci_reporting_bonus(self):
+        """Test that CI reporting adds bonus."""
+        document = {
+            'abstract': 'We enrolled n = 100 participants. The 95% CI was 1.2-3.4.'
+        }
+        result = extract_sample_size_dimension(document)
+        
+        components = [d.component for d in result.details]
+        assert 'ci_reporting' in components
+
+    def test_no_sample_size_found(self):
+        """Test when no sample size found."""
+        document = {'abstract': 'This study examined treatment effects.'}
+        result = extract_sample_size_dimension(document)
+        
+        assert result.score == 0.0
         assert result.details[0].extracted_value == 'not_found'
 
-    def test_very_large_sample_size(self, agent):
-        """Test very large sample sizes are handled correctly."""
-        document = {
-            'abstract': 'This population study included 500000 participants.'
+    def test_custom_scoring_config(self):
+        """Test with custom scoring configuration."""
+        document = {'abstract': 'We enrolled n = 100 participants.'}
+        config = {
+            'log_multiplier': 3.0,
+            'power_calculation_bonus': 1.0,
+            'ci_reported_bonus': 0.25
         }
+        result = extract_sample_size_dimension(document, scoring_config=config)
+        
+        # log10(100) * 3.0 = 6.0
+        assert abs(result.score - 6.0) < 0.1
 
-        result = agent._extract_sample_size(document)
 
-        assert result.details[0].extracted_value == '500000'
-        assert result.score == 10.0  # Capped at max (log10(500000)*2 = 11.4 -> capped to 10)
+class TestGetExtractedValues:
+    """Tests for get_extracted_sample_size and get_extracted_study_type."""
 
+    def test_get_extracted_sample_size(self):
+        """Test extracting sample size from DimensionScore."""
+        document = {'abstract': 'We enrolled n = 200 participants.'}
+        result = extract_sample_size_dimension(document)
+        
+        sample_size = get_extracted_sample_size(result)
+        assert sample_size == 200
 
-class TestDimensionScoreIntegration:
-    """Tests for DimensionScore dataclass integration."""
+    def test_get_extracted_sample_size_not_found(self):
+        """Test when sample size not found."""
+        document = {'abstract': 'No sample size mentioned.'}
+        result = extract_sample_size_dimension(document)
+        
+        sample_size = get_extracted_sample_size(result)
+        assert sample_size is None
 
-    def test_study_type_returns_dimension_score(self, agent):
-        """Test _extract_study_type returns proper DimensionScore."""
-        from bmlibrarian.agents.paper_weight_agent import DimensionScore
-
+    def test_get_extracted_study_type(self):
+        """Test extracting study type from DimensionScore."""
         document = {'abstract': 'This was a randomized controlled trial.'}
-        result = agent._extract_study_type(document)
+        result = extract_study_type(document)
+        
+        study_type = get_extracted_study_type(result)
+        assert study_type == 'rct'
 
-        assert isinstance(result, DimensionScore)
-        assert result.dimension_name == 'study_design'
-        assert 0 <= result.score <= 10
+    def test_get_extracted_study_type_unknown(self):
+        """Test when study type is unknown."""
+        document = {'abstract': 'We studied patients.'}
+        result = extract_study_type(document)
+        
+        study_type = get_extracted_study_type(result)
+        assert study_type == 'unknown'
 
-    def test_sample_size_returns_dimension_score(self, agent):
-        """Test _extract_sample_size returns proper DimensionScore."""
-        from bmlibrarian.agents.paper_weight_agent import DimensionScore
 
-        document = {'abstract': 'We enrolled n=100 participants.'}
-        result = agent._extract_sample_size(document)
+class TestConstants:
+    """Tests for module constants."""
 
-        assert isinstance(result, DimensionScore)
-        assert result.dimension_name == 'sample_size'
-        assert 0 <= result.score <= 10
+    def test_study_type_priority(self):
+        """Test study type priority order."""
+        assert STUDY_TYPE_PRIORITY[0] == 'systematic_review'
+        assert STUDY_TYPE_PRIORITY[1] == 'meta_analysis'
+        assert STUDY_TYPE_PRIORITY[2] == 'rct'
 
-    def test_dimension_score_to_dict(self, agent):
-        """Test DimensionScore serialization."""
-        document = {'abstract': 'This randomized controlled trial enrolled n=450 participants.'}
+    def test_default_keywords_coverage(self):
+        """Test that all priority types have keywords."""
+        for study_type in STUDY_TYPE_PRIORITY:
+            assert study_type in DEFAULT_STUDY_TYPE_KEYWORDS
+            assert len(DEFAULT_STUDY_TYPE_KEYWORDS[study_type]) > 0
 
-        study_result = agent._extract_study_type(document)
-        study_dict = study_result.to_dict()
-
-        assert 'dimension_name' in study_dict
-        assert 'score' in study_dict
-        assert 'details' in study_dict
-        assert isinstance(study_dict['details'], list)
+    def test_hierarchy_scores(self):
+        """Test hierarchy score values."""
+        assert DEFAULT_STUDY_TYPE_HIERARCHY['systematic_review'] == 10.0
+        assert DEFAULT_STUDY_TYPE_HIERARCHY['rct'] == 8.0
+        assert DEFAULT_STUDY_TYPE_HIERARCHY['case_report'] == 1.0

--- a/tests/test_paper_weight_llm_assessors.py
+++ b/tests/test_paper_weight_llm_assessors.py
@@ -1,641 +1,387 @@
-"""Tests for LLM-based assessors in PaperWeightAssessmentAgent
+"""
+Tests for paper_weight_llm_assessors.py
 
-This module tests the methodological quality and risk of bias assessors
-that use LLM analysis for nuanced paper evaluation.
-
-Tests are organized into:
-1. Unit tests (fast, no external dependencies)
-2. Integration tests (require Ollama, marked with pytest.mark.slow)
+Tests cover:
+- Text preparation for LLM analysis
+- Methodological quality score calculation
+- Risk of bias score calculation
+- StudyAssessmentAgent integration functions
+- Error handling and edge cases
 """
 
 import pytest
-import json
-from unittest.mock import Mock, patch, MagicMock
 
-from bmlibrarian.agents.paper_weight_agent import (
-    PaperWeightAssessmentAgent,
-    DimensionScore,
-    AssessmentDetail
+from bmlibrarian.agents.paper_weight_llm_assessors import (
+    DEFAULT_MAX_TEXT_LENGTH,
+    RISK_LEVEL_SCORES,
+    RANDOMIZATION_SCORE,
+    DOUBLE_BLIND_SCORE,
+    SINGLE_BLIND_SCORE,
+    REMAINING_COMPONENTS_MAX,
+    QUALITY_SCORE_MAX,
+    prepare_text_for_analysis,
+    calculate_methodological_quality_score,
+    calculate_risk_of_bias_score,
+    extract_mq_from_study_assessment,
+    extract_rob_from_study_assessment,
+    create_error_dimension_score,
+)
+from bmlibrarian.agents.paper_weight_models import (
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
 )
 
 
-# ============================================================================
-# Fixtures
-# ============================================================================
+class TestPrepareTextForAnalysis:
+    """Tests for prepare_text_for_analysis function."""
 
-@pytest.fixture
-def agent():
-    """Create agent instance for testing (without connecting to Ollama)."""
-    with patch.object(PaperWeightAssessmentAgent, 'test_connection', return_value=True):
-        agent = PaperWeightAssessmentAgent(show_model_info=False)
-    return agent
-
-
-@pytest.fixture
-def sample_rct_document():
-    """Sample RCT document for testing."""
-    return {
-        'title': 'Effect of Exercise on Cardiovascular Health: A Randomized Controlled Trial',
-        'abstract': '''This double-blind randomized controlled trial examined
-        the effect of exercise on cardiovascular outcomes. Participants were
-        randomly assigned using computer-generated random numbers to either
-        exercise or control groups. Allocation was concealed using sealed
-        envelopes. The study was registered at ClinicalTrials.gov (NCT12345678)
-        before enrollment. We enrolled 450 participants and followed them for
-        12 months. Outcome assessors were blinded to group assignment.
-        Analysis was conducted using intention-to-treat principles.
-        The dropout rate was 5%. Missing data were handled using multiple
-        imputation. Confidence intervals are reported for all primary outcomes.''',
-        'full_text': ''
-    }
-
-
-@pytest.fixture
-def sample_observational_document():
-    """Sample observational study document for testing."""
-    return {
-        'title': 'Association Between Diet and Cancer Risk: A Cohort Study',
-        'abstract': '''This retrospective cohort study examined the association
-        between dietary patterns and cancer risk. We reviewed medical records
-        of 1200 patients treated at our center between 2010 and 2020.
-        Inclusion criteria were age > 18 and complete dietary records.
-        No blinding was performed. Statistical analysis used Cox proportional
-        hazards models with 95% confidence intervals reported.''',
-        'full_text': ''
-    }
-
-
-@pytest.fixture
-def sample_study_assessment():
-    """Sample StudyAssessmentAgent output for integration testing."""
-    return {
-        'study_type': 'Randomized Controlled Trial',
-        'study_design': 'Prospective, double-blinded, multi-center',
-        'quality_score': 8.5,
-        'is_prospective': True,
-        'is_retrospective': False,
-        'is_randomized': True,
-        'is_controlled': True,
-        'is_blinded': True,
-        'is_double_blinded': True,
-        'is_multi_center': True,
-        'selection_bias_risk': 'low',
-        'performance_bias_risk': 'low',
-        'detection_bias_risk': 'moderate',
-        'attrition_bias_risk': 'low',
-        'reporting_bias_risk': 'low'
-    }
-
-
-# ============================================================================
-# Unit Tests - Text Preparation
-# ============================================================================
-
-class TestTextPreparation:
-    """Tests for _prepare_text_for_analysis helper method."""
-
-    def test_prepare_text_with_abstract_only(self, agent):
-        """Test text preparation when only abstract is available."""
+    def test_basic_preparation_with_abstract(self):
+        """Test basic text preparation with abstract only."""
         document = {
             'title': 'Test Study',
-            'abstract': 'This is a test abstract about cardiovascular research.',
-            'full_text': ''
+            'abstract': 'This is the abstract text.',
+            'full_text': None
         }
+        result = prepare_text_for_analysis(document)
+        
+        assert 'TITLE: Test Study' in result
+        assert 'ABSTRACT:' in result
+        assert 'This is the abstract text.' in result
 
-        text = agent._prepare_text_for_analysis(document)
-
-        assert 'TITLE: Test Study' in text
-        assert 'ABSTRACT:' in text
-        assert 'cardiovascular research' in text
-        assert 'FULL TEXT:' not in text
-
-    def test_prepare_text_with_full_text(self, agent):
-        """Test text preparation when full text is available."""
+    def test_prefers_full_text(self):
+        """Test that full_text is preferred over abstract."""
         document = {
             'title': 'Test Study',
             'abstract': 'Short abstract.',
-            'full_text': 'This is the full text of the paper with much more detail.'
+            'full_text': 'This is the full text of the paper.'
         }
+        result = prepare_text_for_analysis(document)
+        
+        assert 'FULL TEXT:' in result
+        assert 'full text of the paper' in result
+        assert 'ABSTRACT:' not in result
 
-        text = agent._prepare_text_for_analysis(document)
-
-        assert 'TITLE: Test Study' in text
-        assert 'FULL TEXT:' in text
-        assert 'much more detail' in text
-        assert 'Short abstract' not in text  # Full text takes precedence
-
-    def test_prepare_text_truncates_long_text(self, agent):
-        """Test that long text is truncated to MAX_TEXT_LENGTH."""
-        long_abstract = 'A' * 10000  # Longer than MAX_TEXT_LENGTH
+    def test_truncation(self):
+        """Test text truncation at max_length."""
         document = {
             'title': 'Test',
-            'abstract': long_abstract,
+            'abstract': 'A' * 10000,  # Very long abstract
+            'full_text': None
+        }
+        result = prepare_text_for_analysis(document, max_length=100)
+        
+        assert len(result) <= 130  # Some buffer for truncation message
+        assert '[Text truncated...]' in result
+
+    def test_empty_document(self):
+        """Test with empty document fields."""
+        document = {
+            'title': '',
+            'abstract': '',
             'full_text': ''
         }
+        result = prepare_text_for_analysis(document)
+        
+        assert 'TITLE: ' in result
+        assert 'ABSTRACT:' in result
 
-        text = agent._prepare_text_for_analysis(document)
-
-        assert len(text) <= agent.MAX_TEXT_LENGTH + 50  # Allow for truncation message
-        assert '[Text truncated...]' in text
-
-    def test_prepare_text_handles_none_values(self, agent):
-        """Test handling of None values in document fields."""
+    def test_none_values(self):
+        """Test with None values."""
         document = {
             'title': None,
             'abstract': None,
             'full_text': None
         }
-
-        text = agent._prepare_text_for_analysis(document)
-
-        assert 'TITLE:' in text
-        assert 'ABSTRACT:' in text
+        result = prepare_text_for_analysis(document)
+        
+        assert 'TITLE: ' in result
 
 
-# ============================================================================
-# Unit Tests - Prompt Building
-# ============================================================================
+class TestCalculateMethodologicalQualityScore:
+    """Tests for calculate_methodological_quality_score function."""
 
-class TestPromptBuilding:
-    """Tests for prompt building methods."""
-
-    def test_build_methodological_quality_prompt(self, agent, sample_rct_document):
-        """Test prompt building for methodological quality."""
-        text = agent._prepare_text_for_analysis(sample_rct_document)
-        prompt = agent._build_methodological_quality_prompt(text)
-
-        # Check required elements in prompt
-        assert 'RANDOMIZATION' in prompt
-        assert 'BLINDING' in prompt
-        assert 'ALLOCATION CONCEALMENT' in prompt
-        assert 'PROTOCOL PREREGISTRATION' in prompt
-        assert 'ITT ANALYSIS' in prompt
-        assert 'ATTRITION HANDLING' in prompt
-        assert 'JSON' in prompt
-        assert 'cardiovascular' in prompt.lower()  # Document content included
-
-    def test_build_risk_of_bias_prompt(self, agent, sample_rct_document):
-        """Test prompt building for risk of bias."""
-        text = agent._prepare_text_for_analysis(sample_rct_document)
-        prompt = agent._build_risk_of_bias_prompt(text)
-
-        # Check required elements in prompt
-        assert 'SELECTION BIAS' in prompt
-        assert 'PERFORMANCE BIAS' in prompt
-        assert 'DETECTION BIAS' in prompt
-        assert 'REPORTING BIAS' in prompt
-        assert 'INVERTED SCALE' in prompt
-        assert 'JSON' in prompt
-
-
-# ============================================================================
-# Unit Tests - Score Calculation
-# ============================================================================
-
-class TestScoreCalculation:
-    """Tests for score calculation methods."""
-
-    def test_calculate_methodological_quality_score_perfect(self, agent):
-        """Test score calculation with perfect component scores."""
+    def test_full_score_components(self):
+        """Test with all components present."""
         components = {
-            "randomization": {"score": 2.0, "evidence": "computer-generated", "reasoning": "Proper method"},
-            "blinding": {"score": 3.0, "evidence": "triple-blind", "reasoning": "Excellent"},
-            "allocation_concealment": {"score": 1.5, "evidence": "sealed envelopes", "reasoning": "Proper"},
-            "protocol_preregistration": {"score": 1.5, "evidence": "NCT12345", "reasoning": "Registered"},
-            "itt_analysis": {"score": 1.0, "evidence": "ITT analysis", "reasoning": "Proper"},
-            "attrition_handling": {"score": 1.0, "evidence": "5% dropout", "reasoning": "Low attrition"}
+            'randomization': {'score': 2.0, 'evidence': 'random', 'reasoning': 'good'},
+            'blinding': {'score': 3.0, 'evidence': 'triple', 'reasoning': 'excellent'},
+            'allocation_concealment': {'score': 1.5, 'evidence': 'sealed', 'reasoning': 'ok'},
+            'protocol_preregistration': {'score': 1.5, 'evidence': 'yes', 'reasoning': 'ok'},
+            'itt_analysis': {'score': 1.0, 'evidence': 'ITT', 'reasoning': 'ok'},
+            'attrition_handling': {'score': 1.0, 'attrition_rate': 0.05, 'evidence': 'low', 'reasoning': 'ok'}
         }
-
-        result = agent._calculate_methodological_quality_score(components)
-
-        assert result.dimension_name == 'methodological_quality'
-        assert result.score == 10.0  # Perfect score
+        result = calculate_methodological_quality_score(components)
+        
+        assert result.dimension_name == DIMENSION_METHODOLOGICAL_QUALITY
+        assert result.score == 10.0  # Capped at 10
         assert len(result.details) == 6
 
-    def test_calculate_methodological_quality_score_partial(self, agent):
-        """Test score calculation with partial scores."""
+    def test_partial_components(self):
+        """Test with partial components."""
         components = {
-            "randomization": {"score": 1.0, "evidence": "mentioned", "reasoning": "Unclear"},
-            "blinding": {"score": 0.0, "evidence": "none", "reasoning": "Not blinded"},
-            "allocation_concealment": {"score": 0.0, "evidence": "", "reasoning": "Not mentioned"},
-            "protocol_preregistration": {"score": 0.0, "evidence": "", "reasoning": "Not registered"},
-            "itt_analysis": {"score": 0.5, "evidence": "modified ITT", "reasoning": "Partial"},
-            "attrition_handling": {"score": 0.5, "evidence": "10% dropout", "reasoning": "Moderate"}
+            'randomization': {'score': 2.0, 'evidence': '', 'reasoning': ''},
+            'blinding': {'score': 1.0, 'evidence': '', 'reasoning': ''}
         }
+        result = calculate_methodological_quality_score(components)
+        
+        assert result.score == 3.0
+        assert len(result.details) == 2
 
-        result = agent._calculate_methodological_quality_score(components)
+    def test_empty_components(self):
+        """Test with empty components dict."""
+        result = calculate_methodological_quality_score({})
+        
+        assert result.score == 0.0
+        assert len(result.details) == 0
 
-        assert result.dimension_name == 'methodological_quality'
-        assert result.score == 2.0  # 1.0 + 0 + 0 + 0 + 0.5 + 0.5
-        assert len(result.details) == 6
-
-    def test_calculate_methodological_quality_score_with_attrition_rate(self, agent):
-        """Test that attrition rate is included in value string."""
+    def test_attrition_rate_in_value(self):
+        """Test that attrition rate appears in value field."""
         components = {
-            "attrition_handling": {
-                "score": 0.8,
-                "attrition_rate": 0.05,
-                "evidence": "5% dropout",
-                "reasoning": "Low attrition"
-            }
+            'attrition_handling': {'score': 0.5, 'attrition_rate': 0.15, 'evidence': '', 'reasoning': ''}
         }
+        result = calculate_methodological_quality_score(components)
+        
+        assert 'attrition rate: 0.15' in result.details[0].extracted_value
 
-        result = agent._calculate_methodological_quality_score(components)
-
+    def test_non_dict_components_skipped(self):
+        """Test that non-dict component values are skipped."""
+        components = {
+            'randomization': {'score': 2.0, 'evidence': '', 'reasoning': ''},
+            'invalid': 'not a dict',
+            'also_invalid': 123
+        }
+        result = calculate_methodological_quality_score(components)
+        
+        assert result.score == 2.0
         assert len(result.details) == 1
-        assert 'attrition rate: 0.05' in result.details[0].extracted_value
 
-    def test_calculate_risk_of_bias_score_low_risk(self, agent):
-        """Test risk of bias score calculation with low risk."""
+
+class TestCalculateRiskOfBiasScore:
+    """Tests for calculate_risk_of_bias_score function."""
+
+    def test_low_risk_all_domains(self):
+        """Test with low risk in all domains."""
         components = {
-            "selection_bias": {"score": 2.5, "risk_level": "low", "evidence": "random", "reasoning": "Good"},
-            "performance_bias": {"score": 2.5, "risk_level": "low", "evidence": "blinded", "reasoning": "Good"},
-            "detection_bias": {"score": 2.5, "risk_level": "low", "evidence": "blinded", "reasoning": "Good"},
-            "reporting_bias": {"score": 2.5, "risk_level": "low", "evidence": "protocol", "reasoning": "Good"}
+            'selection_bias': {'score': 2.5, 'risk_level': 'low', 'evidence': '', 'reasoning': ''},
+            'performance_bias': {'score': 2.5, 'risk_level': 'low', 'evidence': '', 'reasoning': ''},
+            'detection_bias': {'score': 2.5, 'risk_level': 'low', 'evidence': '', 'reasoning': ''},
+            'reporting_bias': {'score': 2.5, 'risk_level': 'low', 'evidence': '', 'reasoning': ''}
         }
-
-        result = agent._calculate_risk_of_bias_score(components)
-
-        assert result.dimension_name == 'risk_of_bias'
-        assert result.score == 10.0  # Perfect score (low risk)
+        result = calculate_risk_of_bias_score(components)
+        
+        assert result.dimension_name == DIMENSION_RISK_OF_BIAS
+        assert result.score == 10.0
         assert len(result.details) == 4
 
-    def test_calculate_risk_of_bias_score_high_risk(self, agent):
-        """Test risk of bias score calculation with high risk."""
+    def test_high_risk_components(self):
+        """Test with high risk components."""
         components = {
-            "selection_bias": {"score": 0, "risk_level": "high", "evidence": "convenience", "reasoning": "Poor"},
-            "performance_bias": {"score": 0, "risk_level": "high", "evidence": "unblinded", "reasoning": "Poor"},
-            "detection_bias": {"score": 0, "risk_level": "high", "evidence": "unblinded", "reasoning": "Poor"},
-            "reporting_bias": {"score": 0, "risk_level": "high", "evidence": "selective", "reasoning": "Poor"}
+            'selection_bias': {'score': 0.0, 'risk_level': 'high', 'evidence': '', 'reasoning': ''},
+            'performance_bias': {'score': 0.0, 'risk_level': 'high', 'evidence': '', 'reasoning': ''}
         }
+        result = calculate_risk_of_bias_score(components)
+        
+        assert result.score == 0.0
 
-        result = agent._calculate_risk_of_bias_score(components)
-
-        assert result.score == 0.0  # Zero score (high risk)
-        assert all('high risk' in d.extracted_value for d in result.details)
-
-    def test_calculate_score_handles_non_dict_components(self, agent):
-        """Test that non-dict components are skipped."""
+    def test_risk_level_in_value(self):
+        """Test that risk level appears in value field."""
         components = {
-            "randomization": {"score": 2.0, "evidence": "test", "reasoning": "test"},
-            "invalid_component": "not a dict",  # Should be skipped
-            "another_invalid": 123  # Should be skipped
+            'selection_bias': {'score': 1.25, 'risk_level': 'moderate', 'evidence': '', 'reasoning': ''}
         }
+        result = calculate_risk_of_bias_score(components)
+        
+        assert 'moderate risk' in result.details[0].extracted_value
 
-        result = agent._calculate_methodological_quality_score(components)
+    def test_score_capped_at_10(self):
+        """Test that score is capped at 10."""
+        components = {
+            'selection_bias': {'score': 5.0, 'risk_level': 'low', 'evidence': '', 'reasoning': ''},
+            'performance_bias': {'score': 5.0, 'risk_level': 'low', 'evidence': '', 'reasoning': ''},
+            'detection_bias': {'score': 5.0, 'risk_level': 'low', 'evidence': '', 'reasoning': ''}
+        }
+        result = calculate_risk_of_bias_score(components)
+        
+        assert result.score == 10.0
 
-        assert len(result.details) == 1
-        assert result.score == 2.0
 
+class TestExtractMQFromStudyAssessment:
+    """Tests for extract_mq_from_study_assessment function."""
 
-# ============================================================================
-# Unit Tests - StudyAssessmentAgent Integration
-# ============================================================================
-
-class TestStudyAssessmentIntegration:
-    """Tests for StudyAssessmentAgent integration helpers."""
-
-    def test_extract_mq_from_study_assessment_high_quality(self, agent, sample_study_assessment):
-        """Test MQ extraction from high-quality RCT assessment."""
-        document = {'title': 'Test'}
-
-        result = agent._extract_mq_from_study_assessment(sample_study_assessment, document)
-
+    def test_randomized_double_blind(self):
+        """Test extraction with randomized and double-blind study."""
+        study_assessment = {
+            'is_randomized': True,
+            'is_double_blinded': True,
+            'is_blinded': True,
+            'quality_score': 8.0
+        }
+        result = extract_mq_from_study_assessment(study_assessment)
+        
         assert result is not None
-        assert result.dimension_name == 'methodological_quality'
-        assert result.score > 5.0  # High quality RCT should score well
-        assert len(result.details) >= 3  # At least randomization, blinding, other_components
+        assert result.dimension_name == DIMENSION_METHODOLOGICAL_QUALITY
+        # 2.0 (random) + 2.0 (double-blind) + 4.0 (quality estimate) = 8.0
+        expected_score = RANDOMIZATION_SCORE + DOUBLE_BLIND_SCORE + (8.0 / QUALITY_SCORE_MAX * REMAINING_COMPONENTS_MAX)
+        assert abs(result.score - expected_score) < 0.1
 
-        # Check specific components
-        component_names = [d.component for d in result.details]
-        assert 'randomization' in component_names
-        assert 'blinding' in component_names
+    def test_randomized_single_blind(self):
+        """Test extraction with randomized and single-blind study."""
+        study_assessment = {
+            'is_randomized': True,
+            'is_double_blinded': False,
+            'is_blinded': True,
+            'quality_score': 6.0
+        }
+        result = extract_mq_from_study_assessment(study_assessment)
+        
+        assert result is not None
+        # 2.0 (random) + 1.0 (single-blind) + 3.0 (quality estimate) = 6.0
+        expected_score = RANDOMIZATION_SCORE + SINGLE_BLIND_SCORE + (6.0 / QUALITY_SCORE_MAX * REMAINING_COMPONENTS_MAX)
+        assert abs(result.score - expected_score) < 0.1
 
-    def test_extract_mq_from_study_assessment_no_randomization(self, agent):
-        """Test MQ extraction when study is not randomized."""
+    def test_not_randomized_not_blinded(self):
+        """Test extraction with non-randomized, non-blinded study."""
         study_assessment = {
             'is_randomized': False,
-            'is_blinded': False,
             'is_double_blinded': False,
-            'quality_score': 4.0
+            'is_blinded': False,
+            'quality_score': 5.0
         }
-        document = {'title': 'Test'}
-
-        result = agent._extract_mq_from_study_assessment(study_assessment, document)
-
+        result = extract_mq_from_study_assessment(study_assessment)
+        
         assert result is not None
-        # Score should be lower due to no randomization or blinding
-        randomization_detail = next(d for d in result.details if d.component == 'randomization')
-        assert randomization_detail.score_contribution == 0.0
+        # 0 + 0 + 2.5 (quality estimate) = 2.5
+        expected_score = 0 + 0 + (5.0 / QUALITY_SCORE_MAX * REMAINING_COMPONENTS_MAX)
+        assert abs(result.score - expected_score) < 0.1
 
-    def test_extract_rob_from_study_assessment(self, agent, sample_study_assessment):
-        """Test RoB extraction from StudyAssessmentAgent output."""
-        document = {'title': 'Test'}
-
-        result = agent._extract_rob_from_study_assessment(sample_study_assessment, document)
-
+    def test_missing_fields_use_defaults(self):
+        """Test that missing fields use default values."""
+        study_assessment = {}
+        result = extract_mq_from_study_assessment(study_assessment)
+        
         assert result is not None
-        assert result.dimension_name == 'risk_of_bias'
-        assert len(result.details) == 4  # 4 bias types
+        # Should use defaults: not randomized, not blinded, quality_score=5.0
 
-        # Check that low risk gives high scores
-        for detail in result.details:
-            if 'low' in detail.extracted_value:
-                assert detail.score_contribution == 2.5
+    def test_none_quality_score(self):
+        """Test handling of None quality_score."""
+        study_assessment = {
+            'is_randomized': True,
+            'quality_score': None
+        }
+        result = extract_mq_from_study_assessment(study_assessment)
+        
+        assert result is not None
 
-    def test_extract_rob_from_study_assessment_high_risk(self, agent):
-        """Test RoB extraction with high risk bias ratings."""
+
+class TestExtractROBFromStudyAssessment:
+    """Tests for extract_rob_from_study_assessment function."""
+
+    def test_all_low_risk(self):
+        """Test extraction with all low risk domains."""
+        study_assessment = {
+            'selection_bias_risk': 'low',
+            'performance_bias_risk': 'low',
+            'detection_bias_risk': 'low',
+            'reporting_bias_risk': 'low'
+        }
+        result = extract_rob_from_study_assessment(study_assessment)
+        
+        assert result is not None
+        assert result.dimension_name == DIMENSION_RISK_OF_BIAS
+        # 4 * 2.5 = 10.0
+        assert result.score == 10.0
+
+    def test_all_high_risk(self):
+        """Test extraction with all high risk domains."""
         study_assessment = {
             'selection_bias_risk': 'high',
             'performance_bias_risk': 'high',
             'detection_bias_risk': 'high',
             'reporting_bias_risk': 'high'
         }
-        document = {'title': 'Test'}
-
-        result = agent._extract_rob_from_study_assessment(study_assessment, document)
-
+        result = extract_rob_from_study_assessment(study_assessment)
+        
         assert result is not None
-        assert result.score == 0.0  # All high risk = 0
+        assert result.score == 0.0
 
-    def test_extract_mq_handles_invalid_input(self, agent):
-        """Test that MQ extraction returns None on invalid input."""
-        result = agent._extract_mq_from_study_assessment(None, {})
+    def test_mixed_risk_levels(self):
+        """Test extraction with mixed risk levels."""
+        study_assessment = {
+            'selection_bias_risk': 'low',
+            'performance_bias_risk': 'moderate',
+            'detection_bias_risk': 'high',
+            'reporting_bias_risk': 'unclear'
+        }
+        result = extract_rob_from_study_assessment(study_assessment)
+        
+        assert result is not None
+        # 2.5 + 1.25 + 0 + 0.625 = 4.375
+        expected = RISK_LEVEL_SCORES['low'] + RISK_LEVEL_SCORES['moderate'] + RISK_LEVEL_SCORES['high'] + RISK_LEVEL_SCORES['unclear']
+        assert abs(result.score - expected) < 0.1
 
-        # Should either handle gracefully or return None
-        # The implementation catches exceptions and returns None
-        assert result is None or isinstance(result, DimensionScore)
+    def test_case_insensitive(self):
+        """Test that risk levels are case insensitive."""
+        study_assessment = {
+            'selection_bias_risk': 'LOW',
+            'performance_bias_risk': 'MODERATE'
+        }
+        result = extract_rob_from_study_assessment(study_assessment)
+        
+        assert result is not None
+        assert result.score > 0
+
+    def test_missing_fields(self):
+        """Test with missing risk fields."""
+        study_assessment = {}
+        result = extract_rob_from_study_assessment(study_assessment)
+        
+        assert result is not None
 
 
-# ============================================================================
-# Unit Tests - Error Handling
-# ============================================================================
+class TestCreateErrorDimensionScore:
+    """Tests for create_error_dimension_score function."""
 
-class TestErrorHandling:
-    """Tests for error handling in LLM assessors."""
-
-    def test_assess_mq_returns_degraded_score_on_error(self, agent, sample_rct_document):
-        """Test that methodological quality assessment returns neutral score on error."""
-        with patch.object(agent, '_generate_and_parse_json', side_effect=Exception("LLM error")):
-            result = agent._assess_methodological_quality(sample_rct_document)
-
-        assert result.dimension_name == 'methodological_quality'
-        assert result.score == 5.0  # Neutral degraded score
+    def test_basic_error_score(self):
+        """Test creating error dimension score."""
+        result = create_error_dimension_score(
+            DIMENSION_METHODOLOGICAL_QUALITY,
+            'LLM timeout'
+        )
+        
+        assert result.dimension_name == DIMENSION_METHODOLOGICAL_QUALITY
+        assert result.score == 5.0  # Default neutral score
         assert len(result.details) == 1
         assert result.details[0].component == 'error'
-        assert 'LLM error' in result.details[0].reasoning
+        assert 'LLM timeout' in result.details[0].reasoning
 
-    def test_assess_rob_returns_degraded_score_on_error(self, agent, sample_rct_document):
-        """Test that risk of bias assessment returns neutral score on error."""
-        with patch.object(agent, '_generate_and_parse_json', side_effect=Exception("LLM error")):
-            result = agent._assess_risk_of_bias(sample_rct_document)
-
-        assert result.dimension_name == 'risk_of_bias'
-        assert result.score == 5.0  # Neutral degraded score
-        assert result.details[0].component == 'error'
-
-
-# ============================================================================
-# Unit Tests - JSON Response Parsing
-# ============================================================================
-
-class TestJsonParsing:
-    """Tests for JSON response parsing from LLM."""
-
-    def test_parse_methodological_quality_response_with_markdown(self, agent):
-        """Test JSON parsing from markdown code block response."""
-        response_with_markdown = '''```json
-        {
-          "randomization": {"score": 2.0, "evidence": "computer-generated", "reasoning": "Proper method"},
-          "blinding": {"score": 2.0, "evidence": "double-blind", "reasoning": "Participants and assessors"}
-        }
-        ```'''
-
-        # Use the base agent's _parse_json_response method
-        result = agent._parse_json_response(response_with_markdown)
-
-        assert result['randomization']['score'] == 2.0
-        assert result['blinding']['score'] == 2.0
-
-    def test_parse_methodological_quality_response_bare_json(self, agent):
-        """Test JSON parsing from bare JSON response."""
-        response_bare = '''{
-          "randomization": {"score": 2.0, "evidence": "test", "reasoning": "test"}
-        }'''
-
-        result = agent._parse_json_response(response_bare)
-
-        assert result['randomization']['score'] == 2.0
-
-
-# ============================================================================
-# Unit Tests - Edge Cases
-# ============================================================================
-
-class TestEdgeCases:
-    """Tests for edge cases and boundary conditions."""
-
-    def test_empty_components_dict(self, agent):
-        """Test score calculation with empty components dict."""
-        result = agent._calculate_methodological_quality_score({})
-
-        assert result.dimension_name == 'methodological_quality'
-        assert result.score == 0.0
-        assert len(result.details) == 0
-
-    def test_components_missing_score_key(self, agent):
-        """Test handling of components missing score key."""
-        components = {
-            "randomization": {"evidence": "test", "reasoning": "test"},  # No score
-            "blinding": {"score": 2.0, "evidence": "test", "reasoning": "test"}
-        }
-
-        result = agent._calculate_methodological_quality_score(components)
-
-        # Should use default score of 0.0 for missing score
-        assert result.score == 2.0  # Only blinding contributes
-
-    def test_components_with_negative_score(self, agent):
-        """Test handling of negative score values."""
-        components = {
-            "randomization": {"score": -1.0, "evidence": "test", "reasoning": "test"}
-        }
-
-        result = agent._calculate_methodological_quality_score(components)
-
-        # Negative scores should still be used (clamping happens at final score)
-        assert result.details[0].score_contribution == -1.0
-
-    def test_score_capped_at_10(self, agent):
-        """Test that total score is capped at 10.0."""
-        components = {
-            "randomization": {"score": 5.0, "evidence": "test", "reasoning": "test"},
-            "blinding": {"score": 5.0, "evidence": "test", "reasoning": "test"},
-            "allocation": {"score": 5.0, "evidence": "test", "reasoning": "test"}
-        }
-
-        result = agent._calculate_methodological_quality_score(components)
-
-        assert result.score == 10.0  # Capped at 10
-
-    def test_empty_document(self, agent):
-        """Test text preparation with empty document."""
-        document = {}
-
-        text = agent._prepare_text_for_analysis(document)
-
-        assert 'TITLE:' in text
-        assert 'ABSTRACT:' in text
-
-    def test_extract_mq_with_none_quality_score(self, agent):
-        """Test MQ extraction when quality_score is None."""
-        study_assessment = {
-            'is_randomized': True,
-            'is_double_blinded': True,
-            'quality_score': None  # Explicit None
-        }
-        document = {'title': 'Test'}
-
-        result = agent._extract_mq_from_study_assessment(study_assessment, document)
-
-        assert result is not None
-        # Should use default of 5.0 for None quality_score
-        other_component = next(d for d in result.details if d.component == 'other_components')
-        assert 'quality_score=5.0' in other_component.extracted_value
-
-    def test_extract_mq_with_extreme_quality_score(self, agent):
-        """Test MQ extraction with extreme quality_score values."""
-        # Test with quality_score > 10
-        study_assessment = {
-            'is_randomized': False,
-            'quality_score': 15.0  # Out of range
-        }
-        document = {'title': 'Test'}
-
-        result = agent._extract_mq_from_study_assessment(study_assessment, document)
-
-        # Should clamp to 10.0
-        assert result.score <= 10.0
-
-    def test_extract_rob_with_unknown_risk_level(self, agent):
-        """Test RoB extraction with unknown risk levels."""
-        study_assessment = {
-            'selection_bias_risk': 'unknown',
-            'performance_bias_risk': 'very_high',  # Not in mapping
-            'detection_bias_risk': 'low',
-            'reporting_bias_risk': None
-        }
-        document = {'title': 'Test'}
-
-        result = agent._extract_rob_from_study_assessment(study_assessment, document)
-
-        assert result is not None
-        # Unknown risk levels should get default score (0.625)
-
-    def test_components_with_string_score(self, agent):
-        """Test handling of string score values (should convert to float)."""
-        components = {
-            "randomization": {"score": "2.0", "evidence": "test", "reasoning": "test"}
-        }
-
-        result = agent._calculate_methodological_quality_score(components)
-
-        assert result.score == 2.0  # String converted to float
-
-    def test_risk_of_bias_with_mixed_risk_levels(self, agent):
-        """Test RoB calculation with mixed risk levels."""
-        components = {
-            "selection_bias": {"score": 2.5, "risk_level": "low", "evidence": "", "reasoning": ""},
-            "performance_bias": {"score": 0, "risk_level": "high", "evidence": "", "reasoning": ""},
-            "detection_bias": {"score": 1.25, "risk_level": "moderate", "evidence": "", "reasoning": ""}
-        }
-
-        result = agent._calculate_risk_of_bias_score(components)
-
-        assert result.score == 3.75  # 2.5 + 0 + 1.25
-
-
-# ============================================================================
-# Integration Tests (require Ollama)
-# ============================================================================
-
-@pytest.mark.slow
-@pytest.mark.requires_ollama
-class TestLLMIntegration:
-    """Integration tests that require a running Ollama instance."""
-
-    @pytest.fixture
-    def live_agent(self):
-        """Create agent that connects to real Ollama instance."""
-        return PaperWeightAssessmentAgent(show_model_info=False)
-
-    def test_assess_methodological_quality_integration(self, live_agent, sample_rct_document):
-        """Integration test for methodological quality assessment."""
-        if not live_agent.test_connection():
-            pytest.skip("Ollama not available")
-
-        result = live_agent._assess_methodological_quality(sample_rct_document)
-
-        assert result.dimension_name == 'methodological_quality'
-        assert 0 <= result.score <= 10
-        assert len(result.details) > 0
-
-        # High quality RCT should score well
-        assert result.score > 5.0, f"Expected score > 5.0 for RCT, got {result.score}"
-
-    def test_assess_risk_of_bias_integration(self, live_agent, sample_rct_document):
-        """Integration test for risk of bias assessment."""
-        if not live_agent.test_connection():
-            pytest.skip("Ollama not available")
-
-        result = live_agent._assess_risk_of_bias(sample_rct_document)
-
-        assert result.dimension_name == 'risk_of_bias'
-        assert 0 <= result.score <= 10
-        assert len(result.details) > 0
-
-        # Low risk RCT should have high score (inverted scale)
-        assert result.score > 5.0, f"Expected score > 5.0 for RCT (low risk), got {result.score}"
-
-    def test_assess_observational_study(self, live_agent, sample_observational_document):
-        """Test assessment of observational study (should score lower than RCT)."""
-        if not live_agent.test_connection():
-            pytest.skip("Ollama not available")
-
-        mq_result = live_agent._assess_methodological_quality(sample_observational_document)
-        rob_result = live_agent._assess_risk_of_bias(sample_observational_document)
-
-        # Observational study should score lower than RCT
-        assert mq_result.score < 8.0, "Observational study shouldn't score as high as RCT"
-        # Retrospective study typically has higher bias risk (lower score)
-        assert rob_result.score < 8.0, "Retrospective study should have some bias risk"
-
-    def test_uses_study_assessment_when_provided(self, live_agent, sample_rct_document, sample_study_assessment):
-        """Test that StudyAssessmentAgent output is used when provided."""
-        # When study_assessment is provided, should use extraction instead of LLM
-        mq_result = live_agent._assess_methodological_quality(
-            sample_rct_document,
-            study_assessment=sample_study_assessment
+    def test_custom_default_score(self):
+        """Test with custom default score."""
+        result = create_error_dimension_score(
+            DIMENSION_RISK_OF_BIAS,
+            'Connection failed',
+            default_score=3.0
         )
-        rob_result = live_agent._assess_risk_of_bias(
-            sample_rct_document,
-            study_assessment=sample_study_assessment
-        )
-
-        # Results should come from extraction (check reasoning mentions StudyAssessmentAgent)
-        assert any('StudyAssessmentAgent' in d.reasoning for d in mq_result.details if d.reasoning)
-        assert any('StudyAssessmentAgent' in d.reasoning for d in rob_result.details if d.reasoning)
+        
+        assert result.score == 3.0
 
 
-# ============================================================================
-# Run Tests
-# ============================================================================
+class TestConstants:
+    """Tests for module constants."""
 
-if __name__ == '__main__':
-    # Run unit tests only (fast)
-    # pytest tests/test_paper_weight_llm_assessors.py -v -m "not slow"
+    def test_risk_level_scores(self):
+        """Test risk level score mappings."""
+        assert RISK_LEVEL_SCORES['low'] == 2.5
+        assert RISK_LEVEL_SCORES['moderate'] == 1.25
+        assert RISK_LEVEL_SCORES['high'] == 0.0
+        assert RISK_LEVEL_SCORES['unclear'] == 0.625
 
-    # Run all tests including integration tests (requires Ollama)
-    # pytest tests/test_paper_weight_llm_assessors.py -v
+    def test_mq_score_constants(self):
+        """Test methodological quality score constants."""
+        assert RANDOMIZATION_SCORE == 2.0
+        assert DOUBLE_BLIND_SCORE == 2.0
+        assert SINGLE_BLIND_SCORE == 1.0
+        assert REMAINING_COMPONENTS_MAX == 5.0
+        assert QUALITY_SCORE_MAX == 10.0
 
-    pytest.main([__file__, '-v', '-m', 'not slow'])
+    def test_max_text_length(self):
+        """Test max text length constant."""
+        assert DEFAULT_MAX_TEXT_LENGTH == 8000

--- a/tests/test_paper_weight_models.py
+++ b/tests/test_paper_weight_models.py
@@ -1,165 +1,165 @@
-"""Tests for paper weight assessment data models.
+"""
+Tests for paper_weight_models.py
 
-This test module verifies the functionality of the paper weight assessment
-dataclasses: AssessmentDetail, DimensionScore, and PaperWeightResult.
+Tests cover:
+- AssessmentDetail creation and serialization
+- DimensionScore creation, adding details, and serialization
+- PaperWeightResult creation, serialization, and markdown output
+- Edge cases: empty details, None values, boundary scores
 """
 
 import pytest
 from datetime import datetime
 import json
-from bmlibrarian.agents.paper_weight_agent import (
-    AssessmentDetail, DimensionScore, PaperWeightResult
+
+from bmlibrarian.agents.paper_weight_models import (
+    AssessmentDetail,
+    DimensionScore,
+    PaperWeightResult,
+    DATETIME_FORMAT,
+    DIMENSION_STUDY_DESIGN,
+    DIMENSION_SAMPLE_SIZE,
+    DIMENSION_METHODOLOGICAL_QUALITY,
+    DIMENSION_RISK_OF_BIAS,
+    DIMENSION_REPLICATION_STATUS,
+    ALL_DIMENSIONS,
 )
 
 
 class TestAssessmentDetail:
     """Tests for AssessmentDetail dataclass."""
 
-    def test_creation_with_all_fields(self):
-        """Test creating an AssessmentDetail with all fields populated."""
+    def test_creation_with_required_fields(self):
+        """Test creating AssessmentDetail with required fields only."""
         detail = AssessmentDetail(
-            dimension="study_design",
-            component="study_type",
-            extracted_value="RCT",
-            score_contribution=8.0,
-            evidence_text="randomized controlled trial",
-            reasoning="Identified as RCT from methods section"
+            dimension='study_design',
+            component='study_type',
+            extracted_value='rct',
+            score_contribution=8.0
         )
-
-        assert detail.dimension == "study_design"
-        assert detail.component == "study_type"
-        assert detail.extracted_value == "RCT"
+        assert detail.dimension == 'study_design'
+        assert detail.component == 'study_type'
+        assert detail.extracted_value == 'rct'
         assert detail.score_contribution == 8.0
-        assert "randomized" in detail.evidence_text
-        assert "RCT" in detail.reasoning
-
-    def test_creation_with_optional_fields_none(self):
-        """Test creating an AssessmentDetail with optional fields as None."""
-        detail = AssessmentDetail(
-            dimension="sample_size",
-            component="extracted_n",
-            extracted_value="250",
-            score_contribution=4.8
-        )
-
-        assert detail.dimension == "sample_size"
         assert detail.evidence_text is None
         assert detail.reasoning is None
 
-    def test_to_dict(self):
-        """Test serialization to dictionary."""
+    def test_creation_with_all_fields(self):
+        """Test creating AssessmentDetail with all fields."""
         detail = AssessmentDetail(
-            dimension="methodological_quality",
-            component="blinding_type",
-            extracted_value="double-blind",
+            dimension='methodological_quality',
+            component='blinding',
+            extracted_value='double-blind',
             score_contribution=3.0,
-            evidence_text="participants were masked",
-            reasoning="Full blinding detected"
+            evidence_text='Participants and investigators were masked...',
+            reasoning='Double-blind design detected'
         )
+        assert detail.evidence_text == 'Participants and investigators were masked...'
+        assert detail.reasoning == 'Double-blind design detected'
 
-        data = detail.to_dict()
+    def test_to_dict(self):
+        """Test to_dict serialization."""
+        detail = AssessmentDetail(
+            dimension='sample_size',
+            component='extracted_n',
+            extracted_value='450',
+            score_contribution=5.3,
+            evidence_text='n=450 participants',
+            reasoning='Log10(450) * 2'
+        )
+        result = detail.to_dict()
 
-        assert data['dimension'] == "methodological_quality"
-        assert data['component'] == "blinding_type"
-        assert data['extracted_value'] == "double-blind"
-        assert data['score_contribution'] == 3.0
-        assert data['evidence_text'] == "participants were masked"
-        assert data['reasoning'] == "Full blinding detected"
+        assert result['dimension'] == 'sample_size'
+        assert result['component'] == 'extracted_n'
+        assert result['extracted_value'] == '450'
+        assert result['score_contribution'] == 5.3
+        assert result['evidence_text'] == 'n=450 participants'
+        assert result['reasoning'] == 'Log10(450) * 2'
 
     def test_to_dict_with_none_values(self):
-        """Test serialization preserves None values."""
+        """Test to_dict when optional fields are None."""
         detail = AssessmentDetail(
-            dimension="risk_of_bias",
-            component="selection_bias",
+            dimension='test',
+            component='test_component',
             extracted_value=None,
             score_contribution=0.0
         )
+        result = detail.to_dict()
 
-        data = detail.to_dict()
-
-        assert data['extracted_value'] is None
-        assert data['evidence_text'] is None
-        assert data['reasoning'] is None
+        assert result['extracted_value'] is None
+        assert result['evidence_text'] is None
+        assert result['reasoning'] is None
 
 
 class TestDimensionScore:
     """Tests for DimensionScore dataclass."""
 
-    def test_creation_with_score(self):
-        """Test creating a DimensionScore with just a score."""
-        score = DimensionScore(dimension_name="sample_size", score=7.5)
+    def test_creation_basic(self):
+        """Test basic DimensionScore creation."""
+        score = DimensionScore(dimension_name='study_design', score=8.0)
 
-        assert score.dimension_name == "sample_size"
-        assert score.score == 7.5
+        assert score.dimension_name == 'study_design'
+        assert score.score == 8.0
         assert score.details == []
 
     def test_add_detail(self):
-        """Test adding details to DimensionScore."""
-        score = DimensionScore(dimension_name="sample_size", score=7.5)
+        """Test adding details to a DimensionScore."""
+        score = DimensionScore(dimension_name='sample_size', score=7.0)
 
         score.add_detail(
-            component="extracted_n",
-            value="450",
-            contribution=5.5
-        )
-
-        score.add_detail(
-            component="power_calculation",
-            value="yes",
-            contribution=2.0,
-            reasoning="Power calculation mentioned in methods"
-        )
-
-        assert len(score.details) == 2
-        assert score.details[0].component == "extracted_n"
-        assert score.details[0].extracted_value == "450"
-        assert score.details[0].score_contribution == 5.5
-        assert score.details[0].dimension == "sample_size"  # Auto-set from dimension_name
-        assert score.details[1].component == "power_calculation"
-        assert score.details[1].score_contribution == 2.0
-        assert score.details[1].reasoning == "Power calculation mentioned in methods"
-
-    def test_add_detail_with_evidence(self):
-        """Test adding a detail with evidence text."""
-        score = DimensionScore(dimension_name="methodological_quality", score=6.5)
-
-        score.add_detail(
-            component="randomization",
-            value="computer-generated",
-            contribution=2.0,
-            evidence="Randomization was performed using a computer-generated sequence",
-            reasoning="Proper sequence generation method described"
+            component='extracted_n',
+            value='500',
+            contribution=5.4,
+            evidence='n=500 participants',
+            reasoning='Logarithmic scaling'
         )
 
         assert len(score.details) == 1
         detail = score.details[0]
-        assert detail.evidence_text is not None
-        assert "computer-generated" in detail.evidence_text
-        assert detail.reasoning is not None
+        assert detail.dimension == 'sample_size'
+        assert detail.component == 'extracted_n'
+        assert detail.extracted_value == '500'
+        assert detail.score_contribution == 5.4
+
+    def test_add_multiple_details(self):
+        """Test adding multiple details."""
+        score = DimensionScore(dimension_name='sample_size', score=9.0)
+
+        score.add_detail('extracted_n', '1000', 6.0)
+        score.add_detail('power_calculation', 'yes', 2.0, reasoning='Power calc found')
+        score.add_detail('ci_reporting', 'yes', 0.5, reasoning='CI reported')
+
+        assert len(score.details) == 3
+        assert score.details[0].component == 'extracted_n'
+        assert score.details[1].component == 'power_calculation'
+        assert score.details[2].component == 'ci_reporting'
 
     def test_to_dict(self):
-        """Test serialization of DimensionScore."""
-        score = DimensionScore(dimension_name="study_design", score=8.0)
-        score.add_detail(
-            component="study_type",
-            value="RCT",
-            contribution=8.0
-        )
+        """Test to_dict serialization."""
+        score = DimensionScore(dimension_name='methodological_quality', score=6.5)
+        score.add_detail('randomization', 'yes', 2.0)
 
-        data = score.to_dict()
+        result = score.to_dict()
 
-        assert data['dimension_name'] == "study_design"
-        assert data['score'] == 8.0
-        assert len(data['details']) == 1
-        assert data['details'][0]['component'] == "study_type"
+        assert result['dimension_name'] == 'methodological_quality'
+        assert result['score'] == 6.5
+        assert len(result['details']) == 1
+        assert result['details'][0]['component'] == 'randomization'
 
-    def test_to_dict_empty_details(self):
-        """Test serialization with no details."""
-        score = DimensionScore(dimension_name="replication_status", score=0.0)
+    def test_empty_details(self):
+        """Test DimensionScore with no details."""
+        score = DimensionScore(dimension_name='test', score=5.0)
+        result = score.to_dict()
 
-        data = score.to_dict()
+        assert result['details'] == []
 
-        assert data['details'] == []
+    def test_boundary_scores(self):
+        """Test boundary score values."""
+        zero_score = DimensionScore(dimension_name='test', score=0.0)
+        assert zero_score.score == 0.0
+
+        max_score = DimensionScore(dimension_name='test', score=10.0)
+        assert max_score.score == 10.0
 
 
 class TestPaperWeightResult:
@@ -170,388 +170,120 @@ class TestPaperWeightResult:
         """Create a sample PaperWeightResult for testing."""
         return PaperWeightResult(
             document_id=12345,
-            assessor_version="1.0.0",
-            assessed_at=datetime(2025, 1, 15, 10, 30),
-            study_design=DimensionScore("study_design", 8.0),
-            sample_size=DimensionScore("sample_size", 7.5),
-            methodological_quality=DimensionScore("methodological_quality", 6.5),
-            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
-            replication_status=DimensionScore("replication_status", 5.0),
+            assessor_version='1.0.0',
+            assessed_at=datetime(2024, 1, 15, 10, 30, 0),
+            study_design=DimensionScore(DIMENSION_STUDY_DESIGN, 8.0),
+            sample_size=DimensionScore(DIMENSION_SAMPLE_SIZE, 7.5),
+            methodological_quality=DimensionScore(DIMENSION_METHODOLOGICAL_QUALITY, 6.5),
+            risk_of_bias=DimensionScore(DIMENSION_RISK_OF_BIAS, 7.0),
+            replication_status=DimensionScore(DIMENSION_REPLICATION_STATUS, 5.0),
             final_weight=7.2,
             dimension_weights={
-                "study_design": 0.25,
-                "sample_size": 0.15,
-                "methodological_quality": 0.30,
-                "risk_of_bias": 0.20,
-                "replication_status": 0.10
+                'study_design': 0.25,
+                'sample_size': 0.15,
+                'methodological_quality': 0.30,
+                'risk_of_bias': 0.20,
+                'replication_status': 0.10
             },
-            study_type="RCT",
+            study_type='rct',
             sample_size_n=450
         )
 
     def test_creation(self, sample_result):
-        """Test creating a PaperWeightResult."""
+        """Test PaperWeightResult creation."""
         assert sample_result.document_id == 12345
-        assert sample_result.assessor_version == "1.0.0"
-        assert sample_result.study_design.score == 8.0
-        assert sample_result.sample_size.score == 7.5
+        assert sample_result.assessor_version == '1.0.0'
         assert sample_result.final_weight == 7.2
-        assert sample_result.study_type == "RCT"
+        assert sample_result.study_type == 'rct'
         assert sample_result.sample_size_n == 450
 
-    def test_creation_without_metadata(self):
-        """Test creating without optional metadata."""
-        result = PaperWeightResult(
-            document_id=99999,
-            assessor_version="1.0.0",
-            assessed_at=datetime.now(),
-            study_design=DimensionScore("study_design", 5.0),
-            sample_size=DimensionScore("sample_size", 5.0),
-            methodological_quality=DimensionScore("methodological_quality", 5.0),
-            risk_of_bias=DimensionScore("risk_of_bias", 5.0),
-            replication_status=DimensionScore("replication_status", 5.0),
-            final_weight=5.0,
-            dimension_weights={}
-        )
-
-        assert result.study_type is None
-        assert result.sample_size_n is None
-
     def test_to_dict(self, sample_result):
-        """Test serialization of PaperWeightResult."""
-        data = sample_result.to_dict()
+        """Test to_dict serialization."""
+        result = sample_result.to_dict()
 
-        assert data['document_id'] == 12345
-        assert data['assessor_version'] == "1.0.0"
-        assert data['study_design_score'] == 8.0
-        assert data['sample_size_score'] == 7.5
-        assert data['methodological_quality_score'] == 6.5
-        assert data['risk_of_bias_score'] == 7.0
-        assert data['replication_status_score'] == 5.0
-        assert data['final_weight'] == 7.2
-        assert data['study_type'] == "RCT"
-        assert data['sample_size'] == 450  # Note: maps to sample_size, not sample_size_n
+        assert result['document_id'] == 12345
+        assert result['assessor_version'] == '1.0.0'
+        assert result['study_design_score'] == 8.0
+        assert result['sample_size_score'] == 7.5
+        assert result['final_weight'] == 7.2
+        assert result['study_type'] == 'rct'
+        assert result['sample_size'] == 450
 
-        # Dimension weights should be JSON string
-        weights = json.loads(data['dimension_weights'])
+        weights = json.loads(result['dimension_weights'])
         assert weights['study_design'] == 0.25
-        assert weights['methodological_quality'] == 0.30
 
-    def test_get_all_details(self):
-        """Test collecting all audit trail details."""
-        study_design = DimensionScore("study_design", 8.0)
-        study_design.add_detail("study_type", "RCT", 8.0)
+    def test_get_all_details(self, sample_result):
+        """Test collecting all details from all dimensions."""
+        sample_result.study_design.add_detail('study_type', 'rct', 8.0)
+        sample_result.sample_size.add_detail('extracted_n', '450', 5.3)
+        sample_result.sample_size.add_detail('power_calculation', 'yes', 2.0)
 
-        sample_size = DimensionScore("sample_size", 7.5)
-        sample_size.add_detail("extracted_n", "450", 5.5)
-        sample_size.add_detail("power_calculation", "yes", 2.0)
+        all_details = sample_result.get_all_details()
 
-        methodological = DimensionScore("methodological_quality", 6.5)
-        methodological.add_detail("blinding", "double-blind", 3.0)
-
-        result = PaperWeightResult(
-            document_id=12345,
-            assessor_version="1.0.0",
-            assessed_at=datetime.now(),
-            study_design=study_design,
-            sample_size=sample_size,
-            methodological_quality=methodological,
-            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
-            replication_status=DimensionScore("replication_status", 5.0),
-            final_weight=7.2,
-            dimension_weights={}
-        )
-
-        all_details = result.get_all_details()
-
-        assert len(all_details) == 4  # 1 + 2 + 1 + 0 + 0
-        assert all_details[0].dimension == "study_design"
-        assert all_details[1].dimension == "sample_size"
-        assert all_details[2].dimension == "sample_size"
-        assert all_details[3].dimension == "methodological_quality"
+        assert len(all_details) == 3
+        dimensions = {d.dimension for d in all_details}
+        assert DIMENSION_STUDY_DESIGN in dimensions
+        assert DIMENSION_SAMPLE_SIZE in dimensions
 
     def test_get_all_details_empty(self, sample_result):
         """Test get_all_details when no details exist."""
         all_details = sample_result.get_all_details()
         assert all_details == []
 
-    def test_to_markdown(self):
+    def test_to_markdown(self, sample_result):
         """Test Markdown report generation."""
-        study_design = DimensionScore("study_design", 8.0)
-        study_design.add_detail(
-            "study_type", "RCT", 8.0,
-            evidence="This randomized controlled trial...",
-            reasoning="Clear RCT identified"
-        )
+        sample_result.study_design.add_detail('study_type', 'rct', 8.0, reasoning='Matched RCT keyword')
 
-        result = PaperWeightResult(
-            document_id=12345,
-            assessor_version="1.0.0",
-            assessed_at=datetime(2025, 1, 15, 10, 30),
-            study_design=study_design,
-            sample_size=DimensionScore("sample_size", 7.5),
-            methodological_quality=DimensionScore("methodological_quality", 6.5),
-            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
-            replication_status=DimensionScore("replication_status", 5.0),
-            final_weight=7.2,
-            dimension_weights={"study_design": 0.25},
-            study_type="RCT",
-            sample_size_n=450
-        )
-
-        markdown = result.to_markdown()
-
-        assert "# Paper Weight Assessment Report" in markdown
-        assert "**Document ID:** 12345" in markdown
-        assert "**Study Type:** RCT" in markdown
-        assert "**Sample Size:** 450" in markdown
-        assert "**Assessor Version:** 1.0.0" in markdown
-        assert "## Final Weight: 7.20/10" in markdown
-        assert "### Study Design: 8.00/10" in markdown
-        assert "### Sample Size: 7.50/10" in markdown
-        assert "**study_type:** RCT" in markdown
-        assert "Score contribution: 8.00" in markdown
-        assert "Clear RCT identified" in markdown
-
-    def test_to_markdown_without_details(self, sample_result):
-        """Test Markdown generation for dimensions without details."""
         markdown = sample_result.to_markdown()
 
-        # Should indicate no detailed breakdown
-        assert "*No detailed breakdown available*" in markdown
+        assert '# Paper Weight Assessment Report' in markdown
+        assert '**Document ID:** 12345' in markdown
+        assert '**Study Type:** rct' in markdown
+        assert '**Sample Size:** 450' in markdown
+        assert '## Final Weight: 7.20/10' in markdown
+        assert '### Study Design: 8.00/10' in markdown
 
-    def test_to_markdown_preserves_full_evidence(self):
-        """Test that full evidence text is preserved in Markdown (no truncation)."""
-        study_design = DimensionScore("study_design", 8.0)
-        # Create substantial evidence text - should be fully preserved
-        long_evidence = "This is a detailed evidence excerpt from the paper that describes " \
-                        "the randomization procedure in full detail including the specific " \
-                        "method used for sequence generation and allocation concealment."
-        study_design.add_detail(
-            "study_type", "RCT", 8.0,
-            evidence=long_evidence
-        )
-
+    def test_to_markdown_unknown_study_type(self):
+        """Test Markdown when study_type is None."""
         result = PaperWeightResult(
-            document_id=12345,
-            assessor_version="1.0.0",
+            document_id=1,
+            assessor_version='1.0.0',
             assessed_at=datetime.now(),
-            study_design=study_design,
-            sample_size=DimensionScore("sample_size", 5.0),
-            methodological_quality=DimensionScore("methodological_quality", 5.0),
-            risk_of_bias=DimensionScore("risk_of_bias", 5.0),
-            replication_status=DimensionScore("replication_status", 5.0),
-            final_weight=5.5,
-            dimension_weights={}
+            study_design=DimensionScore(DIMENSION_STUDY_DESIGN, 5.0),
+            sample_size=DimensionScore(DIMENSION_SAMPLE_SIZE, 0.0),
+            methodological_quality=DimensionScore(DIMENSION_METHODOLOGICAL_QUALITY, 5.0),
+            risk_of_bias=DimensionScore(DIMENSION_RISK_OF_BIAS, 5.0),
+            replication_status=DimensionScore(DIMENSION_REPLICATION_STATUS, 0.0),
+            final_weight=3.5,
+            dimension_weights={'study_design': 0.25},
+            study_type=None,
+            sample_size_n=None
         )
 
         markdown = result.to_markdown()
 
-        # Full evidence should be preserved for audit trail integrity
-        assert long_evidence in markdown
-        # Should not have truncation indicator
-        assert "..." not in markdown or long_evidence in markdown
-
-    def test_from_db_row(self):
-        """Test reconstructing PaperWeightResult from database rows."""
-        # Simulate database row
-        row = {
-            'document_id': 12345,
-            'assessor_version': "1.0.0",
-            'assessed_at': datetime(2025, 1, 15, 10, 30),
-            'study_design_score': 8.0,
-            'sample_size_score': 7.5,
-            'methodological_quality_score': 6.5,
-            'risk_of_bias_score': 7.0,
-            'replication_status_score': 5.0,
-            'final_weight': 7.2,
-            'dimension_weights': '{"study_design": 0.25, "sample_size": 0.15}',
-            'study_type': "RCT",
-            'sample_size': 450
-        }
-
-        # Simulate detail rows
-        details = [
-            {
-                'dimension': 'study_design',
-                'component': 'study_type',
-                'extracted_value': 'RCT',
-                'score_contribution': 8.0,
-                'evidence_text': 'randomized controlled',
-                'reasoning': 'Identified as RCT'
-            },
-            {
-                'dimension': 'sample_size',
-                'component': 'extracted_n',
-                'extracted_value': '450',
-                'score_contribution': 5.5,
-                'evidence_text': None,
-                'reasoning': 'Log10(450) * 2'
-            }
-        ]
-
-        result = PaperWeightResult.from_db_row(row, details)
-
-        assert result.document_id == 12345
-        assert result.assessor_version == "1.0.0"
-        assert result.study_design.score == 8.0
-        assert result.sample_size.score == 7.5
-        assert result.final_weight == 7.2
-        assert result.study_type == "RCT"
-        assert result.sample_size_n == 450
-        assert len(result.study_design.details) == 1
-        assert len(result.sample_size.details) == 1
-        assert result.study_design.details[0].component == "study_type"
-        assert result.dimension_weights['study_design'] == 0.25
-
-    def test_from_db_row_with_dict_weights(self):
-        """Test from_db_row when dimension_weights is already a dict."""
-        row = {
-            'document_id': 99999,
-            'assessor_version': "1.0.0",
-            'assessed_at': datetime.now(),
-            'study_design_score': 5.0,
-            'sample_size_score': 5.0,
-            'methodological_quality_score': 5.0,
-            'risk_of_bias_score': 5.0,
-            'replication_status_score': 5.0,
-            'final_weight': 5.0,
-            'dimension_weights': {"study_design": 0.25},  # Already dict
-            'study_type': None,
-            'sample_size': None
-        }
-
-        result = PaperWeightResult.from_db_row(row, [])
-
-        assert result.dimension_weights == {"study_design": 0.25}
-
-    def test_from_db_row_empty_details(self):
-        """Test from_db_row with no detail rows."""
-        row = {
-            'document_id': 99999,
-            'assessor_version': "1.0.0",
-            'assessed_at': datetime.now(),
-            'study_design_score': 5.0,
-            'sample_size_score': 5.0,
-            'methodological_quality_score': 5.0,
-            'risk_of_bias_score': 5.0,
-            'replication_status_score': 5.0,
-            'final_weight': 5.0,
-            'dimension_weights': '{}',
-            'study_type': None,
-            'sample_size': None
-        }
-
-        result = PaperWeightResult.from_db_row(row, [])
-
-        assert len(result.get_all_details()) == 0
-
-    def test_from_db_row_null_score_contribution(self):
-        """Test from_db_row handles NULL score_contribution."""
-        row = {
-            'document_id': 99999,
-            'assessor_version': "1.0.0",
-            'assessed_at': datetime.now(),
-            'study_design_score': 5.0,
-            'sample_size_score': 5.0,
-            'methodological_quality_score': 5.0,
-            'risk_of_bias_score': 5.0,
-            'replication_status_score': 5.0,
-            'final_weight': 5.0,
-            'dimension_weights': '{}',
-            'study_type': None,
-            'sample_size': None
-        }
-
-        details = [
-            {
-                'dimension': 'study_design',
-                'component': 'unknown',
-                'extracted_value': None,
-                'score_contribution': None,  # NULL from database
-                'evidence_text': None,
-                'reasoning': None
-            }
-        ]
-
-        result = PaperWeightResult.from_db_row(row, details)
-
-        assert result.study_design.details[0].score_contribution == 0.0
+        assert '**Study Type:** Unknown' in markdown
+        assert '**Sample Size:** Not extracted' in markdown
 
 
-class TestIntegration:
-    """Integration tests for the complete data model workflow."""
+class TestConstants:
+    """Tests for module constants."""
 
-    def test_full_workflow_serialization_roundtrip(self):
-        """Test that data can be serialized and deserialized correctly."""
-        # Create a comprehensive result
-        study_design = DimensionScore("study_design", 8.0)
-        study_design.add_detail("study_type", "RCT", 8.0, reasoning="Clear RCT")
+    def test_dimension_constants(self):
+        """Test dimension name constants."""
+        assert DIMENSION_STUDY_DESIGN == 'study_design'
+        assert DIMENSION_SAMPLE_SIZE == 'sample_size'
+        assert DIMENSION_METHODOLOGICAL_QUALITY == 'methodological_quality'
+        assert DIMENSION_RISK_OF_BIAS == 'risk_of_bias'
+        assert DIMENSION_REPLICATION_STATUS == 'replication_status'
 
-        sample_size = DimensionScore("sample_size", 7.3)
-        sample_size.add_detail("extracted_n", "450", 5.3, reasoning="Log10(450) * 2")
-        sample_size.add_detail("power_calculation", "yes", 2.0, evidence="80% power")
+    def test_all_dimensions_list(self):
+        """Test ALL_DIMENSIONS contains all dimension constants."""
+        assert len(ALL_DIMENSIONS) == 5
+        assert DIMENSION_STUDY_DESIGN in ALL_DIMENSIONS
 
-        result = PaperWeightResult(
-            document_id=12345,
-            assessor_version="1.0.0",
-            assessed_at=datetime(2025, 1, 15, 10, 30),
-            study_design=study_design,
-            sample_size=sample_size,
-            methodological_quality=DimensionScore("methodological_quality", 6.5),
-            risk_of_bias=DimensionScore("risk_of_bias", 7.0),
-            replication_status=DimensionScore("replication_status", 5.0),
-            final_weight=7.2,
-            dimension_weights={
-                "study_design": 0.25,
-                "sample_size": 0.15,
-                "methodological_quality": 0.30,
-                "risk_of_bias": 0.20,
-                "replication_status": 0.10
-            },
-            study_type="RCT",
-            sample_size_n=450
-        )
-
-        # Serialize
-        data = result.to_dict()
-        all_details = [d.to_dict() for d in result.get_all_details()]
-
-        # Convert to DB format (simulate database retrieval)
-        db_row = {
-            'document_id': data['document_id'],
-            'assessor_version': data['assessor_version'],
-            'assessed_at': data['assessed_at'],
-            'study_design_score': data['study_design_score'],
-            'sample_size_score': data['sample_size_score'],
-            'methodological_quality_score': data['methodological_quality_score'],
-            'risk_of_bias_score': data['risk_of_bias_score'],
-            'replication_status_score': data['replication_status_score'],
-            'final_weight': data['final_weight'],
-            'dimension_weights': data['dimension_weights'],
-            'study_type': data['study_type'],
-            'sample_size': data['sample_size']
-        }
-
-        # Deserialize
-        reconstructed = PaperWeightResult.from_db_row(db_row, all_details)
-
-        # Verify
-        assert reconstructed.document_id == result.document_id
-        assert reconstructed.final_weight == result.final_weight
-        assert reconstructed.study_design.score == result.study_design.score
-        assert len(reconstructed.get_all_details()) == len(result.get_all_details())
-        assert reconstructed.study_design.details[0].reasoning == "Clear RCT"
-
-    def test_dimension_weights_sum_validation(self):
-        """Test that dimension weights can be validated to sum to 1.0."""
-        weights = {
-            "study_design": 0.25,
-            "sample_size": 0.15,
-            "methodological_quality": 0.30,
-            "risk_of_bias": 0.20,
-            "replication_status": 0.10
-        }
-
-        # Weights should sum to 1.0
-        assert abs(sum(weights.values()) - 1.0) < 0.001
+    def test_datetime_format(self):
+        """Test datetime format constant."""
+        test_dt = datetime(2024, 1, 15, 10, 30, 45)
+        formatted = test_dt.strftime(DATETIME_FORMAT)
+        assert formatted == '2024-01-15 10:30:45'


### PR DESCRIPTION
## Summary

Refactors the 2039-line `paper_weight_agent.py` into 6 modular files, each under 500 lines, following the project guideline to keep files concise. The refactoring prioritizes reusable pure functions over complex structures.

## Changes

### New Module Structure

| Module | Lines | Purpose |
|--------|-------|---------|
| `paper_weight_models.py` | 355 | Data models (`AssessmentDetail`, `DimensionScore`, `PaperWeightResult`) |
| `paper_weight_extractors.py` | 448 | Pure functions for rule-based study type and sample size extraction |
| `paper_weight_llm_assessors.py` | 400 | LLM score calculators and StudyAssessmentAgent integration |
| `paper_weight_prompts.py` | 182 | LLM prompt templates |
| `paper_weight_db.py` | 500 | Database operations (caching, persistence, document retrieval) |
| `paper_weight_agent.py` | 484 | Main agent class orchestrating all components |

### Code Quality Improvements

- **Magic numbers replaced with named constants:**
  - `RANDOMIZATION_SCORE`, `DOUBLE_BLIND_SCORE`, `SINGLE_BLIND_SCORE`, etc. in `paper_weight_llm_assessors.py`
  - `REPLICATION_SCORE_SINGLE_COMPARABLE`, `REPLICATION_SCORE_SINGLE_HIGHER`, etc. in `paper_weight_db.py`
- **Unused import removed** from `paper_weight_agent.py`
- **Full docstrings** with Args/Returns on all public functions
- **Type hints** throughout all modules

### Test Coverage

Added 113 tests across 4 test files:
- `test_paper_weight_models.py` - Data model tests
- `test_paper_weight_extractors.py` - Rule-based extractor tests (including edge cases)
- `test_paper_weight_llm_assessors.py` - LLM assessment function tests
- `test_paper_weight_db.py` - Database operation tests

## Test Plan

- [x] All 113 new tests pass
- [x] Existing imports from `bmlibrarian.agents` work (backward compatibility)
- [x] Syntax verification via Python import
- [ ] Manual testing of paper weight assessment workflow