### PR TITLE
Fix worker thread safety in PDF upload widget

### DIFF
--- a/src/bmlibrarian/gui/qt/widgets/pdf_upload_widget.py
+++ b/src/bmlibrarian/gui/qt/widgets/pdf_upload_widget.py
@@ -54,6 +54,7 @@ from .validators import (
     classify_extraction_error,
     ValidationStatus,
     WORKER_TERMINATE_TIMEOUT_MS,
+    WORKER_FORCE_TERMINATE_TIMEOUT_MS,
 )
 from .document_create_dialog import DocumentCreateDialog
 
@@ -67,11 +68,6 @@ SPLITTER_RATIO_PDF = 60  # PDF viewer gets 60% width
 SPLITTER_RATIO_METADATA = 40  # Metadata panel gets 40% width
 DEFAULT_WINDOW_WIDTH = 1200
 DEFAULT_WINDOW_HEIGHT = 800
-
-# =============================================================================
-# Worker Cleanup Constants
-# =============================================================================
-WORKER_FORCE_TERMINATE_TIMEOUT_MS = 1000  # Timeout before forcing terminate
 
 
 class PDFUploadWidget(QWidget):


### PR DESCRIPTION
## PR: Address PR#159 Review - Thread Safety and Validation UX

### Summary

This PR addresses three enhancement areas identified in PR#159 review:
- Thread safety improvements for worker termination
- Error classification completeness for PDF processing
- Form validation UX improvements with debouncing

### Changes

#### 1. Thread Safety Enhancement ⚠️

**Issue**: Worker termination could be more robust after `terminate()` call.

**Solution**:
- Added `WORKER_FORCE_TERMINATE_TIMEOUT_MS = 5000` (5 seconds) constant
- Centralized all timeout constants in `validators.py`
- Worker cleanup now waits after `terminate()` with proper error logging if the thread is stuck

**Files Changed**:
- `src/bmlibrarian/gui/qt/widgets/validators.py` - Added new constant
- `src/bmlibrarian/gui/qt/widgets/pdf_upload_widget.py` - Removed duplicate constant, imports from validators

#### 2. Error Classification Completeness

**Issue**: `classify_extraction_error()` was missing patterns for specific PDF errors.

**Solution**: Added detection for:
- **Encrypted PDFs**: `'encrypt'`, `'password'`, `'protected'` → category: `"encrypted"`
- **Permission errors**: `'permission'`, `'access denied'`, `'cannot read'`, `'not readable'` → category: `"permission"`
- **File format errors**: `'invalid pdf'`, `'not a pdf'`, `'magic number'`, `'file format'`, `'bad header'`, `'malformed'` → category: `"format"`

**Files Changed**:
- `src/bmlibrarian/gui/qt/widgets/validators.py` - Enhanced `classify_extraction_error()` (lines 210-303)

#### 3. Form Validation UX

**Issue**: Validation ran on every keystroke, which could be distracting with long text.

**Solution**:
- Implemented `DebouncedValidator` class with configurable delay (default 300ms)
- Uses Qt's `QTimer` with `setSingleShot(True)` for debouncing
- Provides `force_validate()` for immediate validation on form submission
- Handles callback exceptions gracefully with logging

**Files Changed**:
- `src/bmlibrarian/gui/qt/widgets/validators.py` - Added `DebouncedValidator` class
- `src/bmlibrarian/gui/qt/widgets/document_create_dialog.py` - Updated to use debounced validation

### Testing

Added comprehensive tests in `tests/test_pdf_upload_validators.py`:
- Tests for all new error categories (encrypted, permission, format)
- Tests for `DebouncedValidator` class functionality
- Tests for timeout constants values

### Golden Rules Compliance

- ✅ **Rule #2**: No magic numbers - all timeouts use named constants
- ✅ **Rule #6**: Type hints - `Callable[[], None]`, `Any` for variadic args
- ✅ **Rule #7**: Docstrings - all methods documented
- ✅ **Rule #8**: Error handling - exceptions logged in debounced validator
- ✅ **Rule #11**: Reusable class - `DebouncedValidator` is framework-agnostic
- ✅ **Rule #13**: Tests written for all new functionality

### Test Plan

- [ ] Verify worker cleanup terminates gracefully with 5-second timeout
- [ ] Test encrypted PDF error message displays correctly
- [ ] Test permission-denied PDF error message displays correctly
- [ ] Test invalid PDF format error message displays correctly
- [ ] Verify form validation debouncing (300ms delay after typing stops)
- [ ] Verify save button triggers immediate validation