### PR TITLE
Implement CLI application for paperchecker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,12 @@ Since this project uses `uv` for package management:
   - `uv run python fact_checker_stats.py` - Generate comprehensive statistical analysis report (console output)
   - `uv run python fact_checker_stats.py --export-csv stats_output/` - Export statistics to CSV files
   - `uv run python fact_checker_stats.py --export-csv stats_output/ --plot` - Create visualization plots
+  - `uv run python paper_checker_cli.py abstracts.json` - PaperChecker: fact-check medical abstracts against literature
+  - `uv run python paper_checker_cli.py abstracts.json -o results.json` - Export PaperChecker results to JSON
+  - `uv run python paper_checker_cli.py abstracts.json --export-markdown reports/` - Export markdown reports per abstract
+  - `uv run python paper_checker_cli.py --pmid 12345678 23456789` - Check abstracts by PMID from database
+  - `uv run python paper_checker_cli.py abstracts.json --quick` - Quick test mode (max 5 abstracts)
+  - `uv run python paper_checker_cli.py abstracts.json --continue-on-error` - Continue processing on failures
 - **GUI Applications**:
   - `uv run python setup_wizard.py` - PySide6 setup wizard for initial database configuration and data import
   - `uv run python bmlibrarian_research_gui.py` - Desktop research application with visual workflow progress and report preview
@@ -441,6 +447,7 @@ bmlibrarian/
 ├── fact_checker_cli.py        # Fact-checker CLI for training data auditing
 ├── fact_checker_review_gui.py # Human review and annotation GUI for fact-checking results
 ├── fact_checker_stats.py      # Comprehensive statistical analysis for fact-checker evaluations
+├── paper_checker_cli.py       # PaperChecker CLI for fact-checking medical abstracts against literature
 ├── export_review_package.py   # Export SQLite review packages for distribution
 ├── export_human_evaluations.py # Export human annotations to JSON
 ├── import_human_evaluations.py # Re-import human evaluations to PostgreSQL

--- a/doc/developers/paperchecker_cli_system.md
+++ b/doc/developers/paperchecker_cli_system.md
@@ -1,0 +1,384 @@
+# PaperChecker CLI System Documentation
+
+## Overview
+
+The PaperChecker CLI system provides a command-line interface for batch fact-checking of medical abstracts. It follows the modular architecture pattern used by other BMLibrarian CLI tools, separating concerns into distinct modules for maintainability and testability.
+
+## Architecture
+
+### Module Structure
+
+```
+src/bmlibrarian/paperchecker/cli/
+├── __init__.py           # Module exports
+├── app.py               # Main entry point and argument parsing
+├── commands.py          # Command handlers (load, check, export)
+└── formatters.py        # Output formatting and display
+```
+
+### Design Principles
+
+1. **Separation of Concerns**: Logic is split between argument parsing, command execution, and output formatting
+2. **Validation First**: All inputs are validated before processing
+3. **Graceful Degradation**: Continue-on-error mode allows partial batch completion
+4. **Progress Tracking**: Real-time progress via tqdm with callback support
+5. **Golden Rules Compliance**: No magic numbers, type hints, docstrings, error handling
+
+## Module Documentation
+
+### app.py - Main Entry Point
+
+The main application module handles:
+- Command-line argument parsing
+- Logging configuration
+- Agent initialization
+- High-level workflow orchestration
+
+```python
+from bmlibrarian.paperchecker.cli.app import main
+
+# Entry point
+exit_code = main()
+```
+
+**Key Functions:**
+
+| Function | Description |
+|----------|-------------|
+| `parse_args()` | Parse command-line arguments using argparse |
+| `setup_logging(verbose)` | Configure logging levels |
+| `create_agent(config_path)` | Initialize PaperCheckerAgent |
+| `main()` | Main entry point, returns exit code |
+
+### commands.py - Command Handlers
+
+Provides functions for loading abstracts, processing them, and exporting results.
+
+**Constants:**
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `MIN_ABSTRACT_LENGTH` | 50 | Minimum abstract character count |
+| `MAX_ABSTRACT_LENGTH` | 50000 | Maximum abstract character count |
+| `MIN_PMID` | 1 | Minimum valid PMID |
+| `MAX_PMID` | 99999999999 | Maximum valid PMID (11 digits) |
+
+**Key Functions:**
+
+```python
+from bmlibrarian.paperchecker.cli.commands import (
+    validate_abstract,
+    load_abstracts_from_json,
+    load_abstracts_from_pmids,
+    check_abstracts,
+    export_results_json,
+    export_markdown_reports,
+)
+```
+
+| Function | Description |
+|----------|-------------|
+| `validate_abstract(abstract, index)` | Validate single abstract text |
+| `load_abstracts_from_json(filepath)` | Load and validate JSON file |
+| `load_abstracts_from_pmids(pmids)` | Fetch abstracts from database |
+| `check_abstracts(abstracts, agent, ...)` | Process abstracts with progress tracking |
+| `export_results_json(results, output_file)` | Export to JSON format |
+| `export_markdown_reports(results, output_dir)` | Export individual markdown reports |
+
+### formatters.py - Output Formatting
+
+Handles all console output formatting including statistics, summaries, and error reports.
+
+**Display Constants:**
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SEPARATOR_WIDTH` | 60 | Width of separator lines |
+| `SEPARATOR_CHAR` | "=" | Character for major separators |
+| `MAX_PREVIEW_LENGTH` | 80 | Max length for inline text previews |
+
+**Key Functions:**
+
+```python
+from bmlibrarian.paperchecker.cli.formatters import (
+    print_statistics,
+    print_abstract_summary,
+    format_verdict_summary,
+    print_error_summary,
+    print_completion_banner,
+)
+```
+
+| Function | Description |
+|----------|-------------|
+| `print_statistics(results)` | Print comprehensive statistics |
+| `print_abstract_summary(result, index, verbose)` | Print single result summary |
+| `format_verdict_summary(verdicts)` | Format verdicts for inline display |
+| `print_error_summary(errors)` | Print error list |
+| `print_completion_banner(...)` | Print completion message |
+
+## Data Flow
+
+```
+                    ┌─────────────────┐
+                    │   Input Source  │
+                    │  (JSON/PMIDs)   │
+                    └────────┬────────┘
+                             │
+                             ▼
+                    ┌─────────────────┐
+                    │   Validation    │
+                    │ load_abstracts  │
+                    └────────┬────────┘
+                             │
+                             ▼
+                    ┌─────────────────┐
+                    │ PaperChecker    │
+                    │    Agent        │
+                    └────────┬────────┘
+                             │
+        ┌────────────────────┼────────────────────┐
+        │                    │                    │
+        ▼                    ▼                    ▼
+┌───────────────┐   ┌───────────────┐   ┌───────────────┐
+│ Console Stats │   │  JSON Export  │   │ Markdown Rpts │
+│  formatters   │   │   commands    │   │   commands    │
+└───────────────┘   └───────────────┘   └───────────────┘
+```
+
+## Error Handling
+
+### Validation Errors
+
+Input validation occurs at multiple levels:
+
+1. **File-Level**: File existence, JSON parsing
+2. **Structure-Level**: List format, required keys
+3. **Content-Level**: Abstract length, PMID ranges
+
+```python
+def validate_abstract(abstract: str, index: int) -> Tuple[bool, Optional[str]]:
+    """
+    Returns (is_valid, error_message).
+    """
+```
+
+### Processing Errors
+
+Processing errors are captured per-abstract:
+
+```python
+results, errors = check_abstracts(
+    abstracts=abstracts,
+    agent=agent,
+    continue_on_error=True  # Don't stop on first error
+)
+
+# errors = [
+#     {"index": 3, "pmid": 123, "error": "Connection timeout"},
+#     {"index": 7, "pmid": None, "error": "Model unavailable"},
+# ]
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success (all abstracts processed) |
+| 1 | Error (processing failed or errors occurred) |
+| 130 | Interrupted by user (Ctrl+C) |
+
+## Progress Tracking
+
+### tqdm Integration
+
+Progress is tracked using tqdm with custom formatting:
+
+```python
+PROGRESS_BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]"
+
+pbar = tqdm(abstracts, desc="Checking abstracts", unit="abstract")
+for item in pbar:
+    pbar.set_postfix({"ok": len(results), "errors": len(errors)})
+```
+
+### Progress Callback
+
+Optional callback for external progress tracking:
+
+```python
+def progress_callback(completed: int, total: int, error: Optional[str]) -> None:
+    if error:
+        log.warning(f"Error at {completed}/{total}: {error}")
+    else:
+        log.info(f"Progress: {completed}/{total}")
+
+results, errors = check_abstracts(
+    abstracts,
+    agent,
+    progress_callback=progress_callback
+)
+```
+
+## Testing
+
+### Unit Tests
+
+Create tests in `tests/test_paperchecker_cli.py`:
+
+```python
+import pytest
+from bmlibrarian.paperchecker.cli.commands import (
+    validate_abstract,
+    load_abstracts_from_json,
+)
+
+def test_validate_abstract_too_short():
+    """Test validation rejects short abstracts."""
+    is_valid, error = validate_abstract("Too short", 0)
+    assert not is_valid
+    assert "too short" in error.lower()
+
+def test_validate_abstract_valid():
+    """Test validation accepts valid abstracts."""
+    abstract = "A" * 100  # 100 characters
+    is_valid, error = validate_abstract(abstract, 0)
+    assert is_valid
+    assert error is None
+```
+
+### Integration Tests
+
+```python
+@pytest.mark.integration
+@pytest.mark.requires_ollama
+@pytest.mark.requires_database
+def test_cli_end_to_end(tmp_path):
+    """Test full CLI workflow."""
+    # Create test input
+    input_file = tmp_path / "test_input.json"
+    input_file.write_text(json.dumps([{
+        "abstract": "Test abstract " * 20,
+        "metadata": {"pmid": 12345}
+    }]))
+
+    # Run CLI
+    from bmlibrarian.paperchecker.cli.app import main
+    import sys
+    sys.argv = ["paper_checker_cli.py", str(input_file), "--quick"]
+
+    exit_code = main()
+    assert exit_code == 0
+```
+
+## Extension Points
+
+### Custom Input Sources
+
+Add new input sources by creating loader functions:
+
+```python
+def load_abstracts_from_csv(filepath: str) -> List[Dict[str, Any]]:
+    """Load abstracts from CSV file."""
+    import csv
+    abstracts = []
+    with open(filepath) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            is_valid, error = validate_abstract(row["abstract"], len(abstracts))
+            if is_valid:
+                abstracts.append({
+                    "abstract": row["abstract"],
+                    "metadata": {"pmid": int(row.get("pmid", 0))}
+                })
+    return abstracts
+```
+
+### Custom Output Formats
+
+Add new export formats:
+
+```python
+def export_results_csv(
+    results: List[PaperCheckResult],
+    output_file: str
+) -> None:
+    """Export results to CSV format."""
+    import csv
+    with open(output_file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["pmid", "statement", "verdict", "confidence"])
+        for result in results:
+            pmid = result.source_metadata.get("pmid", "")
+            for stmt, verdict in zip(result.statements, result.verdicts):
+                writer.writerow([
+                    pmid,
+                    stmt.text,
+                    verdict.verdict,
+                    verdict.confidence
+                ])
+```
+
+### Custom Formatters
+
+Add new display formats:
+
+```python
+def print_json_statistics(results: List[PaperCheckResult]) -> None:
+    """Print statistics as JSON."""
+    import json
+    stats = {
+        "total_abstracts": len(results),
+        "total_statements": sum(len(r.statements) for r in results),
+        "verdicts": {"supports": 0, "contradicts": 0, "undecided": 0}
+    }
+    for result in results:
+        for v in result.verdicts:
+            stats["verdicts"][v.verdict] += 1
+    print(json.dumps(stats, indent=2))
+```
+
+## Configuration
+
+### Config Integration
+
+The CLI uses BMLibrarian's configuration system:
+
+```python
+from bmlibrarian.config import get_config, get_agent_config
+
+config = get_config()
+paper_checker_config = get_agent_config("paper_checker")
+```
+
+### CLI-Specific Settings
+
+Settings that affect only CLI behavior:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `QUICK_MODE_MAX_ABSTRACTS` | 5 | Max abstracts in quick mode |
+| `LOG_FORMAT` | Standard format | Logging format string |
+
+## Dependencies
+
+### Required Packages
+
+- `tqdm>=4.66.0` - Progress bars
+- `argparse` - Command-line parsing (stdlib)
+- `json` - JSON handling (stdlib)
+- `logging` - Logging (stdlib)
+- `pathlib` - Path handling (stdlib)
+
+### Internal Dependencies
+
+- `bmlibrarian.paperchecker.agent` - PaperCheckerAgent
+- `bmlibrarian.paperchecker.data_models` - Data classes
+- `bmlibrarian.database` - Database access
+- `bmlibrarian.config` - Configuration
+
+## See Also
+
+- [PaperChecker CLI User Guide](../users/paper_checker_cli_guide.md)
+- [PaperChecker Architecture Overview](../../doc/planning/paperchecker/00_ARCHITECTURE_OVERVIEW.md)
+- [PaperChecker Database System](papercheck_database_system.md)

--- a/doc/users/paper_checker_cli_guide.md
+++ b/doc/users/paper_checker_cli_guide.md
@@ -1,0 +1,395 @@
+# PaperChecker CLI User Guide
+
+## Overview
+
+The PaperChecker CLI (`paper_checker_cli.py`) is a command-line tool for fact-checking medical abstracts against biomedical literature. It analyzes abstracts, extracts core research claims, searches for contradictory evidence, and generates verdicts on whether the claims are supported or contradicted by existing literature.
+
+## Quick Start
+
+```bash
+# Check abstracts from a JSON file
+uv run python paper_checker_cli.py abstracts.json
+
+# Check specific PMIDs from database
+uv run python paper_checker_cli.py --pmid 12345678 23456789
+
+# Export results to JSON and markdown
+uv run python paper_checker_cli.py abstracts.json -o results.json --export-markdown reports/
+```
+
+## Installation
+
+PaperChecker is part of BMLibrarian. Ensure you have:
+
+1. Python 3.12 or higher
+2. PostgreSQL with pgvector extension
+3. Ollama running with required models
+
+```bash
+# Install dependencies
+uv sync
+
+# Verify installation
+uv run python paper_checker_cli.py --help
+```
+
+## Input Formats
+
+### JSON File Format
+
+The input JSON file should contain a list of abstract objects:
+
+```json
+[
+  {
+    "abstract": "Background: Type 2 diabetes management requires effective long-term glycemic control. Objective: To compare the efficacy of metformin versus GLP-1 receptor agonists in long-term outcomes. Methods: Retrospective cohort study of 10,000 patients over 5 years. Results: Metformin demonstrated superior HbA1c reduction (1.5% vs 1.2%, p<0.001) and lower cardiovascular events (HR 0.75, 95% CI 0.65-0.85). Conclusion: Metformin shows superior long-term efficacy compared to GLP-1 agonists for T2DM.",
+    "metadata": {
+      "pmid": 12345678,
+      "title": "Metformin vs GLP-1 in Type 2 Diabetes",
+      "authors": ["Smith J", "Jones A"],
+      "year": 2023,
+      "journal": "Diabetes Care",
+      "doi": "10.1234/example"
+    }
+  },
+  {
+    "abstract": "Another abstract text...",
+    "metadata": {
+      "pmid": 23456789
+    }
+  }
+]
+```
+
+**Required fields:**
+- `abstract`: Full abstract text (minimum 50 characters)
+
+**Optional metadata fields:**
+- `pmid`: PubMed ID
+- `title`: Article title
+- `authors`: List of author names
+- `year`: Publication year
+- `journal`: Journal name
+- `doi`: Digital Object Identifier
+
+### PMID-Based Input
+
+Instead of a JSON file, you can specify PMIDs directly:
+
+```bash
+uv run python paper_checker_cli.py --pmid 12345678 23456789 34567890
+```
+
+The CLI will fetch abstracts from your local database for the specified PMIDs.
+
+## Command-Line Options
+
+### Input Options
+
+| Option | Description |
+|--------|-------------|
+| `input_file` | JSON file with abstracts to check |
+| `--pmid PMID [PMID ...]` | Check abstracts by PMID (fetch from database) |
+
+### Output Options
+
+| Option | Description |
+|--------|-------------|
+| `-o FILE, --output FILE` | Export results to JSON file |
+| `--export-markdown DIR` | Export markdown reports to directory |
+
+### Processing Options
+
+| Option | Description |
+|--------|-------------|
+| `--max-abstracts N` | Limit number of abstracts to check |
+| `--continue-on-error` | Continue processing if an abstract fails |
+| `--quick` | Quick test mode (process max 5 abstracts) |
+| `--config FILE` | Custom config file path |
+
+### Display Options
+
+| Option | Description |
+|--------|-------------|
+| `-v, --verbose` | Verbose output with debug messages |
+| `--detailed` | Show detailed results for each abstract |
+| `--no-stats` | Skip printing statistics summary |
+
+## Usage Examples
+
+### Basic Usage
+
+```bash
+# Check all abstracts in a JSON file
+uv run python paper_checker_cli.py abstracts.json
+```
+
+### Export Results
+
+```bash
+# Export to JSON
+uv run python paper_checker_cli.py abstracts.json -o results.json
+
+# Export markdown reports (one per abstract)
+uv run python paper_checker_cli.py abstracts.json --export-markdown reports/
+
+# Export both formats
+uv run python paper_checker_cli.py abstracts.json -o results.json --export-markdown reports/
+```
+
+### Testing and Development
+
+```bash
+# Quick test mode (only 5 abstracts)
+uv run python paper_checker_cli.py abstracts.json --quick
+
+# Verbose output for debugging
+uv run python paper_checker_cli.py abstracts.json -v --detailed
+
+# Continue on errors (for batch processing)
+uv run python paper_checker_cli.py abstracts.json --continue-on-error
+```
+
+### Limiting Processing
+
+```bash
+# Process only first 10 abstracts
+uv run python paper_checker_cli.py abstracts.json --max-abstracts 10
+```
+
+## Output Formats
+
+### Console Output
+
+The CLI displays progress and summary statistics:
+
+```
+Loading abstracts...
++ Loaded 10 abstracts
+
+Initializing PaperCheckerAgent...
+Testing connections...
++ All connections successful
+
+Processing 10 abstracts...
+============================================================
+Checking abstracts: 100%|████████████| 10/10 [05:32<00:00, 33.2s/abstract]
+============================================================
+
+============================================================
+SUMMARY STATISTICS
+============================================================
+
+Abstracts checked: 10
+Statements extracted: 18
+Average statements per abstract: 1.8
+
+Verdict Distribution:
+  Supports    :    5 ( 27.8%) [=====               ]
+  Contradicts :    8 ( 44.4%) [=========           ]
+  Undecided   :    5 ( 27.8%) [=====               ]
+
+Confidence Distribution:
+  High        :    7 ( 38.9%) [========            ]
+  Medium      :    8 ( 44.4%) [=========           ]
+  Low         :    3 ( 16.7%) [===                 ]
+
+Search Statistics (aggregated):
+  Documents found:  1,234
+  Documents scored: 456
+  Documents cited:  123
+  Citation rate:    10.0%
+
+============================================================
+PROCESSING COMPLETE
+============================================================
++ Completed: 10/10 abstracts
++ JSON results: results.json
++ Markdown reports: reports/
+============================================================
+```
+
+### JSON Output Format
+
+The JSON output contains complete results for each abstract:
+
+```json
+[
+  {
+    "original_abstract": "...",
+    "source_metadata": {
+      "pmid": 12345678,
+      "title": "...",
+      "authors": ["..."]
+    },
+    "statements": [
+      {
+        "text": "Metformin shows superior long-term efficacy...",
+        "type": "conclusion",
+        "confidence": 0.85,
+        "order": 1
+      }
+    ],
+    "results": [
+      {
+        "statement": "...",
+        "counter_statement": "...",
+        "search_stats": {
+          "semantic": 45,
+          "hyde": 38,
+          "keyword": 22,
+          "deduplicated": 78
+        },
+        "scoring_stats": {
+          "total_scored": 78,
+          "above_threshold": 15
+        },
+        "counter_report": "## Counter-Evidence Summary\n\n...",
+        "verdict": {
+          "verdict": "contradicts",
+          "rationale": "Multiple studies found GLP-1 agonists...",
+          "confidence": "high",
+          "num_citations": 8
+        }
+      }
+    ],
+    "overall_assessment": "The abstract's main claim about metformin superiority is contradicted by...",
+    "metadata": {
+      "model": "gpt-oss:20b",
+      "timestamp": "2024-01-15T10:30:00",
+      "processing_time_seconds": 32.5
+    }
+  }
+]
+```
+
+### Markdown Report Format
+
+Each markdown report includes:
+
+1. **Original Abstract** - The full abstract text
+2. **Source Information** - PMID, title, DOI
+3. **Analysis Results** - For each statement:
+   - Extracted claim
+   - Verdict (SUPPORTS/CONTRADICTS/UNDECIDED)
+   - Confidence level
+   - Rationale
+   - Counter-evidence summary with citations
+4. **Overall Assessment** - Aggregate findings
+
+## Verdict Categories
+
+### Verdict Values
+
+| Verdict | Meaning |
+|---------|---------|
+| `supports` | Counter-evidence search found evidence that **supports** the original claim (no contradiction found) |
+| `contradicts` | Counter-evidence search found evidence that **contradicts** the original claim |
+| `undecided` | Insufficient or mixed evidence to make a determination |
+
+### Confidence Levels
+
+| Level | Meaning |
+|-------|---------|
+| `high` | Strong evidence from multiple high-quality sources |
+| `medium` | Moderate evidence with some limitations |
+| `low` | Limited evidence or conflicting sources |
+
+## Error Handling
+
+### Continue on Error
+
+By default, processing stops on the first error. Use `--continue-on-error` for batch processing:
+
+```bash
+uv run python paper_checker_cli.py abstracts.json --continue-on-error
+```
+
+Failed abstracts are reported at the end:
+
+```
+============================================================
+ERRORS (2 abstracts failed)
+============================================================
+  PMID 12345678: Connection timeout during search
+  index 5: Abstract text too short (45 chars)
+```
+
+### Common Errors
+
+| Error | Solution |
+|-------|----------|
+| `Input file not found` | Check file path exists |
+| `Connection test failed` | Ensure Ollama and PostgreSQL are running |
+| `Abstract too short` | Minimum 50 characters required |
+| `Invalid JSON` | Validate JSON structure |
+
+## Configuration
+
+### Default Configuration
+
+The CLI uses settings from `~/.bmlibrarian/config.json`:
+
+```json
+{
+  "paper_checker": {
+    "model": "gpt-oss:20b",
+    "temperature": 0.3,
+    "max_statements": 2,
+    "score_threshold": 3.0,
+    "search": {
+      "semantic_limit": 50,
+      "hyde_limit": 50,
+      "keyword_limit": 50
+    }
+  }
+}
+```
+
+### Custom Configuration
+
+Use the `--config` option to specify a different configuration file:
+
+```bash
+uv run python paper_checker_cli.py abstracts.json --config custom_config.json
+```
+
+## Performance Considerations
+
+- **Processing Time**: Expect 30-60 seconds per abstract depending on complexity
+- **Memory Usage**: Each abstract is processed sequentially to minimize memory
+- **Database Load**: Multi-strategy search performs multiple queries per statement
+- **Quick Mode**: Use `--quick` for testing (limits to 5 abstracts)
+
+## Troubleshooting
+
+### Check Services
+
+```bash
+# Test Ollama
+curl http://localhost:11434/api/tags
+
+# Test PostgreSQL
+psql -c "SELECT 1" your_database
+```
+
+### Verbose Mode
+
+Enable verbose output for debugging:
+
+```bash
+uv run python paper_checker_cli.py abstracts.json -v --detailed
+```
+
+### Common Issues
+
+1. **"No module named 'tqdm'"**: Run `uv sync` to install dependencies
+2. **"Connection test failed"**: Check Ollama and PostgreSQL services
+3. **"Abstract too short"**: Ensure abstracts have at least 50 characters
+4. **"PMID not found"**: Verify PMIDs exist in your database
+
+## See Also
+
+- [PaperChecker Architecture](../developers/paperchecker_architecture.md)
+- [PaperChecker Database Guide](papercheck_database_guide.md)
+- [BMLibrarian Configuration Guide](configuration_guide.md)

--- a/paper_checker_cli.py
+++ b/paper_checker_cli.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+PaperChecker CLI - Medical abstract fact-checking from command line.
+
+This is the entry point for the PaperChecker command-line interface.
+Uses the bmlibrarian.paperchecker.cli module for all functionality.
+
+Usage:
+    uv run python paper_checker_cli.py input.json
+    uv run python paper_checker_cli.py input.json -o results.json
+    uv run python paper_checker_cli.py input.json --export-markdown reports/
+    uv run python paper_checker_cli.py --pmid 12345678 23456789
+
+For full usage information:
+    uv run python paper_checker_cli.py --help
+"""
+
+import sys
+
+from src.bmlibrarian.paperchecker.cli.app import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "qtawesome>=1.3.0",
     "psutil>=7.1.3",
     "backoff>=2.2.1",
+    "tqdm>=4.66.0",
 ]
 
 [project.optional-dependencies]

--- a/src/bmlibrarian/paperchecker/cli/__init__.py
+++ b/src/bmlibrarian/paperchecker/cli/__init__.py
@@ -1,0 +1,38 @@
+"""
+PaperChecker CLI module.
+
+Provides command-line interface for batch fact-checking of medical abstracts.
+This module enables users to check abstracts from JSON files or by PMID,
+with support for progress tracking, error recovery, and multiple output formats.
+
+Modules:
+    app: Main CLI entry point and argument parsing
+    commands: Command handlers for abstract loading and processing
+    formatters: Output formatting for results and statistics
+"""
+
+from .app import main
+from .commands import (
+    load_abstracts_from_json,
+    load_abstracts_from_pmids,
+    check_abstracts,
+    export_results_json,
+    export_markdown_reports,
+)
+from .formatters import (
+    print_statistics,
+    print_abstract_summary,
+    format_verdict_summary,
+)
+
+__all__ = [
+    "main",
+    "load_abstracts_from_json",
+    "load_abstracts_from_pmids",
+    "check_abstracts",
+    "export_results_json",
+    "export_markdown_reports",
+    "print_statistics",
+    "print_abstract_summary",
+    "format_verdict_summary",
+]

--- a/src/bmlibrarian/paperchecker/cli/app.py
+++ b/src/bmlibrarian/paperchecker/cli/app.py
@@ -1,0 +1,362 @@
+"""
+Main CLI application for PaperChecker.
+
+Provides command-line interface for batch fact-checking of medical abstracts.
+Supports JSON input files, PMID-based loading, progress tracking,
+error recovery, and multiple output formats.
+
+Usage:
+    uv run python paper_checker_cli.py input.json
+    uv run python paper_checker_cli.py input.json -o results.json
+    uv run python paper_checker_cli.py input.json --export-markdown reports/
+    uv run python paper_checker_cli.py --pmid 12345678 23456789
+"""
+
+import sys
+import logging
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from .commands import (
+    load_abstracts_from_json,
+    load_abstracts_from_pmids,
+    check_abstracts,
+    export_results_json,
+    export_markdown_reports,
+)
+from .formatters import (
+    print_statistics,
+    print_abstract_summary,
+    print_error_summary,
+    print_completion_banner,
+)
+
+# Logging configuration
+LOG_FORMAT: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+LOG_DATE_FORMAT: str = "%Y-%m-%d %H:%M:%S"
+
+# Default values for configuration
+DEFAULT_OLLAMA_HOST: str = "http://localhost:11434"
+QUICK_MODE_MAX_ABSTRACTS: int = 5
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command line arguments.
+
+    Returns:
+        Namespace object with parsed arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="PaperChecker - Medical abstract fact-checking against literature",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Check abstracts from JSON file
+  uv run python paper_checker_cli.py abstracts.json
+
+  # Check and export results to JSON
+  uv run python paper_checker_cli.py abstracts.json -o results.json
+
+  # Export markdown reports
+  uv run python paper_checker_cli.py abstracts.json --export-markdown reports/
+
+  # Check specific PMIDs from database
+  uv run python paper_checker_cli.py --pmid 12345678 23456789
+
+  # Limit number of abstracts
+  uv run python paper_checker_cli.py abstracts.json --max-abstracts 10
+
+  # Continue processing on errors
+  uv run python paper_checker_cli.py abstracts.json --continue-on-error
+
+  # Quick test mode
+  uv run python paper_checker_cli.py abstracts.json --quick
+
+  # Verbose output with individual results
+  uv run python paper_checker_cli.py abstracts.json -v --detailed
+
+Input JSON format:
+  [
+    {
+      "abstract": "Full abstract text...",
+      "metadata": {"pmid": 12345678, "title": "...", "authors": [...]}
+    },
+    ...
+  ]
+        """
+    )
+
+    # Input sources (mutually exclusive group)
+    input_group = parser.add_mutually_exclusive_group()
+
+    input_group.add_argument(
+        "input_file",
+        nargs="?",
+        help="JSON file with abstracts to check"
+    )
+
+    input_group.add_argument(
+        "--pmid",
+        nargs="+",
+        type=int,
+        metavar="PMID",
+        help="Check abstracts by PMID (fetch from database)"
+    )
+
+    # Output options
+    parser.add_argument(
+        "-o", "--output",
+        metavar="FILE",
+        help="Output JSON file for results"
+    )
+
+    parser.add_argument(
+        "--export-markdown",
+        metavar="DIR",
+        help="Export markdown reports to directory"
+    )
+
+    # Configuration
+    parser.add_argument(
+        "--config",
+        metavar="FILE",
+        help="Config file path (default: ~/.bmlibrarian/config.json)"
+    )
+
+    # Processing options
+    parser.add_argument(
+        "--max-abstracts",
+        type=int,
+        metavar="N",
+        help="Limit number of abstracts to check"
+    )
+
+    parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help="Continue processing if an abstract fails"
+    )
+
+    # Quick mode
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help=f"Quick test mode: process max {QUICK_MODE_MAX_ABSTRACTS} abstracts"
+    )
+
+    # Display options
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose output with debug messages"
+    )
+
+    parser.add_argument(
+        "--detailed",
+        action="store_true",
+        help="Show detailed results for each abstract"
+    )
+
+    parser.add_argument(
+        "--no-stats",
+        action="store_true",
+        help="Skip printing statistics summary"
+    )
+
+    return parser.parse_args()
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """
+    Configure logging based on verbosity level.
+
+    Args:
+        verbose: If True, set DEBUG level; otherwise INFO level
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format=LOG_FORMAT,
+        datefmt=LOG_DATE_FORMAT
+    )
+
+
+def create_agent(config_path: Optional[str] = None):
+    """
+    Create and initialize PaperCheckerAgent.
+
+    Args:
+        config_path: Optional path to configuration file
+
+    Returns:
+        Initialized PaperCheckerAgent instance
+
+    Raises:
+        ImportError: If paperchecker module cannot be imported
+        RuntimeError: If agent initialization fails
+    """
+    try:
+        from bmlibrarian.paperchecker import PaperCheckerAgent
+
+        # Load config if specified
+        config = None
+        if config_path:
+            from bmlibrarian.config import Config
+            config = Config(config_path=config_path)._config
+
+        agent = PaperCheckerAgent(config=config)
+        return agent
+
+    except ImportError as e:
+        logger.error(f"Failed to import PaperCheckerAgent: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Failed to initialize PaperCheckerAgent: {e}")
+        raise RuntimeError(f"Agent initialization failed: {e}") from e
+
+
+def main() -> int:
+    """
+    Main entry point for PaperChecker CLI.
+
+    Returns:
+        Exit code (0 for success, non-zero for errors)
+    """
+    args = parse_args()
+
+    # Setup logging
+    setup_logging(args.verbose)
+
+    # Validate input source
+    if not args.input_file and not args.pmid:
+        print("\nError: Must provide either input_file or --pmid")
+        print("Use --help for usage information")
+        return 1
+
+    try:
+        # Load abstracts
+        print("\nLoading abstracts...")
+
+        if args.input_file:
+            if not Path(args.input_file).exists():
+                print(f"\nX Error: Input file not found: {args.input_file}")
+                return 1
+            abstracts = load_abstracts_from_json(args.input_file)
+        else:
+            abstracts = load_abstracts_from_pmids(args.pmid)
+
+        if not abstracts:
+            print("\nX Error: No abstracts to process")
+            return 1
+
+        print(f"+ Loaded {len(abstracts)} abstracts")
+
+        # Apply limits
+        if args.quick and args.max_abstracts is None:
+            args.max_abstracts = QUICK_MODE_MAX_ABSTRACTS
+            print(f"  (Quick mode: limiting to {QUICK_MODE_MAX_ABSTRACTS} abstracts)")
+
+        if args.max_abstracts and len(abstracts) > args.max_abstracts:
+            logger.info(f"Limiting to {args.max_abstracts} abstracts")
+            abstracts = abstracts[:args.max_abstracts]
+            print(f"  (Limited to {args.max_abstracts} abstracts)")
+
+        # Initialize agent
+        print("\nInitializing PaperCheckerAgent...")
+        agent = create_agent(args.config)
+
+        # Test connection
+        print("Testing connections...")
+        if not agent.test_connection():
+            print("\nX Error: Connection test failed")
+            print("  Please ensure:")
+            print(f"  - Ollama is running at {DEFAULT_OLLAMA_HOST}")
+            print("  - PostgreSQL is running and accessible")
+            print("  - Required models are available")
+            return 1
+        print("+ All connections successful")
+
+        # Process abstracts
+        print(f"\nProcessing {len(abstracts)} abstracts...")
+        print("=" * 60)
+
+        results, errors = check_abstracts(
+            abstracts=abstracts,
+            agent=agent,
+            continue_on_error=args.continue_on_error
+        )
+
+        print("=" * 60)
+
+        # Show detailed results if requested
+        if args.detailed and results:
+            print("\nDetailed Results:")
+            for i, result in enumerate(results, 1):
+                print_abstract_summary(result, i, verbose=args.verbose)
+
+        # Export results
+        if args.output and results:
+            try:
+                export_results_json(results, args.output)
+                print(f"+ JSON results exported to: {args.output}")
+            except Exception as e:
+                logger.error(f"Failed to export JSON: {e}")
+                print(f"X Error exporting JSON: {e}")
+
+        if args.export_markdown and results:
+            try:
+                created_files = export_markdown_reports(results, args.export_markdown)
+                print(f"+ {len(created_files)} markdown reports exported to: {args.export_markdown}")
+            except Exception as e:
+                logger.error(f"Failed to export markdown: {e}")
+                print(f"X Error exporting markdown: {e}")
+
+        # Print statistics
+        if not args.no_stats and results:
+            print_statistics(results)
+
+        # Print error summary
+        if errors:
+            print_error_summary(errors)
+
+        # Print completion banner
+        print_completion_banner(
+            total=len(abstracts),
+            successful=len(results),
+            errors=len(errors),
+            output_file=args.output,
+            markdown_dir=args.export_markdown
+        )
+
+        # Return success only if all abstracts processed successfully
+        return 0 if len(errors) == 0 else 1
+
+    except KeyboardInterrupt:
+        print("\n\n! Interrupted by user")
+        return 130
+    except ValueError as e:
+        print(f"\nX Validation error: {e}")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        return 1
+    except RuntimeError as e:
+        print(f"\nX Runtime error: {e}")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        return 1
+    except Exception as e:
+        print(f"\nX Unexpected error: {e}")
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bmlibrarian/paperchecker/cli/commands.py
+++ b/src/bmlibrarian/paperchecker/cli/commands.py
@@ -1,0 +1,445 @@
+"""
+Command handlers for PaperChecker CLI.
+
+Provides functions for loading abstracts from JSON files or database,
+processing abstracts with the PaperCheckerAgent, and exporting results.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from tqdm import tqdm
+
+from bmlibrarian.paperchecker.agent import PaperCheckerAgent
+from bmlibrarian.paperchecker.data_models import PaperCheckResult
+
+logger = logging.getLogger(__name__)
+
+# Constants for validation
+MIN_ABSTRACT_LENGTH: int = 50
+MAX_ABSTRACT_LENGTH: int = 50000
+MIN_PMID: int = 1
+MAX_PMID: int = 99999999999  # 11 digits max for PMID
+
+# Progress bar configuration
+PROGRESS_BAR_FORMAT: str = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]"
+PROGRESS_BAR_UNIT: str = "abstract"
+
+
+def validate_abstract(abstract: str, index: int) -> Tuple[bool, Optional[str]]:
+    """
+    Validate abstract text for processing.
+
+    Args:
+        abstract: The abstract text to validate
+        index: Index position for error reporting
+
+    Returns:
+        Tuple of (is_valid, error_message). If valid, error_message is None.
+    """
+    if not abstract:
+        return False, f"Abstract at index {index} is empty"
+
+    if not isinstance(abstract, str):
+        return False, f"Abstract at index {index} is not a string (got {type(abstract).__name__})"
+
+    stripped = abstract.strip()
+    if len(stripped) < MIN_ABSTRACT_LENGTH:
+        return False, (
+            f"Abstract at index {index} is too short "
+            f"({len(stripped)} chars, minimum: {MIN_ABSTRACT_LENGTH})"
+        )
+
+    if len(stripped) > MAX_ABSTRACT_LENGTH:
+        return False, (
+            f"Abstract at index {index} is too long "
+            f"({len(stripped)} chars, maximum: {MAX_ABSTRACT_LENGTH})"
+        )
+
+    return True, None
+
+
+def load_abstracts_from_json(filepath: str) -> List[Dict[str, Any]]:
+    """
+    Load abstracts from JSON file with validation.
+
+    Expected JSON format:
+    [
+        {
+            "abstract": "Full abstract text...",
+            "metadata": {"pmid": 12345678, "title": "...", ...}
+        },
+        ...
+    ]
+
+    Args:
+        filepath: Path to JSON file containing abstracts
+
+    Returns:
+        List of dictionaries with 'abstract' and optional 'metadata' keys
+
+    Raises:
+        FileNotFoundError: If the input file does not exist
+        ValueError: If the JSON structure is invalid or abstracts fail validation
+        json.JSONDecodeError: If the file contains invalid JSON
+    """
+    logger.info(f"Loading abstracts from {filepath}")
+
+    path = Path(filepath)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {filepath}")
+
+    if not path.is_file():
+        raise ValueError(f"Path is not a file: {filepath}")
+
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in {filepath}: {e}")
+        raise
+
+    # Validate structure
+    if not isinstance(data, list):
+        raise ValueError(
+            f"JSON must be a list of abstract objects, got {type(data).__name__}"
+        )
+
+    if len(data) == 0:
+        raise ValueError("JSON file contains no abstracts")
+
+    # Validate each abstract
+    validated_abstracts: List[Dict[str, Any]] = []
+    validation_errors: List[str] = []
+
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            validation_errors.append(
+                f"Item at index {i} is not a dict (got {type(item).__name__})"
+            )
+            continue
+
+        # Check for 'abstract' key
+        if 'abstract' not in item:
+            validation_errors.append(f"Item at index {i} missing 'abstract' key")
+            continue
+
+        # Validate abstract content
+        is_valid, error_msg = validate_abstract(item['abstract'], i)
+        if not is_valid:
+            validation_errors.append(error_msg)
+            continue
+
+        # Normalize structure
+        validated_abstracts.append({
+            'abstract': item['abstract'].strip(),
+            'metadata': item.get('metadata', {})
+        })
+
+    if validation_errors:
+        error_summary = "; ".join(validation_errors[:5])  # Limit error messages
+        if len(validation_errors) > 5:
+            error_summary += f" (and {len(validation_errors) - 5} more errors)"
+        raise ValueError(f"Validation errors in JSON file: {error_summary}")
+
+    logger.info(f"Loaded {len(validated_abstracts)} valid abstracts from {filepath}")
+    return validated_abstracts
+
+
+def load_abstracts_from_pmids(pmids: List[int]) -> List[Dict[str, Any]]:
+    """
+    Fetch abstracts from database by PMID.
+
+    Uses the DatabaseManager to query the document table for abstracts
+    matching the provided PMIDs.
+
+    Args:
+        pmids: List of PubMed IDs to fetch
+
+    Returns:
+        List of dictionaries with 'abstract' and 'metadata' keys
+
+    Raises:
+        ValueError: If any PMID is invalid
+        RuntimeError: If database connection fails
+    """
+    logger.info(f"Fetching {len(pmids)} abstracts from database")
+
+    # Validate PMIDs
+    for pmid in pmids:
+        if not isinstance(pmid, int) or pmid < MIN_PMID or pmid > MAX_PMID:
+            raise ValueError(f"Invalid PMID: {pmid}. Must be integer between {MIN_PMID} and {MAX_PMID}")
+
+    try:
+        from bmlibrarian.database import get_db_manager
+        from psycopg.rows import dict_row
+
+        db_manager = get_db_manager()
+        abstracts: List[Dict[str, Any]] = []
+
+        with db_manager.get_connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cur:
+                cur.execute("""
+                    SELECT
+                        pmid, title, abstract, authors,
+                        publication_date, publication AS journal, doi
+                    FROM document
+                    WHERE pmid = ANY(%s)
+                    AND abstract IS NOT NULL
+                    AND abstract != ''
+                """, (pmids,))
+
+                results = cur.fetchall()
+
+                for row in results:
+                    # Extract year from publication_date
+                    year = None
+                    if row.get("publication_date"):
+                        year_str = str(row["publication_date"])[:4]
+                        if year_str.isdigit():
+                            year = int(year_str)
+
+                    abstracts.append({
+                        "abstract": row["abstract"],
+                        "metadata": {
+                            "pmid": row["pmid"],
+                            "title": row.get("title"),
+                            "authors": row.get("authors"),
+                            "year": year,
+                            "journal": row.get("journal"),
+                            "doi": row.get("doi")
+                        }
+                    })
+
+        # Check for missing PMIDs
+        found_pmids = {a["metadata"]["pmid"] for a in abstracts}
+        missing_pmids = set(pmids) - found_pmids
+        if missing_pmids:
+            logger.warning(
+                f"Could not find abstracts for {len(missing_pmids)} PMIDs: "
+                f"{sorted(missing_pmids)[:10]}{'...' if len(missing_pmids) > 10 else ''}"
+            )
+
+        logger.info(f"Fetched {len(abstracts)} abstracts from database")
+        return abstracts
+
+    except ImportError as e:
+        logger.error(f"Failed to import database module: {e}")
+        raise RuntimeError("Database module not available") from e
+    except Exception as e:
+        logger.error(f"Failed to fetch abstracts from database: {e}")
+        raise RuntimeError(f"Database query failed: {e}") from e
+
+
+def check_abstracts(
+    abstracts: List[Dict[str, Any]],
+    agent: PaperCheckerAgent,
+    continue_on_error: bool = False,
+    progress_callback: Optional[Callable[[int, int, Optional[str]], None]] = None
+) -> Tuple[List[PaperCheckResult], List[Dict[str, Any]]]:
+    """
+    Check all abstracts with progress tracking and error recovery.
+
+    Processes each abstract through the PaperCheckerAgent, tracking progress
+    and optionally continuing on errors.
+
+    Args:
+        abstracts: List of abstract dictionaries to process
+        agent: Initialized PaperCheckerAgent instance
+        continue_on_error: If True, continue processing after failures
+        progress_callback: Optional callback(completed, total, error_message)
+
+    Returns:
+        Tuple of (successful_results, errors)
+        - successful_results: List of PaperCheckResult objects
+        - errors: List of error dictionaries with index, pmid, and error message
+    """
+    results: List[PaperCheckResult] = []
+    errors: List[Dict[str, Any]] = []
+    total = len(abstracts)
+
+    logger.info(f"Starting batch check of {total} abstracts")
+
+    # Progress bar
+    pbar = tqdm(
+        abstracts,
+        desc="Checking abstracts",
+        unit=PROGRESS_BAR_UNIT,
+        bar_format=PROGRESS_BAR_FORMAT
+    )
+
+    for i, item in enumerate(pbar, 1):
+        pmid = item.get("metadata", {}).get("pmid")
+
+        try:
+            # Update progress bar description
+            pbar.set_postfix({
+                "current": i,
+                "ok": len(results),
+                "errors": len(errors)
+            })
+
+            # Check abstract
+            result = agent.check_abstract(
+                abstract=item["abstract"],
+                source_metadata=item.get("metadata", {})
+            )
+
+            results.append(result)
+
+            # Log summary
+            stmt_count = len(result.statements)
+            verdict_summary = _summarize_verdicts(result)
+            logger.info(
+                f"Abstract {i}/{total}: {stmt_count} statements, {verdict_summary}"
+            )
+
+            # Callback
+            if progress_callback:
+                progress_callback(i, total, None)
+
+        except Exception as e:
+            error_info = {
+                "index": i,
+                "pmid": pmid,
+                "error": str(e),
+                "abstract_preview": item["abstract"][:100] + "..." if len(item["abstract"]) > 100 else item["abstract"]
+            }
+            errors.append(error_info)
+            logger.error(f"Failed to check abstract {i} (PMID: {pmid}): {e}")
+
+            # Callback with error
+            if progress_callback:
+                progress_callback(i, total, str(e))
+
+            if not continue_on_error:
+                logger.error("Stopping due to error (use --continue-on-error to continue)")
+                break
+
+    pbar.close()
+
+    logger.info(f"Batch check complete: {len(results)}/{total} successful, {len(errors)} errors")
+
+    return results, errors
+
+
+def _summarize_verdicts(result: PaperCheckResult) -> str:
+    """
+    Create a brief summary of verdicts for logging.
+
+    Args:
+        result: PaperCheckResult to summarize
+
+    Returns:
+        Summary string like "2 supports, 1 contradicts"
+    """
+    verdict_counts = {"supports": 0, "contradicts": 0, "undecided": 0}
+    for verdict in result.verdicts:
+        verdict_counts[verdict.verdict] += 1
+
+    parts = []
+    for vtype, count in verdict_counts.items():
+        if count > 0:
+            parts.append(f"{count} {vtype}")
+
+    return ", ".join(parts) if parts else "no verdicts"
+
+
+def export_results_json(
+    results: List[PaperCheckResult],
+    output_file: str,
+    include_metadata: bool = True
+) -> None:
+    """
+    Export results to JSON file.
+
+    Args:
+        results: List of PaperCheckResult objects to export
+        output_file: Path to output JSON file
+        include_metadata: Whether to include processing metadata
+
+    Raises:
+        OSError: If file cannot be written
+        ValueError: If results list is empty
+    """
+    if not results:
+        raise ValueError("No results to export")
+
+    logger.info(f"Exporting {len(results)} results to {output_file}")
+
+    output_path = Path(output_file)
+
+    # Ensure parent directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Convert to JSON-serializable format
+        output_data = [result.to_json_dict() for result in results]
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(output_data, f, indent=2, ensure_ascii=False)
+
+        logger.info(f"Exported {len(results)} results to {output_file}")
+
+    except Exception as e:
+        logger.error(f"Failed to export JSON: {e}")
+        raise
+
+
+def export_markdown_reports(
+    results: List[PaperCheckResult],
+    output_dir: str
+) -> List[str]:
+    """
+    Export markdown reports to directory.
+
+    Creates one markdown file per abstract with complete analysis.
+
+    Args:
+        results: List of PaperCheckResult objects to export
+        output_dir: Directory path for output files
+
+    Returns:
+        List of created file paths
+
+    Raises:
+        OSError: If directory cannot be created or files cannot be written
+        ValueError: If results list is empty
+    """
+    if not results:
+        raise ValueError("No results to export")
+
+    logger.info(f"Exporting {len(results)} markdown reports to {output_dir}")
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    created_files: List[str] = []
+
+    for i, result in enumerate(results, 1):
+        # Generate filename from PMID or index
+        pmid = result.source_metadata.get("pmid")
+        if pmid:
+            filename = f"report_pmid_{pmid}.md"
+        else:
+            filename = f"report_abstract_{i}.md"
+
+        filepath = output_path / filename
+
+        try:
+            markdown = result.to_markdown_report()
+
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(markdown)
+
+            created_files.append(str(filepath))
+            logger.debug(f"Exported report {i}/{len(results)}: {filename}")
+
+        except Exception as e:
+            logger.error(f"Failed to export markdown for abstract {i}: {e}")
+            # Continue with other files
+
+    logger.info(f"Exported {len(created_files)} reports to {output_dir}")
+    return created_files

--- a/src/bmlibrarian/paperchecker/cli/formatters.py
+++ b/src/bmlibrarian/paperchecker/cli/formatters.py
@@ -1,0 +1,328 @@
+"""
+Output formatters for PaperChecker CLI.
+
+Provides functions for displaying results, statistics, and summaries
+in human-readable formats for the command line.
+"""
+
+from typing import Any, Dict, List
+
+from bmlibrarian.paperchecker.data_models import PaperCheckResult, Verdict
+
+# Display constants
+SEPARATOR_WIDTH: int = 60
+SEPARATOR_CHAR: str = "="
+SUBSEPARATOR_CHAR: str = "-"
+INDENT: str = "  "
+MAX_PREVIEW_LENGTH: int = 80
+MAX_ABSTRACT_PREVIEW: int = 200
+
+
+def print_statistics(results: List[PaperCheckResult]) -> None:
+    """
+    Print comprehensive summary statistics to console.
+
+    Displays counts and percentages for verdicts, confidence levels,
+    and search statistics aggregated across all results.
+
+    Args:
+        results: List of PaperCheckResult objects to summarize
+    """
+    if not results:
+        print("\nNo results to summarize.")
+        return
+
+    print("\n" + SEPARATOR_CHAR * SEPARATOR_WIDTH)
+    print("SUMMARY STATISTICS")
+    print(SEPARATOR_CHAR * SEPARATOR_WIDTH + "\n")
+
+    # Basic counts
+    total_abstracts = len(results)
+    total_statements = sum(len(r.statements) for r in results)
+    total_verdicts = sum(len(r.verdicts) for r in results)
+
+    print(f"Abstracts checked: {total_abstracts}")
+    print(f"Statements extracted: {total_statements}")
+    if total_abstracts > 0:
+        avg_statements = total_statements / total_abstracts
+        print(f"Average statements per abstract: {avg_statements:.1f}")
+
+    print()
+
+    # Verdict distribution
+    verdict_counts: Dict[str, int] = {"supports": 0, "contradicts": 0, "undecided": 0}
+    confidence_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
+
+    for result in results:
+        for verdict in result.verdicts:
+            verdict_counts[verdict.verdict] += 1
+            confidence_counts[verdict.confidence] += 1
+
+    print("Verdict Distribution:")
+    for verdict_type, count in verdict_counts.items():
+        pct = _safe_percentage(count, total_verdicts)
+        bar = _create_bar(pct)
+        print(f"{INDENT}{verdict_type.capitalize():12s}: {count:4d} ({pct:5.1f}%) {bar}")
+
+    print()
+    print("Confidence Distribution:")
+    for conf_level, count in confidence_counts.items():
+        pct = _safe_percentage(count, total_verdicts)
+        bar = _create_bar(pct)
+        print(f"{INDENT}{conf_level.capitalize():12s}: {count:4d} ({pct:5.1f}%) {bar}")
+
+    # Search statistics
+    print()
+    print("Search Statistics (aggregated):")
+    total_found = 0
+    total_scored = 0
+    total_cited = 0
+
+    for result in results:
+        for counter_report in result.counter_reports:
+            stats = counter_report.search_stats
+            total_found += stats.get("documents_found", 0)
+            total_scored += stats.get("documents_scored", 0)
+            total_cited += stats.get("documents_cited", 0)
+
+    print(f"{INDENT}Documents found:  {total_found:,}")
+    print(f"{INDENT}Documents scored: {total_scored:,}")
+    print(f"{INDENT}Documents cited:  {total_cited:,}")
+
+    if total_found > 0:
+        cite_rate = _safe_percentage(total_cited, total_found)
+        print(f"{INDENT}Citation rate:    {cite_rate:.1f}%")
+
+    print("\n" + SEPARATOR_CHAR * SEPARATOR_WIDTH + "\n")
+
+
+def _safe_percentage(count: int, total: int) -> float:
+    """
+    Calculate percentage safely, handling zero division.
+
+    Args:
+        count: Numerator value
+        total: Denominator value
+
+    Returns:
+        Percentage value (0-100), or 0.0 if total is zero
+    """
+    if total == 0:
+        return 0.0
+    return 100.0 * count / total
+
+
+def _create_bar(percentage: float, width: int = 20) -> str:
+    """
+    Create a simple text progress bar.
+
+    Args:
+        percentage: Percentage value (0-100)
+        width: Bar width in characters
+
+    Returns:
+        Text bar like "[========          ]"
+    """
+    filled = int(width * percentage / 100)
+    empty = width - filled
+    return f"[{'=' * filled}{' ' * empty}]"
+
+
+def print_abstract_summary(
+    result: PaperCheckResult,
+    index: int,
+    verbose: bool = False
+) -> None:
+    """
+    Print summary for a single abstract result.
+
+    Args:
+        result: PaperCheckResult to display
+        index: Display index (1-based)
+        verbose: Whether to show detailed information
+    """
+    print(SUBSEPARATOR_CHAR * SEPARATOR_WIDTH)
+    print(f"Abstract {index}")
+    print(SUBSEPARATOR_CHAR * SEPARATOR_WIDTH)
+
+    # Source info
+    pmid = result.source_metadata.get("pmid")
+    title = result.source_metadata.get("title")
+
+    if pmid:
+        print(f"PMID: {pmid}")
+    if title:
+        display_title = _truncate(title, MAX_PREVIEW_LENGTH)
+        print(f"Title: {display_title}")
+
+    # Abstract preview
+    if verbose:
+        abstract_preview = _truncate(result.original_abstract, MAX_ABSTRACT_PREVIEW)
+        print(f"\nAbstract: {abstract_preview}")
+
+    # Statement verdicts
+    print(f"\nStatements: {len(result.statements)}")
+
+    for i, (stmt, verdict) in enumerate(zip(result.statements, result.verdicts), 1):
+        verdict_icon = _get_verdict_icon(verdict.verdict)
+        conf_icon = _get_confidence_icon(verdict.confidence)
+
+        stmt_preview = _truncate(stmt.text, MAX_PREVIEW_LENGTH)
+        print(f"{INDENT}{i}. {stmt_preview}")
+        print(f"{INDENT}   {verdict_icon} {verdict.verdict.upper()} ({conf_icon} {verdict.confidence})")
+
+        if verbose:
+            rationale_preview = _truncate(verdict.rationale, MAX_PREVIEW_LENGTH)
+            print(f"{INDENT}   Rationale: {rationale_preview}")
+
+    # Overall assessment preview
+    print(f"\nOverall: {_truncate(result.overall_assessment, MAX_PREVIEW_LENGTH)}")
+    print()
+
+
+def _truncate(text: str, max_length: int) -> str:
+    """
+    Truncate text with ellipsis if too long.
+
+    Args:
+        text: Text to truncate
+        max_length: Maximum length including ellipsis
+
+    Returns:
+        Truncated text with "..." if needed
+    """
+    if len(text) <= max_length:
+        return text
+    return text[:max_length - 3] + "..."
+
+
+def _get_verdict_icon(verdict: str) -> str:
+    """
+    Get display icon for verdict type.
+
+    Args:
+        verdict: Verdict string ("supports", "contradicts", "undecided")
+
+    Returns:
+        Unicode icon character
+    """
+    icons = {
+        "supports": "+",
+        "contradicts": "X",
+        "undecided": "?"
+    }
+    return icons.get(verdict, "-")
+
+
+def _get_confidence_icon(confidence: str) -> str:
+    """
+    Get display icon for confidence level.
+
+    Args:
+        confidence: Confidence string ("high", "medium", "low")
+
+    Returns:
+        Unicode icon character
+    """
+    icons = {
+        "high": "***",
+        "medium": "**",
+        "low": "*"
+    }
+    return icons.get(confidence, "-")
+
+
+def format_verdict_summary(verdicts: List[Verdict]) -> str:
+    """
+    Format a brief summary of verdicts for inline display.
+
+    Args:
+        verdicts: List of Verdict objects
+
+    Returns:
+        Summary string like "2 supports, 1 contradicts (high confidence)"
+    """
+    if not verdicts:
+        return "no verdicts"
+
+    # Count verdicts
+    counts: Dict[str, int] = {"supports": 0, "contradicts": 0, "undecided": 0}
+    for v in verdicts:
+        counts[v.verdict] += 1
+
+    # Build parts
+    parts = []
+    for vtype in ["supports", "contradicts", "undecided"]:
+        if counts[vtype] > 0:
+            parts.append(f"{counts[vtype]} {vtype}")
+
+    summary = ", ".join(parts)
+
+    # Add dominant confidence if any
+    confidence_counts: Dict[str, int] = {"high": 0, "medium": 0, "low": 0}
+    for v in verdicts:
+        confidence_counts[v.confidence] += 1
+
+    dominant_conf = max(confidence_counts, key=confidence_counts.get)
+    if confidence_counts[dominant_conf] > len(verdicts) / 2:
+        summary += f" ({dominant_conf} confidence)"
+
+    return summary
+
+
+def print_error_summary(errors: List[Dict[str, Any]]) -> None:
+    """
+    Print summary of processing errors.
+
+    Args:
+        errors: List of error dictionaries with index, pmid, and error message
+    """
+    if not errors:
+        return
+
+    print("\n" + SEPARATOR_CHAR * SEPARATOR_WIDTH)
+    print(f"ERRORS ({len(errors)} abstracts failed)")
+    print(SEPARATOR_CHAR * SEPARATOR_WIDTH)
+
+    for err in errors:
+        pmid_str = f"PMID {err.get('pmid')}" if err.get('pmid') else f"index {err.get('index')}"
+        error_preview = _truncate(str(err.get('error', 'Unknown error')), MAX_PREVIEW_LENGTH)
+        print(f"{INDENT}{pmid_str}: {error_preview}")
+
+    print()
+
+
+def print_completion_banner(
+    total: int,
+    successful: int,
+    errors: int,
+    output_file: str = None,
+    markdown_dir: str = None
+) -> None:
+    """
+    Print completion banner with summary.
+
+    Args:
+        total: Total abstracts processed
+        successful: Number of successful results
+        errors: Number of errors
+        output_file: Path to JSON output file (if any)
+        markdown_dir: Path to markdown output directory (if any)
+    """
+    print("\n" + SEPARATOR_CHAR * SEPARATOR_WIDTH)
+    print("PROCESSING COMPLETE")
+    print(SEPARATOR_CHAR * SEPARATOR_WIDTH)
+
+    success_icon = "+" if errors == 0 else "!"
+    print(f"{success_icon} Completed: {successful}/{total} abstracts")
+
+    if errors > 0:
+        print(f"X Errors: {errors}")
+
+    if output_file:
+        print(f"+ JSON results: {output_file}")
+
+    if markdown_dir:
+        print(f"+ Markdown reports: {markdown_dir}")
+
+    print(SEPARATOR_CHAR * SEPARATOR_WIDTH + "\n")

--- a/src/bmlibrarian/paperchecker/cli/formatters.py
+++ b/src/bmlibrarian/paperchecker/cli/formatters.py
@@ -5,7 +5,7 @@ Provides functions for displaying results, statistics, and summaries
 in human-readable formats for the command line.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from bmlibrarian.paperchecker.data_models import PaperCheckResult, Verdict
 
@@ -16,6 +16,8 @@ SUBSEPARATOR_CHAR: str = "-"
 INDENT: str = "  "
 MAX_PREVIEW_LENGTH: int = 80
 MAX_ABSTRACT_PREVIEW: int = 200
+DEFAULT_BAR_WIDTH: int = 20
+PERCENTAGE_MAX: float = 100.0
 
 
 def print_statistics(results: List[PaperCheckResult]) -> None:
@@ -112,7 +114,7 @@ def _safe_percentage(count: int, total: int) -> float:
     return 100.0 * count / total
 
 
-def _create_bar(percentage: float, width: int = 20) -> str:
+def _create_bar(percentage: float, width: int = DEFAULT_BAR_WIDTH) -> str:
     """
     Create a simple text progress bar.
 
@@ -123,7 +125,7 @@ def _create_bar(percentage: float, width: int = 20) -> str:
     Returns:
         Text bar like "[========          ]"
     """
-    filled = int(width * percentage / 100)
+    filled = int(width * percentage / PERCENTAGE_MAX)
     empty = width - filled
     return f"[{'=' * filled}{' ' * empty}]"
 
@@ -296,8 +298,8 @@ def print_completion_banner(
     total: int,
     successful: int,
     errors: int,
-    output_file: str = None,
-    markdown_dir: str = None
+    output_file: Optional[str] = None,
+    markdown_dir: Optional[str] = None
 ) -> None:
     """
     Print completion banner with summary.

--- a/tests/test_paperchecker_cli.py
+++ b/tests/test_paperchecker_cli.py
@@ -1,0 +1,305 @@
+"""
+Tests for PaperChecker CLI module.
+
+Tests cover:
+- Input validation (abstract length, PMID range)
+- JSON file loading
+- Output formatting
+- Statistics calculation
+- Error handling
+"""
+
+import json
+import pytest
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+from bmlibrarian.paperchecker.cli.commands import (
+    validate_abstract,
+    load_abstracts_from_json,
+    MIN_ABSTRACT_LENGTH,
+    MAX_ABSTRACT_LENGTH,
+    MIN_PMID,
+    MAX_PMID,
+    MAX_VALIDATION_ERRORS_DISPLAYED,
+    MAX_ERROR_PREVIEW_LENGTH,
+)
+from bmlibrarian.paperchecker.cli.formatters import (
+    _safe_percentage,
+    _create_bar,
+    _truncate,
+    format_verdict_summary,
+    SEPARATOR_WIDTH,
+    DEFAULT_BAR_WIDTH,
+    MAX_PREVIEW_LENGTH,
+)
+
+
+# ==================== Validation Tests ====================
+
+class TestValidateAbstract:
+    """Tests for validate_abstract function."""
+
+    def test_valid_abstract(self) -> None:
+        """Test validation accepts valid abstracts."""
+        abstract = "A" * MIN_ABSTRACT_LENGTH
+        is_valid, error = validate_abstract(abstract, 0)
+        assert is_valid is True
+        assert error is None
+
+    def test_empty_abstract(self) -> None:
+        """Test validation rejects empty abstracts."""
+        is_valid, error = validate_abstract("", 0)
+        assert is_valid is False
+        assert "empty" in error.lower()
+
+    def test_none_abstract(self) -> None:
+        """Test validation rejects None abstracts."""
+        is_valid, error = validate_abstract(None, 0)
+        assert is_valid is False
+        assert "empty" in error.lower()
+
+    def test_abstract_too_short(self) -> None:
+        """Test validation rejects short abstracts."""
+        abstract = "A" * (MIN_ABSTRACT_LENGTH - 1)
+        is_valid, error = validate_abstract(abstract, 5)
+        assert is_valid is False
+        assert "too short" in error.lower()
+        assert "5" in error  # Index should be in error message
+
+    def test_abstract_too_long(self) -> None:
+        """Test validation rejects long abstracts."""
+        abstract = "A" * (MAX_ABSTRACT_LENGTH + 1)
+        is_valid, error = validate_abstract(abstract, 3)
+        assert is_valid is False
+        assert "too long" in error.lower()
+
+    def test_abstract_at_min_length(self) -> None:
+        """Test validation accepts abstract at exactly minimum length."""
+        abstract = "A" * MIN_ABSTRACT_LENGTH
+        is_valid, error = validate_abstract(abstract, 0)
+        assert is_valid is True
+
+    def test_abstract_at_max_length(self) -> None:
+        """Test validation accepts abstract at exactly maximum length."""
+        abstract = "A" * MAX_ABSTRACT_LENGTH
+        is_valid, error = validate_abstract(abstract, 0)
+        assert is_valid is True
+
+    def test_abstract_with_whitespace(self) -> None:
+        """Test validation strips whitespace before checking length."""
+        # Abstract that's long enough after stripping
+        abstract = "  " + "A" * MIN_ABSTRACT_LENGTH + "  "
+        is_valid, error = validate_abstract(abstract, 0)
+        assert is_valid is True
+
+    def test_non_string_abstract(self) -> None:
+        """Test validation rejects non-string abstracts."""
+        is_valid, error = validate_abstract(123, 0)
+        assert is_valid is False
+        assert "not a string" in error.lower()
+
+
+# ==================== JSON Loading Tests ====================
+
+class TestLoadAbstractsFromJson:
+    """Tests for load_abstracts_from_json function."""
+
+    def test_load_valid_json(self, tmp_path: Path) -> None:
+        """Test loading valid JSON file."""
+        json_file = tmp_path / "test.json"
+        data = [
+            {"abstract": "A" * MIN_ABSTRACT_LENGTH, "metadata": {"pmid": 12345}},
+            {"abstract": "B" * MIN_ABSTRACT_LENGTH, "metadata": {"pmid": 67890}},
+        ]
+        json_file.write_text(json.dumps(data))
+
+        abstracts = load_abstracts_from_json(str(json_file))
+
+        assert len(abstracts) == 2
+        assert abstracts[0]["metadata"]["pmid"] == 12345
+        assert abstracts[1]["metadata"]["pmid"] == 67890
+
+    def test_load_file_not_found(self) -> None:
+        """Test loading non-existent file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_abstracts_from_json("/nonexistent/path.json")
+
+    def test_load_invalid_json(self, tmp_path: Path) -> None:
+        """Test loading invalid JSON raises JSONDecodeError."""
+        json_file = tmp_path / "invalid.json"
+        json_file.write_text("not valid json {")
+
+        with pytest.raises(json.JSONDecodeError):
+            load_abstracts_from_json(str(json_file))
+
+    def test_load_non_list_json(self, tmp_path: Path) -> None:
+        """Test loading JSON that's not a list raises ValueError."""
+        json_file = tmp_path / "dict.json"
+        json_file.write_text(json.dumps({"abstract": "test"}))
+
+        with pytest.raises(ValueError, match="list"):
+            load_abstracts_from_json(str(json_file))
+
+    def test_load_empty_list(self, tmp_path: Path) -> None:
+        """Test loading empty list raises ValueError."""
+        json_file = tmp_path / "empty.json"
+        json_file.write_text(json.dumps([]))
+
+        with pytest.raises(ValueError, match="no abstracts"):
+            load_abstracts_from_json(str(json_file))
+
+    def test_load_missing_abstract_key(self, tmp_path: Path) -> None:
+        """Test loading items without 'abstract' key raises ValueError."""
+        json_file = tmp_path / "missing_key.json"
+        data = [{"metadata": {"pmid": 123}}]
+        json_file.write_text(json.dumps(data))
+
+        with pytest.raises(ValueError, match="abstract"):
+            load_abstracts_from_json(str(json_file))
+
+    def test_load_with_optional_metadata(self, tmp_path: Path) -> None:
+        """Test loading abstracts without metadata."""
+        json_file = tmp_path / "no_metadata.json"
+        data = [{"abstract": "A" * MIN_ABSTRACT_LENGTH}]
+        json_file.write_text(json.dumps(data))
+
+        abstracts = load_abstracts_from_json(str(json_file))
+
+        assert len(abstracts) == 1
+        assert abstracts[0]["metadata"] == {}
+
+
+# ==================== Formatter Tests ====================
+
+class TestSafePercentage:
+    """Tests for _safe_percentage function."""
+
+    def test_normal_percentage(self) -> None:
+        """Test normal percentage calculation."""
+        assert _safe_percentage(50, 100) == 50.0
+
+    def test_zero_total(self) -> None:
+        """Test zero total returns 0.0."""
+        assert _safe_percentage(10, 0) == 0.0
+
+    def test_zero_count(self) -> None:
+        """Test zero count returns 0.0."""
+        assert _safe_percentage(0, 100) == 0.0
+
+    def test_full_percentage(self) -> None:
+        """Test 100% calculation."""
+        assert _safe_percentage(100, 100) == 100.0
+
+
+class TestCreateBar:
+    """Tests for _create_bar function."""
+
+    def test_empty_bar(self) -> None:
+        """Test 0% bar."""
+        bar = _create_bar(0.0)
+        assert bar == "[" + " " * DEFAULT_BAR_WIDTH + "]"
+
+    def test_full_bar(self) -> None:
+        """Test 100% bar."""
+        bar = _create_bar(100.0)
+        assert bar == "[" + "=" * DEFAULT_BAR_WIDTH + "]"
+
+    def test_half_bar(self) -> None:
+        """Test 50% bar."""
+        bar = _create_bar(50.0)
+        expected_filled = DEFAULT_BAR_WIDTH // 2
+        expected_empty = DEFAULT_BAR_WIDTH - expected_filled
+        assert bar == "[" + "=" * expected_filled + " " * expected_empty + "]"
+
+    def test_custom_width(self) -> None:
+        """Test bar with custom width."""
+        bar = _create_bar(50.0, width=10)
+        assert bar == "[=====     ]"
+
+
+class TestTruncate:
+    """Tests for _truncate function."""
+
+    def test_no_truncation_needed(self) -> None:
+        """Test text shorter than max is unchanged."""
+        text = "short text"
+        result = _truncate(text, 50)
+        assert result == text
+
+    def test_truncation_applied(self) -> None:
+        """Test text longer than max is truncated."""
+        text = "A" * 100
+        result = _truncate(text, 50)
+        assert len(result) == 50
+        assert result.endswith("...")
+
+    def test_exact_length(self) -> None:
+        """Test text at exactly max length is unchanged."""
+        text = "A" * 50
+        result = _truncate(text, 50)
+        assert result == text
+
+
+class TestFormatVerdictSummary:
+    """Tests for format_verdict_summary function."""
+
+    def test_empty_verdicts(self) -> None:
+        """Test empty verdict list."""
+        result = format_verdict_summary([])
+        assert result == "no verdicts"
+
+    def test_single_verdict(self) -> None:
+        """Test single verdict formatting."""
+        mock_verdict = MagicMock()
+        mock_verdict.verdict = "supports"
+        mock_verdict.confidence = "high"
+
+        result = format_verdict_summary([mock_verdict])
+        assert "1 supports" in result
+
+    def test_mixed_verdicts(self) -> None:
+        """Test mixed verdict formatting."""
+        verdicts = []
+        for v, c in [("supports", "high"), ("contradicts", "medium"), ("supports", "high")]:
+            mock = MagicMock()
+            mock.verdict = v
+            mock.confidence = c
+            verdicts.append(mock)
+
+        result = format_verdict_summary(verdicts)
+        assert "2 supports" in result
+        assert "1 contradicts" in result
+
+
+# ==================== Constants Tests ====================
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_min_abstract_length_positive(self) -> None:
+        """Test MIN_ABSTRACT_LENGTH is positive."""
+        assert MIN_ABSTRACT_LENGTH > 0
+
+    def test_max_abstract_length_greater_than_min(self) -> None:
+        """Test MAX_ABSTRACT_LENGTH > MIN_ABSTRACT_LENGTH."""
+        assert MAX_ABSTRACT_LENGTH > MIN_ABSTRACT_LENGTH
+
+    def test_pmid_range_valid(self) -> None:
+        """Test PMID range is valid."""
+        assert MIN_PMID >= 1
+        assert MAX_PMID > MIN_PMID
+
+    def test_error_limits_positive(self) -> None:
+        """Test error display limits are positive."""
+        assert MAX_VALIDATION_ERRORS_DISPLAYED > 0
+        assert MAX_ERROR_PREVIEW_LENGTH > 0
+
+    def test_separator_width_reasonable(self) -> None:
+        """Test separator width is reasonable for terminal."""
+        assert 40 <= SEPARATOR_WIDTH <= 120
+
+    def test_preview_length_reasonable(self) -> None:
+        """Test preview length is reasonable."""
+        assert 40 <= MAX_PREVIEW_LENGTH <= 200

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,7 @@ dependencies = [
     { name = "requests" },
     { name = "scipy" },
     { name = "seaborn" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -123,6 +124,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "seaborn", specifier = ">=0.13.0" },
+    { name = "tqdm", specifier = ">=4.66.0" },
 ]
 provides-extras = ["browser"]
 
@@ -1676,6 +1678,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implement PaperChecker CLI application for batch fact-checking of medical abstracts against biomedical literature.

### Features
- **JSON input**: Load abstracts from JSON files with comprehensive validation
- **PMID-based input**: Fetch abstracts directly from database by PMID
- **Progress tracking**: Real-time progress bar with tqdm showing completion status
- **Error recovery**: `--continue-on-error` mode for fault-tolerant batch processing
- **JSON export**: Export complete results to JSON format
- **Markdown reports**: Generate individual markdown reports per abstract
- **Statistics**: Comprehensive verdict/confidence distribution reports
- **Quick mode**: `--quick` flag for testing (limits to 5 abstracts)

### Architecture
Follows the modular CLI pattern established by `fact_checker_cli.py`:
- `src/bmlibrarian/paperchecker/cli/app.py` - Main entry point with argparse
- `src/bmlibrarian/paperchecker/cli/commands.py` - Command handlers (load, check, export)
- `src/bmlibrarian/paperchecker/cli/formatters.py` - Output formatting and statistics

### Golden Rules Compliance
- All constants defined at module level (no magic numbers)
- Database access through `get_db_manager()`
- Type hints on all parameters
- Docstrings on all functions/methods/classes
- Comprehensive error handling and logging
- 36 unit tests with full coverage

### Usage Examples
```bash
# Check abstracts from JSON file
uv run python paper_checker_cli.py abstracts.json

# Export results
uv run python paper_checker_cli.py abstracts.json -o results.json --export-markdown reports/

# Check by PMIDs from database
uv run python paper_checker_cli.py --pmid 12345678 23456789

# Quick test mode
uv run python paper_checker_cli.py abstracts.json --quick