### PR TITLE
Implement PR #144 feedback and suggestions

### DIFF
--- a/doc/users/paper_checker_cli_guide.md
+++ b/doc/users/paper_checker_cli_guide.md
@@ -390,6 +390,6 @@ uv run python paper_checker_cli.py abstracts.json -v --detailed
 
 ## See Also
 
-- [PaperChecker Architecture](../developers/paperchecker_architecture.md)
+- [PaperChecker Architecture](../developers/paper_checker_architecture.md)
 - [PaperChecker Database Guide](papercheck_database_guide.md)
 - [BMLibrarian Configuration Guide](configuration_guide.md)

--- a/doc/users/paper_checker_lab_guide.md
+++ b/doc/users/paper_checker_lab_guide.md
@@ -261,7 +261,7 @@ Key settings:
 ## Related Documentation
 
 - [PaperChecker CLI Guide](paper_checker_cli_guide.md) - Batch processing interface
-- [PaperChecker Architecture](../developers/paperchecker_architecture.md) - Technical details
+- [PaperChecker Architecture](../developers/paper_checker_architecture.md) - Technical details
 - [Document Embedding Guide](document_embedding_guide.md) - Database preparation
 - [Configuration Guide](configuration_guide.md) - System configuration
 


### PR DESCRIPTION
## Fix broken cross-references in PaperChecker documentation

### Summary
- Fixed broken architecture documentation links in `paper_checker_cli_guide.md` and `paper_checker_lab_guide.md`

### Problem
PR #144 feedback identified cross-reference validation issues. Investigation revealed two broken links:
- Both `paper_checker_cli_guide.md` and `paper_checker_lab_guide.md` referenced `../developers/paperchecker_architecture.md`
- The actual file is named `paper_checker_architecture.md` (with underscore between "paper" and "checker")

### Changes
| File | Line | Change |
|------|------|--------|
| `doc/users/paper_checker_cli_guide.md` | 393 | `paperchecker_architecture.md` → `paper_checker_architecture.md` |
| `doc/users/paper_checker_lab_guide.md` | 264 | `paperchecker_architecture.md` → `paper_checker_architecture.md` |

### Additional Findings
The PR #144 feedback also mentioned "missing CLI references" at lines 281-282 of `paper_checker_guide.md`. Upon investigation, the referenced files (`paper_checker_cli_guide.md` and `paper_checker_lab_guide.md`) **do exist** with comprehensive content. This item is no longer valid.

### Test Plan
- [x] Verified all PaperChecker documentation cross-references resolve to existing files
- [x] Confirmed `paper_checker_architecture.md` exists in `doc/developers/`
- [x] Grep search of all `paper_checker*.md` files shows no remaining broken links