### PR TITLE
Integrate PDF upload widget into lab modules

### DIFF
--- a/src/bmlibrarian/lab/paper_checker_lab/constants.py
+++ b/src/bmlibrarian/lab/paper_checker_lab/constants.py
@@ -192,6 +192,28 @@ SOURCE_ID_OTHER = 3  # Source ID for user-uploaded documents
 
 
 # =============================================================================
+# PDF Upload Tab Layout
+# =============================================================================
+
+SPLITTER_RATIO_PDF = 50  # PDF viewer panel width percentage
+SPLITTER_RATIO_CONTROLS = 50  # Controls panel width percentage
+
+
+# =============================================================================
+# Worker Thread Configuration
+# =============================================================================
+
+WORKER_TERMINATE_TIMEOUT_MS = 3000  # Maximum time to wait for worker thread termination
+
+
+# =============================================================================
+# UI Colors (metadata display)
+# =============================================================================
+
+COLOR_METADATA_BG = "#f0f8ff"  # Light blue background for metadata display
+
+
+# =============================================================================
 # Score Display
 # =============================================================================
 
@@ -292,4 +314,9 @@ __all__ = [
     'SCORE_DECIMALS',
     # Export
     'EXPORT_JSON_INDENT',
+    # PDF Upload Tab
+    'SPLITTER_RATIO_PDF',
+    'SPLITTER_RATIO_CONTROLS',
+    'WORKER_TERMINATE_TIMEOUT_MS',
+    'COLOR_METADATA_BG',
 ]

--- a/src/bmlibrarian/lab/paper_checker_lab/tabs/pdf_upload_tab.py
+++ b/src/bmlibrarian/lab/paper_checker_lab/tabs/pdf_upload_tab.py
@@ -34,18 +34,16 @@ from ..constants import (
     COLOR_PRIMARY,
     COLOR_SUCCESS,
     COLOR_GREY_600,
+    COLOR_METADATA_BG,
+    SPLITTER_RATIO_PDF,
+    SPLITTER_RATIO_CONTROLS,
+    WORKER_TERMINATE_TIMEOUT_MS,
 )
 from ..widgets import StatusSpinnerWidget
 from ..worker import PDFAnalysisWorker
 
 
 logger = logging.getLogger(__name__)
-
-
-# Layout constants
-SPLITTER_RATIO_PDF = 50  # PDF viewer gets 50% width
-SPLITTER_RATIO_CONTROLS = 50  # Controls panel gets 50% width
-WORKER_TERMINATE_TIMEOUT_MS = 3000  # Max time to wait for worker termination
 
 
 class PDFUploadTab(QWidget):
@@ -136,14 +134,14 @@ class PDFUploadTab(QWidget):
             "before fact-checking."
         )
         instructions.setWordWrap(True)
-        instructions.setStyleSheet(f"color: {COLOR_GREY_600};")
+        instructions.setStyleSheet(self.styles.label_stylesheet(color=COLOR_GREY_600))
         file_layout.addWidget(instructions)
 
         # File path row
         path_layout = QHBoxLayout()
 
         self._path_label = QLabel("No file selected")
-        self._path_label.setStyleSheet(f"color: {COLOR_GREY_600};")
+        self._path_label.setStyleSheet(self.styles.label_stylesheet(color=COLOR_GREY_600))
         path_layout.addWidget(self._path_label, stretch=1)
 
         browse_btn = QPushButton("Browse...")
@@ -182,14 +180,18 @@ class PDFUploadTab(QWidget):
         content_layout = QVBoxLayout()
 
         # Metadata display
+        # Note: Using inline stylesheet as StylesheetGenerator doesn't support
+        # panel labels with backgrounds. All values are from constants/DPI scale.
         self._metadata_label = QLabel("")
         self._metadata_label.setWordWrap(True)
         self._metadata_label.setVisible(False)
-        self._metadata_label.setStyleSheet(f"""
-            background-color: #f0f8ff;
-            padding: {self.scale['padding_medium']}px;
-            border-radius: {self.scale['border_radius']}px;
-        """)
+        self._metadata_label.setStyleSheet(
+            f"QLabel {{ "
+            f"background-color: {COLOR_METADATA_BG}; "
+            f"padding: {self.scale['padding_medium']}px; "
+            f"border-radius: {self.scale['border_radius']}px; "
+            f"}}"
+        )
         content_layout.addWidget(self._metadata_label)
 
         # Abstract text (editable)

--- a/src/bmlibrarian/lab/paper_checker_lab/tabs/pdf_upload_tab.py
+++ b/src/bmlibrarian/lab/paper_checker_lab/tabs/pdf_upload_tab.py
@@ -2,23 +2,37 @@
 PaperChecker Laboratory - PDF Upload Tab
 
 Tab widget for uploading PDFs and extracting abstracts for fact-checking.
+Features a split view with PDF viewer on the left and extraction controls on the right.
 """
 
 import logging
+from pathlib import Path
 from typing import Optional, Dict, Any
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
-    QPushButton, QTextEdit, QGroupBox, QMessageBox,
-    QFileDialog, QSizePolicy, QProgressBar,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QGroupBox,
+    QMessageBox,
+    QFileDialog,
+    QSizePolicy,
+    QProgressBar,
+    QSplitter,
 )
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Signal, Qt
+from PySide6.QtGui import QCloseEvent
 
 from bmlibrarian.gui.qt.resources.styles.dpi_scale import get_font_scale
 from bmlibrarian.gui.qt.resources.styles.stylesheet_generator import get_stylesheet_generator
+from bmlibrarian.gui.qt.widgets import PDFViewerWidget, validate_pdf_file, ValidationStatus
 
 from ..constants import (
-    COLOR_PRIMARY, COLOR_SUCCESS, COLOR_WARNING, COLOR_ERROR,
+    COLOR_PRIMARY,
+    COLOR_SUCCESS,
     COLOR_GREY_600,
 )
 from ..widgets import StatusSpinnerWidget
@@ -28,9 +42,19 @@ from ..worker import PDFAnalysisWorker
 logger = logging.getLogger(__name__)
 
 
+# Layout constants
+SPLITTER_RATIO_PDF = 50  # PDF viewer gets 50% width
+SPLITTER_RATIO_CONTROLS = 50  # Controls panel gets 50% width
+WORKER_TERMINATE_TIMEOUT_MS = 3000  # Max time to wait for worker termination
+
+
 class PDFUploadTab(QWidget):
     """
     Tab widget for PDF upload and abstract extraction.
+
+    Features a split-view layout with:
+    - Left panel: PDF viewer for visual inspection
+    - Right panel: Extraction controls, metadata display, and abstract editing
 
     Allows users to upload a PDF, extract the abstract using LLM,
     review/edit the extracted text, and proceed to fact-checking.
@@ -56,22 +80,50 @@ class PDFUploadTab(QWidget):
 
         self.scale = get_font_scale()
         self.styles = get_stylesheet_generator()
-        self._current_pdf_path: Optional[str] = None
+        self._current_pdf_path: Optional[Path] = None
         self._extracted_metadata: Dict[str, Any] = {}
         self._analysis_worker: Optional[PDFAnalysisWorker] = None
 
         self._setup_ui()
 
     def _setup_ui(self) -> None:
-        """Setup tab user interface."""
+        """Setup tab user interface with split view."""
         layout = QVBoxLayout(self)
-        layout.setSpacing(self.scale['spacing_medium'])
+        layout.setSpacing(self.scale['spacing_small'])
         layout.setContentsMargins(
-            self.scale['padding_large'],
-            self.scale['padding_large'],
-            self.scale['padding_large'],
-            self.scale['padding_large']
+            self.scale['padding_medium'],
+            self.scale['padding_medium'],
+            self.scale['padding_medium'],
+            self.scale['padding_medium']
         )
+
+        # Main splitter for PDF viewer and controls
+        self._splitter = QSplitter(Qt.Horizontal)
+
+        # Left panel: PDF Viewer
+        self._pdf_viewer = PDFViewerWidget()
+        self._splitter.addWidget(self._pdf_viewer)
+
+        # Right panel: Controls
+        right_panel = self._create_controls_panel()
+        self._splitter.addWidget(right_panel)
+
+        # Set splitter proportions (50/50)
+        self._splitter.setSizes([SPLITTER_RATIO_PDF, SPLITTER_RATIO_CONTROLS])
+
+        layout.addWidget(self._splitter, stretch=1)
+
+    def _create_controls_panel(self) -> QWidget:
+        """
+        Create the right-side controls panel.
+
+        Returns:
+            QWidget: The controls panel widget
+        """
+        panel = QWidget()
+        layout = QVBoxLayout(panel)
+        layout.setSpacing(self.scale['spacing_medium'])
+        layout.setContentsMargins(0, 0, 0, 0)
 
         # File selection section
         file_group = QGroupBox("PDF File")
@@ -90,10 +142,9 @@ class PDFUploadTab(QWidget):
         # File path row
         path_layout = QHBoxLayout()
 
-        self._path_input = QLineEdit()
-        self._path_input.setPlaceholderText("Select a PDF file...")
-        self._path_input.setReadOnly(True)
-        path_layout.addWidget(self._path_input, stretch=1)
+        self._path_label = QLabel("No file selected")
+        self._path_label.setStyleSheet(f"color: {COLOR_GREY_600};")
+        path_layout.addWidget(self._path_label, stretch=1)
 
         browse_btn = QPushButton("Browse...")
         browse_btn.clicked.connect(self._browse_file)
@@ -149,7 +200,7 @@ class PDFUploadTab(QWidget):
         self._abstract_edit.setPlaceholderText(
             "The extracted abstract will appear here after PDF analysis..."
         )
-        self._abstract_edit.setMinimumHeight(self.scale['line_height'] * 8)
+        self._abstract_edit.setMinimumHeight(self.scale['line_height'] * 6)
         self._abstract_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         content_layout.addWidget(self._abstract_edit, stretch=1)
 
@@ -181,6 +232,8 @@ class PDFUploadTab(QWidget):
 
         layout.addLayout(button_layout)
 
+        return panel
+
     def _browse_file(self) -> None:
         """Open file browser for PDF selection."""
         file_path, _ = QFileDialog.getOpenFileName(
@@ -191,11 +244,51 @@ class PDFUploadTab(QWidget):
         )
 
         if file_path:
-            self._current_pdf_path = file_path
-            self._path_input.setText(file_path)
-            self._analyze_btn.setEnabled(True)
-            self._status_spinner.reset()
-            logger.info(f"PDF selected: {file_path}")
+            self._load_pdf(file_path)
+
+    def _load_pdf(self, file_path: str) -> None:
+        """
+        Load a PDF file for analysis.
+
+        Validates the file and loads it into the viewer.
+
+        Args:
+            file_path: Path to the PDF file
+        """
+        pdf_path = Path(file_path)
+
+        # Validate PDF file
+        is_valid, message, status = validate_pdf_file(pdf_path)
+
+        if status == ValidationStatus.ERROR:
+            QMessageBox.critical(self, "Invalid File", message or "Unknown error")
+            return
+
+        # Show warning for large files but allow proceeding
+        if status == ValidationStatus.WARNING:
+            reply = QMessageBox.warning(
+                self,
+                "Large File Warning",
+                f"{message}\n\nDo you want to continue?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.Yes
+            )
+            if reply != QMessageBox.Yes:
+                return
+
+        # Store path and update UI
+        self._current_pdf_path = pdf_path
+        self._path_label.setText(pdf_path.name)
+        self._path_label.setToolTip(str(pdf_path))
+
+        # Load PDF into viewer
+        self._pdf_viewer.load_pdf(pdf_path)
+
+        # Enable analyze button
+        self._analyze_btn.setEnabled(True)
+        self._status_spinner.reset()
+
+        logger.info(f"PDF loaded: {file_path}")
 
     def _analyze_pdf(self) -> None:
         """Start PDF analysis."""
@@ -214,18 +307,28 @@ class PDFUploadTab(QWidget):
         self._progress_bar.setRange(0, 0)  # Indeterminate
 
         # Start worker
-        self._analysis_worker = PDFAnalysisWorker(self._current_pdf_path)
+        self._analysis_worker = PDFAnalysisWorker(str(self._current_pdf_path))
         self._analysis_worker.progress_update.connect(self._on_progress_update)
         self._analysis_worker.analysis_complete.connect(self._on_analysis_complete)
         self._analysis_worker.analysis_error.connect(self._on_analysis_error)
         self._analysis_worker.start()
 
     def _on_progress_update(self, status: str) -> None:
-        """Handle progress update from worker."""
+        """
+        Handle progress update from worker.
+
+        Args:
+            status: Status message
+        """
         self._status_spinner.set_status(status)
 
     def _on_analysis_complete(self, result: dict) -> None:
-        """Handle successful PDF analysis."""
+        """
+        Handle successful PDF analysis.
+
+        Args:
+            result: Analysis result dictionary
+        """
         self._progress_bar.setVisible(False)
         self._status_spinner.set_complete("Analysis complete")
 
@@ -237,7 +340,7 @@ class PDFUploadTab(QWidget):
             'pmid': result.get('pmid'),
             'doi': result.get('doi'),
             'journal': result.get('journal', ''),
-            'pdf_path': result.get('pdf_path', ''),
+            'pdf_path': str(self._current_pdf_path) if self._current_pdf_path else '',
         }
 
         # Display metadata
@@ -262,7 +365,12 @@ class PDFUploadTab(QWidget):
         self._analyze_btn.setEnabled(True)
 
     def _on_analysis_error(self, error: str) -> None:
-        """Handle analysis error."""
+        """
+        Handle analysis error.
+
+        Args:
+            error: Error message
+        """
         self._progress_bar.setVisible(False)
         self._status_spinner.set_error(f"Error: {error}")
         self._analyze_btn.setEnabled(True)
@@ -275,7 +383,12 @@ class PDFUploadTab(QWidget):
         logger.error(f"PDF analysis error: {error}")
 
     def _show_metadata(self, result: dict) -> None:
-        """Display extracted metadata."""
+        """
+        Display extracted metadata.
+
+        Args:
+            result: Analysis result dictionary
+        """
         parts = []
 
         if result.get('title'):
@@ -335,7 +448,8 @@ class PDFUploadTab(QWidget):
         """Clear all inputs and results."""
         self._current_pdf_path = None
         self._extracted_metadata.clear()
-        self._path_input.clear()
+        self._path_label.setText("No file selected")
+        self._path_label.setToolTip("")
         self._abstract_edit.clear()
         self._metadata_label.setVisible(False)
         self._status_spinner.reset()
@@ -343,6 +457,9 @@ class PDFUploadTab(QWidget):
         self._analyze_btn.setEnabled(False)
         self._check_btn.setEnabled(False)
         self._use_in_input_btn.setEnabled(False)
+
+        # Clear PDF viewer
+        self._pdf_viewer.clear()
 
     def set_enabled(self, enabled: bool) -> None:
         """
@@ -355,6 +472,35 @@ class PDFUploadTab(QWidget):
         self._check_btn.setEnabled(enabled and bool(self._abstract_edit.toPlainText().strip()))
         self._use_in_input_btn.setEnabled(enabled and bool(self._abstract_edit.toPlainText().strip()))
         self._clear_btn.setEnabled(enabled)
+
+    def _terminate_workers(self) -> None:
+        """
+        Safely terminate any running worker threads.
+
+        Waits up to WORKER_TERMINATE_TIMEOUT_MS for workers to finish.
+        """
+        if self._analysis_worker is not None and self._analysis_worker.isRunning():
+            logger.info("Terminating analysis worker thread...")
+            self._analysis_worker.cancel()
+            if not self._analysis_worker.wait(WORKER_TERMINATE_TIMEOUT_MS):
+                logger.warning(
+                    f"Analysis worker did not terminate within "
+                    f"{WORKER_TERMINATE_TIMEOUT_MS}ms"
+                )
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """
+        Handle widget close event.
+
+        Ensures worker threads are properly terminated before closing.
+
+        Args:
+            event: The close event
+        """
+        self._terminate_workers()
+        # Clear worker reference for garbage collection
+        self._analysis_worker = None
+        super().closeEvent(event)
 
 
 __all__ = ['PDFUploadTab']

--- a/src/bmlibrarian/lab/paper_weight_lab/tabs/pdf_upload_tab.py
+++ b/src/bmlibrarian/lab/paper_weight_lab/tabs/pdf_upload_tab.py
@@ -2,161 +2,33 @@
 Paper Weight Laboratory - PDF Upload Tab
 
 Tab widget for uploading PDFs and matching/creating documents.
-Uses the new PDFIngestor for full PDF processing (storage, text extraction, embedding).
+Wraps the reusable PDFUploadWidget with paper weight lab specific behavior.
 """
 
 import logging
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Any
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
-    QPushButton, QGroupBox, QFileDialog, QMessageBox,
-    QTreeWidget, QTreeWidgetItem, QFormLayout, QCheckBox,
+    QWidget,
+    QVBoxLayout,
+    QGroupBox,
+    QCheckBox,
+    QHBoxLayout,
+    QMessageBox,
 )
 from PySide6.QtCore import Signal, QThread
 from PySide6.QtGui import QCloseEvent
 
 from bmlibrarian.gui.qt.resources.styles.dpi_scale import get_font_scale
 from bmlibrarian.gui.qt.resources.styles.stylesheet_generator import get_stylesheet_generator
-from bmlibrarian.database import get_db_manager
+from bmlibrarian.gui.qt.widgets import PDFUploadWidget
 
-from ..constants import (
-    SOURCE_ID_OTHER,
-    TITLE_SIMILARITY_THRESHOLD,
-    ALTERNATIVE_MATCHES_LIMIT,
-)
-from ..widgets import StatusSpinnerWidget
 from ..constants import WORKER_TERMINATE_TIMEOUT_MS
-from ..validators import (
-    validate_pmid,
-    validate_doi,
-    validate_year,
-    validate_pdf_file_size,
-    validate_title,
-)
+from ..widgets import StatusSpinnerWidget
+
 
 logger = logging.getLogger(__name__)
-
-
-class PDFAnalysisWorker(QThread):
-    """
-    Worker thread for PDF analysis and matching.
-
-    Performs PDF text extraction, metadata extraction via LLM,
-    and database matching in background.
-    """
-
-    analysis_complete = Signal(dict)
-    analysis_error = Signal(str)
-    status_update = Signal(str)
-
-    def __init__(
-        self,
-        pdf_path: Path,
-        parent: Optional[object] = None
-    ):
-        """
-        Initialize worker.
-
-        Args:
-            pdf_path: Path to PDF file
-            parent: Parent object
-        """
-        super().__init__(parent)
-        self.pdf_path = pdf_path
-
-    def run(self) -> None:
-        """Run PDF analysis in background."""
-        try:
-            # Import here to avoid circular imports
-            from bmlibrarian.importers.pdf_matcher import PDFMatcher
-
-            self.status_update.emit("Initializing PDF matcher...")
-
-            matcher = PDFMatcher()
-
-            # Extract text from first page
-            self.status_update.emit("Extracting text from PDF...")
-            text = matcher.extract_first_page_text(self.pdf_path)
-
-            if not text:
-                self.analysis_error.emit(
-                    "Could not extract text from PDF. "
-                    "The file may be scanned or corrupted."
-                )
-                return
-
-            # Extract metadata with LLM
-            self.status_update.emit("Extracting metadata with AI...")
-            metadata = matcher.extract_metadata_with_llm(text)
-
-            # Find matching documents
-            self.status_update.emit("Searching for matching documents...")
-            match = matcher.find_matching_document(metadata)
-
-            # Also get alternative matches by title similarity
-            alternatives = []
-            if metadata.get('title'):
-                alternatives = self._find_alternative_matches(metadata['title'])
-
-            result = {
-                'pdf_path': str(self.pdf_path),
-                'metadata': metadata,
-                'match': match,
-                'alternatives': alternatives,
-            }
-
-            self.analysis_complete.emit(result)
-
-        except Exception as e:
-            logger.exception(f"PDF analysis error: {e}")
-            self.analysis_error.emit(str(e))
-
-    def _find_alternative_matches(
-        self,
-        title: str,
-        limit: int = ALTERNATIVE_MATCHES_LIMIT
-    ) -> List[Dict[str, Any]]:
-        """
-        Find alternative document matches by title similarity.
-
-        Args:
-            title: Title to search for
-            limit: Maximum number of alternatives
-
-        Returns:
-            List of potential matching documents
-        """
-        try:
-            db_manager = get_db_manager()
-            with db_manager.get_connection() as conn:
-                with conn.cursor() as cur:
-                    cur.execute("""
-                        SELECT id, doi, title, external_id,
-                               EXTRACT(YEAR FROM publication_date) as year,
-                               similarity(title, %s) AS sim
-                        FROM document
-                        WHERE similarity(title, %s) > %s
-                        ORDER BY sim DESC
-                        LIMIT %s
-                    """, (title, title, TITLE_SIMILARITY_THRESHOLD, limit))
-
-                    results = []
-                    for row in cur.fetchall():
-                        results.append({
-                            'id': row[0],
-                            'doi': row[1],
-                            'title': row[2],
-                            'pmid': row[3],
-                            'year': row[4],
-                            'similarity': row[5],
-                        })
-                    return results
-
-        except Exception as e:
-            logger.error(f"Error finding alternatives: {e}")
-            return []
 
 
 class PDFIngestWorker(QThread):
@@ -223,8 +95,8 @@ class PDFUploadTab(QWidget):
     """
     Tab widget for PDF upload and document matching.
 
-    Allows users to upload PDFs, view extracted metadata,
-    select matching documents, or create new documents.
+    Wraps the reusable PDFUploadWidget and adds paper weight lab specific
+    functionality including PDF ingestion (text extraction and embedding).
 
     Signals:
         document_selected: Emitted when a document is selected/created.
@@ -233,7 +105,7 @@ class PDFUploadTab(QWidget):
 
     document_selected = Signal(int)
 
-    def __init__(self, parent: Optional[object] = None):
+    def __init__(self, parent: Optional[QWidget] = None):
         """
         Initialize PDF upload tab.
 
@@ -245,524 +117,153 @@ class PDFUploadTab(QWidget):
         self.scale = get_font_scale()
         self.styles = get_stylesheet_generator()
 
-        self.current_pdf_path: Optional[Path] = None
-        self.current_metadata: Optional[Dict] = None
-        self.current_match: Optional[Dict] = None
-        self.analysis_worker: Optional[PDFAnalysisWorker] = None
-        self.ingest_worker: Optional[PDFIngestWorker] = None
+        self._ingest_worker: Optional[PDFIngestWorker] = None
         self._pending_document_id: Optional[int] = None
 
         self._setup_ui()
+        self._connect_signals()
 
     def _setup_ui(self) -> None:
         """Setup tab user interface."""
         layout = QVBoxLayout(self)
         layout.setSpacing(self.scale['spacing_medium'])
-
-        # Upload section
-        upload_group = QGroupBox("Upload PDF")
-        upload_layout = QVBoxLayout()
-
-        # File selection row
-        file_layout = QHBoxLayout()
-
-        self.file_path_label = QLabel("No file selected")
-        self.file_path_label.setStyleSheet(self.styles.label_stylesheet(
-            font_size_key='font_normal',
-            color='#666'
-        ))
-        file_layout.addWidget(self.file_path_label, stretch=1)
-
-        browse_btn = QPushButton("Browse...")
-        browse_btn.clicked.connect(self._browse_pdf)
-        browse_btn.setStyleSheet(self.styles.button_stylesheet(
-            bg_color="#2196F3"
-        ))
-        file_layout.addWidget(browse_btn)
-
-        upload_layout.addLayout(file_layout)
-
-        # Status spinner
-        self.status_spinner = StatusSpinnerWidget()
-        upload_layout.addWidget(self.status_spinner)
-
-        upload_group.setLayout(upload_layout)
-        layout.addWidget(upload_group)
-
-        # Extracted metadata section
-        metadata_group = QGroupBox("Extracted Metadata")
-        metadata_layout = QFormLayout()
-
-        self.title_edit = QLineEdit()
-        self.title_edit.setPlaceholderText("Paper title")
-        metadata_layout.addRow("Title:", self.title_edit)
-
-        self.authors_edit = QLineEdit()
-        self.authors_edit.setPlaceholderText("Author names (comma separated)")
-        metadata_layout.addRow("Authors:", self.authors_edit)
-
-        self.doi_edit = QLineEdit()
-        self.doi_edit.setPlaceholderText("10.xxxx/...")
-        metadata_layout.addRow("DOI:", self.doi_edit)
-
-        self.pmid_edit = QLineEdit()
-        self.pmid_edit.setPlaceholderText("PubMed ID")
-        metadata_layout.addRow("PMID:", self.pmid_edit)
-
-        self.year_edit = QLineEdit()
-        self.year_edit.setPlaceholderText("Publication year")
-        metadata_layout.addRow("Year:", self.year_edit)
-
-        metadata_group.setLayout(metadata_layout)
-        layout.addWidget(metadata_group)
-
-        # Matching results section
-        match_group = QGroupBox("Document Matching")
-        match_layout = QVBoxLayout()
-
-        # Match status
-        self.match_status_label = QLabel("Upload a PDF to find matching documents")
-        self.match_status_label.setWordWrap(True)
-        match_layout.addWidget(self.match_status_label)
-
-        # Alternatives tree
-        self.alternatives_tree = QTreeWidget()
-        self.alternatives_tree.setHeaderLabels(
-            ["ID", "Title", "PMID", "Similarity"]
+        layout.setContentsMargins(
+            self.scale['padding_medium'],
+            self.scale['padding_medium'],
+            self.scale['padding_medium'],
+            self.scale['padding_medium']
         )
-        self.alternatives_tree.setColumnWidth(0, self.scale['char_width'] * 8)
-        self.alternatives_tree.setColumnWidth(1, self.scale['char_width'] * 50)
-        self.alternatives_tree.setColumnWidth(2, self.scale['char_width'] * 12)
-        self.alternatives_tree.setAlternatingRowColors(True)
-        self.alternatives_tree.itemDoubleClicked.connect(
-            self._on_alternative_double_clicked
-        )
-        match_layout.addWidget(self.alternatives_tree)
 
-        match_group.setLayout(match_layout)
-        layout.addWidget(match_group, stretch=1)
+        # PDF Upload Widget (main component)
+        self._upload_widget = PDFUploadWidget()
+        layout.addWidget(self._upload_widget, stretch=1)
 
-        # Ingestion options
+        # Ingestion status section
+        status_group = QGroupBox("Ingestion Status")
+        status_layout = QVBoxLayout()
+
+        self._ingest_spinner = StatusSpinnerWidget()
+        status_layout.addWidget(self._ingest_spinner)
+
+        status_group.setLayout(status_layout)
+        layout.addWidget(status_group)
+
+        # Additional options section
+        options_group = QGroupBox("Options")
         options_layout = QHBoxLayout()
 
-        self.ingest_checkbox = QCheckBox("Ingest PDF (extract text & create embeddings)")
-        self.ingest_checkbox.setChecked(True)
-        self.ingest_checkbox.setToolTip(
-            "Store PDF, convert to text, and create semantic embeddings.\n"
-            "This enables full-text analysis for the Paper Weight assessment."
+        self._ingest_on_select = QCheckBox("Ingest PDF on selection")
+        self._ingest_on_select.setChecked(True)
+        self._ingest_on_select.setToolTip(
+            "When checked, automatically ingest PDF (extract text and create embeddings)\n"
+            "when selecting or creating a document. This enables full-text analysis."
         )
-        options_layout.addWidget(self.ingest_checkbox)
+        options_layout.addWidget(self._ingest_on_select)
         options_layout.addStretch()
-        layout.addLayout(options_layout)
 
-        # Action buttons
-        button_layout = QHBoxLayout()
+        options_group.setLayout(options_layout)
+        layout.addWidget(options_group)
 
-        self.use_match_btn = QPushButton("Use Selected Match")
-        self.use_match_btn.clicked.connect(self._use_selected_match)
-        self.use_match_btn.setStyleSheet(self.styles.button_stylesheet(
-            bg_color="#4CAF50"
-        ))
-        self.use_match_btn.setEnabled(False)
-        button_layout.addWidget(self.use_match_btn)
+    def _connect_signals(self) -> None:
+        """Connect widget signals."""
+        # Connect PDFUploadWidget signals
+        self._upload_widget.document_selected.connect(self._on_document_selected)
+        self._upload_widget.document_created.connect(self._on_document_created)
 
-        self.create_new_btn = QPushButton("Create New Document")
-        self.create_new_btn.clicked.connect(self._create_new_document)
-        self.create_new_btn.setStyleSheet(self.styles.button_stylesheet(
-            bg_color="#FF9800"
-        ))
-        self.create_new_btn.setEnabled(False)
-        button_layout.addWidget(self.create_new_btn)
-
-        button_layout.addStretch()
-
-        layout.addLayout(button_layout)
-
-        # Connect tree selection
-        self.alternatives_tree.itemSelectionChanged.connect(
-            self._on_selection_changed
-        )
-
-    def _browse_pdf(self) -> None:
-        """Open file dialog to select PDF."""
-        file_path, _ = QFileDialog.getOpenFileName(
-            self,
-            "Select PDF File",
-            "",
-            "PDF Files (*.pdf)"
-        )
-
-        if file_path:
-            pdf_path = Path(file_path)
-
-            # Validate file size
-            is_valid_size, size_warning = validate_pdf_file_size(pdf_path)
-            if not is_valid_size and size_warning:
-                reply = QMessageBox.warning(
-                    self,
-                    "Large File Warning",
-                    f"{size_warning}\n\nDo you want to continue anyway?",
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No
-                )
-                if reply != QMessageBox.Yes:
-                    return
-
-            self.current_pdf_path = pdf_path
-            self.file_path_label.setText(self.current_pdf_path.name)
-            self._analyze_pdf()
-
-    def _analyze_pdf(self) -> None:
-        """Start PDF analysis in background."""
-        if not self.current_pdf_path:
-            return
-
-        # Clear previous results
-        self._clear_results()
-
-        # Start spinner
-        self.status_spinner.start_spinner()
-        self.status_spinner.set_status("Analyzing PDF...")
-
-        # Create and start worker
-        self.analysis_worker = PDFAnalysisWorker(self.current_pdf_path, self)
-        self.analysis_worker.status_update.connect(self._on_status_update)
-        self.analysis_worker.analysis_complete.connect(self._on_analysis_complete)
-        self.analysis_worker.analysis_error.connect(self._on_analysis_error)
-        self.analysis_worker.start()
-
-    def _clear_results(self) -> None:
-        """Clear all result fields."""
-        self.title_edit.clear()
-        self.authors_edit.clear()
-        self.doi_edit.clear()
-        self.pmid_edit.clear()
-        self.year_edit.clear()
-        self.alternatives_tree.clear()
-        self.match_status_label.setText("Analyzing...")
-        self.use_match_btn.setEnabled(False)
-        self.create_new_btn.setEnabled(False)
-        self.current_metadata = None
-        self.current_match = None
-
-    def _on_status_update(self, status: str) -> None:
-        """Handle status update from worker."""
-        self.status_spinner.set_status(status)
-
-    def _on_analysis_complete(self, result: Dict) -> None:
-        """Handle completed analysis."""
-        self.status_spinner.set_complete("Analysis complete")
-
-        self.current_metadata = result['metadata']
-        self.current_match = result['match']
-
-        # Populate metadata fields
-        if self.current_metadata:
-            self.title_edit.setText(self.current_metadata.get('title') or '')
-            authors = self.current_metadata.get('authors', [])
-            if authors:
-                self.authors_edit.setText(', '.join(authors))
-            self.doi_edit.setText(self.current_metadata.get('doi') or '')
-            self.pmid_edit.setText(str(self.current_metadata.get('pmid') or ''))
-
-        # Populate alternatives tree
-        alternatives = result.get('alternatives', [])
-
-        # Add exact match at top if found
-        if self.current_match:
-            match_item = QTreeWidgetItem([
-                str(self.current_match['id']),
-                self.current_match['title'] or 'No title',
-                str(self.current_match.get('external_id') or ''),
-                "EXACT MATCH"
-            ])
-            match_item.setToolTip(1, self.current_match['title'] or 'No title')
-            self.alternatives_tree.addTopLevelItem(match_item)
-            self.alternatives_tree.setCurrentItem(match_item)
-
-        # Add alternatives
-        for alt in alternatives:
-            # Skip if same as exact match
-            if self.current_match and alt['id'] == self.current_match['id']:
-                continue
-
-            item = QTreeWidgetItem([
-                str(alt['id']),
-                alt['title'] or 'No title',
-                str(alt.get('pmid') or ''),
-                f"{alt['similarity']:.2f}"
-            ])
-            item.setToolTip(1, alt['title'] or 'No title')
-            self.alternatives_tree.addTopLevelItem(item)
-
-        # Update status
-        if self.current_match:
-            self.match_status_label.setText(
-                f"Found exact match: {self.current_match['title'][:80]}..."
-            )
-        elif alternatives:
-            self.match_status_label.setText(
-                f"Found {len(alternatives)} potential matches. "
-                "Select one or create a new document."
-            )
-        else:
-            self.match_status_label.setText(
-                "No matching documents found. "
-                "Edit metadata above and create a new document."
-            )
-
-        # Enable buttons
-        self.create_new_btn.setEnabled(True)
-        self._on_selection_changed()
-
-    def _on_analysis_error(self, error: str) -> None:
+    def _on_document_selected(self, document_id: int) -> None:
         """
-        Handle analysis error with granular error messages.
-
-        Provides specific guidance based on the type of error encountered.
-        """
-        error_lower = error.lower()
-
-        # Determine error type and provide specific guidance
-        if "text extraction" in error_lower or "extract text" in error_lower:
-            status_msg = "Could not extract text - PDF may be scanned"
-            guidance = (
-                "The PDF may be a scanned document without embedded text.\n\n"
-                "Suggestions:\n"
-                "- Use OCR software to convert the scanned PDF to text\n"
-                "- Try a different version of the document if available"
-            )
-        elif "metadata" in error_lower or "llm" in error_lower or "model" in error_lower:
-            status_msg = "AI metadata extraction failed"
-            guidance = (
-                "The AI model could not extract metadata from the PDF.\n\n"
-                "Possible causes:\n"
-                "- Ollama service may not be running\n"
-                "- The configured model may not be available\n"
-                "- The PDF text may be in an unexpected format\n\n"
-                "Try:\n"
-                "- Check that Ollama is running\n"
-                "- Enter metadata manually in the fields above"
-            )
-        elif "connection" in error_lower or "timeout" in error_lower:
-            status_msg = "Connection error"
-            guidance = (
-                "Could not connect to required services.\n\n"
-                "Please check:\n"
-                "- Database connection\n"
-                "- Ollama service is running\n"
-                "- Network connectivity"
-            )
-        elif "permission" in error_lower or "access" in error_lower:
-            status_msg = "File access error"
-            guidance = (
-                "Could not access the PDF file.\n\n"
-                "Please check:\n"
-                "- File permissions\n"
-                "- File is not locked by another application"
-            )
-        elif "corrupt" in error_lower or "invalid" in error_lower:
-            status_msg = "Invalid PDF file"
-            guidance = (
-                "The file does not appear to be a valid PDF.\n\n"
-                "Please check:\n"
-                "- File is not corrupted\n"
-                "- File has a .pdf extension but is actually a PDF"
-            )
-        else:
-            status_msg = "Analysis failed"
-            guidance = f"An unexpected error occurred:\n\n{error}"
-
-        self.status_spinner.set_error(status_msg)
-        self.match_status_label.setText(f"Error: {status_msg}")
-
-        # Enable manual entry as fallback
-        self.create_new_btn.setEnabled(True)
-
-        QMessageBox.critical(
-            self,
-            "Analysis Error",
-            f"{guidance}\n\nYou can still enter metadata manually and create a new document."
-        )
-
-    def _on_selection_changed(self) -> None:
-        """Enable/disable use match button based on selection."""
-        has_selection = len(self.alternatives_tree.selectedItems()) > 0
-        self.use_match_btn.setEnabled(has_selection)
-
-    def _on_alternative_double_clicked(
-        self,
-        item: QTreeWidgetItem,
-        column: int
-    ) -> None:
-        """Handle double-click to use match."""
-        self._use_selected_match()
-
-    def _use_selected_match(self) -> None:
-        """Use selected document match and optionally ingest PDF."""
-        current = self.alternatives_tree.currentItem()
-        if current:
-            document_id = int(current.text(0))
-
-            # If ingest checkbox is checked, ingest the PDF
-            if self.ingest_checkbox.isChecked() and self.current_pdf_path:
-                self._ingest_pdf(document_id)
-            else:
-                self.document_selected.emit(document_id)
-
-    def _create_new_document(self) -> None:
-        """Create new document from extracted metadata."""
-        # Validate title (required field)
-        title = self.title_edit.text().strip()
-        is_valid_title, title_error = validate_title(title)
-        if not is_valid_title:
-            QMessageBox.warning(self, "Invalid Title", title_error)
-            return
-
-        # Validate PMID (optional field)
-        pmid_text = self.pmid_edit.text().strip()
-        is_valid_pmid, pmid_error = validate_pmid(pmid_text)
-        if not is_valid_pmid:
-            QMessageBox.warning(self, "Invalid PMID", pmid_error)
-            return
-
-        # Validate DOI (optional field)
-        doi_text = self.doi_edit.text().strip()
-        is_valid_doi, doi_error = validate_doi(doi_text)
-        if not is_valid_doi:
-            QMessageBox.warning(self, "Invalid DOI", doi_error)
-            return
-
-        # Validate year (optional field)
-        year_text = self.year_edit.text().strip()
-        is_valid_year, year_error = validate_year(year_text)
-        if not is_valid_year:
-            QMessageBox.warning(self, "Invalid Year", year_error)
-            return
-
-        # Confirm creation
-        reply = QMessageBox.question(
-            self,
-            "Create New Document",
-            f"Create new document:\n\n{title[:100]}...\n\n"
-            "This will add a new entry to the database.",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No
-        )
-
-        if reply != QMessageBox.Yes:
-            return
-
-        try:
-            # Parse metadata
-            authors_text = self.authors_edit.text().strip()
-            authors = [a.strip() for a in authors_text.split(',') if a.strip()]
-            doi = self.doi_edit.text().strip() or None
-            pmid = self.pmid_edit.text().strip() or None
-            year = self.year_edit.text().strip()
-
-            # Create external_id (use PMID, DOI hash, or generated)
-            if pmid:
-                external_id = pmid
-            elif doi:
-                # Use DOI as external_id
-                external_id = doi.replace('/', '_')
-            else:
-                # Generate unique ID
-                import uuid
-                external_id = f"other_{uuid.uuid4().hex[:12]}"
-
-            # Insert into database
-            db_manager = get_db_manager()
-            with db_manager.get_connection() as conn:
-                with conn.cursor() as cur:
-                    # First ensure source "other" exists
-                    cur.execute("""
-                        INSERT INTO public.sources (id, name, is_reputable, is_free)
-                        VALUES (%s, 'other', false, true)
-                        ON CONFLICT (name) DO NOTHING
-                    """, (SOURCE_ID_OTHER,))
-
-                    # Insert document
-                    cur.execute("""
-                        INSERT INTO document (
-                            source_id, external_id, doi, title, authors,
-                            publication_date
-                        )
-                        VALUES (%s, %s, %s, %s, %s, %s)
-                        RETURNING id
-                    """, (
-                        SOURCE_ID_OTHER,
-                        external_id,
-                        doi,
-                        title,
-                        authors if authors else None,
-                        f"{year}-01-01" if year else None,
-                    ))
-
-                    document_id = cur.fetchone()[0]
-                    conn.commit()
-
-            logger.info(f"Created new document with ID: {document_id}")
-
-            # If ingest checkbox is checked, ingest the PDF
-            if self.ingest_checkbox.isChecked() and self.current_pdf_path:
-                self._ingest_pdf(document_id)
-            else:
-                QMessageBox.information(
-                    self,
-                    "Document Created",
-                    f"New document created with ID: {document_id}"
-                )
-                self.document_selected.emit(document_id)
-
-        except Exception as e:
-            logger.exception(f"Error creating document: {e}")
-            QMessageBox.critical(
-                self,
-                "Creation Error",
-                f"Failed to create document:\n{e}"
-            )
-
-    def _ingest_pdf(self, document_id: int) -> None:
-        """
-        Ingest PDF for a document.
+        Handle document selection from PDFUploadWidget.
 
         Args:
-            document_id: Database document ID
+            document_id: Selected document ID
         """
-        if not self.current_pdf_path:
+        logger.info(f"Document selected: {document_id}")
+
+        if self._should_ingest():
+            self._start_ingestion(document_id)
+        else:
+            self.document_selected.emit(document_id)
+
+    def _on_document_created(self, document_id: int) -> None:
+        """
+        Handle document creation from PDFUploadWidget.
+
+        Args:
+            document_id: Created document ID
+        """
+        logger.info(f"Document created: {document_id}")
+
+        if self._should_ingest():
+            self._start_ingestion(document_id)
+        else:
+            self.document_selected.emit(document_id)
+
+    def _should_ingest(self) -> bool:
+        """
+        Check if PDF should be ingested.
+
+        Returns:
+            True if ingestion should occur
+        """
+        # Check if checkbox is checked
+        if not self._ingest_on_select.isChecked():
+            return False
+
+        # Check if widget has ingestion requested
+        if not self._upload_widget.should_ingest():
+            return False
+
+        # Check if we have a PDF
+        pdf_path = self._upload_widget.get_pdf_path()
+        return pdf_path is not None
+
+    def _start_ingestion(self, document_id: int) -> None:
+        """
+        Start PDF ingestion for a document.
+
+        Args:
+            document_id: Document ID to ingest PDF for
+        """
+        pdf_path = self._upload_widget.get_pdf_path()
+        if not pdf_path:
+            # No PDF to ingest, just emit the signal
             self.document_selected.emit(document_id)
             return
 
-        # Disable buttons during ingestion
-        self.use_match_btn.setEnabled(False)
-        self.create_new_btn.setEnabled(False)
-
-        # Start spinner
-        self.status_spinner.start_spinner()
-        self.status_spinner.set_status("Ingesting PDF...")
-
-        # Store document_id for completion handler
+        # Store pending document ID
         self._pending_document_id = document_id
 
-        # Create and start ingest worker
-        self.ingest_worker = PDFIngestWorker(
-            document_id,
-            self.current_pdf_path,
-            self
-        )
-        self.ingest_worker.status_update.connect(self._on_status_update)
-        self.ingest_worker.ingest_complete.connect(self._on_ingest_complete)
-        self.ingest_worker.ingest_error.connect(self._on_ingest_error)
-        self.ingest_worker.start()
+        # Start ingestion spinner
+        self._ingest_spinner.start_spinner()
+        self._ingest_spinner.set_status("Preparing ingestion...")
+
+        # Create and start worker
+        self._ingest_worker = PDFIngestWorker(document_id, pdf_path, self)
+        self._ingest_worker.status_update.connect(self._on_ingest_status)
+        self._ingest_worker.ingest_complete.connect(self._on_ingest_complete)
+        self._ingest_worker.ingest_error.connect(self._on_ingest_error)
+        self._ingest_worker.start()
+
+    def _on_ingest_status(self, status: str) -> None:
+        """
+        Handle ingestion status update.
+
+        Args:
+            status: Status message
+        """
+        self._ingest_spinner.set_status(status)
 
     def _on_ingest_complete(self, result: Any) -> None:
-        """Handle completed PDF ingestion."""
+        """
+        Handle completed PDF ingestion.
+
+        Args:
+            result: IngestResult from PDFIngestor
+        """
         document_id = self._pending_document_id
 
         if result.success:
-            self.status_spinner.set_complete(
+            self._ingest_spinner.set_complete(
                 f"Ingestion complete: {result.chunks_created} chunks, "
                 f"{result.char_count:,} chars"
             )
@@ -776,35 +277,33 @@ class PDFUploadTab(QWidget):
                 f"- Chunks created: {result.chunks_created}"
             )
         else:
-            self.status_spinner.set_error("Ingestion failed")
+            self._ingest_spinner.set_error("Ingestion completed with warnings")
 
             # Show warning but still proceed
             QMessageBox.warning(
                 self,
                 "Ingestion Warning",
-                f"PDF ingestion completed with errors:\n{result.error_message}\n\n"
+                f"PDF ingestion completed with issues:\n{result.error_message}\n\n"
                 "The document was still associated, but full-text analysis "
                 "may not be available."
             )
 
-        # Re-enable buttons
-        self.use_match_btn.setEnabled(True)
-        self.create_new_btn.setEnabled(True)
-
         # Emit document selected signal
-        self.document_selected.emit(document_id)
+        if document_id is not None:
+            self.document_selected.emit(document_id)
 
     def _on_ingest_error(self, error: str) -> None:
-        """Handle ingestion error."""
+        """
+        Handle ingestion error.
+
+        Args:
+            error: Error message
+        """
         document_id = self._pending_document_id
 
-        self.status_spinner.set_error("Ingestion failed")
+        self._ingest_spinner.set_error("Ingestion failed")
 
-        # Re-enable buttons
-        self.use_match_btn.setEnabled(True)
-        self.create_new_btn.setEnabled(True)
-
-        # Show error but still proceed
+        # Show error but offer to continue
         reply = QMessageBox.question(
             self,
             "Ingestion Error",
@@ -814,29 +313,23 @@ class PDFUploadTab(QWidget):
             QMessageBox.Yes
         )
 
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.Yes and document_id is not None:
             self.document_selected.emit(document_id)
 
     def _terminate_workers(self) -> None:
         """
         Safely terminate any running worker threads.
 
-        Waits up to WORKER_TERMINATE_TIMEOUT_MS for each worker to finish.
+        Waits up to WORKER_TERMINATE_TIMEOUT_MS for workers to finish.
         """
-        workers = [
-            ('analysis_worker', self.analysis_worker),
-            ('ingest_worker', self.ingest_worker),
-        ]
-
-        for name, worker in workers:
-            if worker is not None and worker.isRunning():
-                logger.info(f"Terminating {name} thread...")
-                worker.terminate()
-                if not worker.wait(WORKER_TERMINATE_TIMEOUT_MS):
-                    logger.warning(
-                        f"{name} did not terminate within "
-                        f"{WORKER_TERMINATE_TIMEOUT_MS}ms"
-                    )
+        if self._ingest_worker is not None and self._ingest_worker.isRunning():
+            logger.info("Terminating ingest worker thread...")
+            self._ingest_worker.terminate()
+            if not self._ingest_worker.wait(WORKER_TERMINATE_TIMEOUT_MS):
+                logger.warning(
+                    f"Ingest worker did not terminate within "
+                    f"{WORKER_TERMINATE_TIMEOUT_MS}ms"
+                )
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """
@@ -848,9 +341,8 @@ class PDFUploadTab(QWidget):
             event: The close event
         """
         self._terminate_workers()
-        # Clear worker references for garbage collection
-        self.analysis_worker = None
-        self.ingest_worker = None
+        # Clear worker reference for garbage collection
+        self._ingest_worker = None
         super().closeEvent(event)
 
 


### PR DESCRIPTION
## Summary

Integrate the new reusable `PDFUploadWidget` into both `paper_weight_lab` and `paper_checker_lab` applications.

- **paper_weight_lab**: Replace custom 857-line PDFUploadTab with thin 349-line wrapper around PDFUploadWidget
- **paper_checker_lab**: Add PDFViewerWidget alongside existing abstract extraction workflow with split-view layout

## Changes

### paper_weight_lab (`src/bmlibrarian/lab/paper_weight_lab/tabs/pdf_upload_tab.py`)

- Replaced custom implementation with wrapper around `PDFUploadWidget`
- Uses widget's split-view PDF viewer with metadata panel, quick regex extraction, and LLM fallback
- Maintains `PDFIngestWorker` for paper weight-specific text extraction and embeddings
- Connects widget signals (`document_selected`, `document_created`) to tab's output signal
- Added "Ingest PDF on selection" checkbox for controlling ingestion behavior
- **Net reduction: ~500 lines of code**

### paper_checker_lab (`src/bmlibrarian/lab/paper_checker_lab/tabs/pdf_upload_tab.py`)

- New split-view layout with `PDFViewerWidget` on left (50%) and controls on right (50%)
- Uses shared validation utilities (`validate_pdf_file`, `ValidationStatus`) from widgets module
- Maintains existing abstract extraction workflow (paper_checker needs abstracts, not document IDs)
- PDF viewer allows users to see the document while abstract is being extracted
- Added proper worker termination on close event

### Golden Rule Compliance (paper_checker_lab)

- Moved magic numbers to `constants.py`: `SPLITTER_RATIO_PDF`, `SPLITTER_RATIO_CONTROLS`, `WORKER_TERMINATE_TIMEOUT_MS`, `COLOR_METADATA_BG`
- Use stylesheet generator (`label_stylesheet`) instead of inline CSS for labels
- All dimensional values from DPI scale system
- Added explanatory comment for metadata label inline style (generator limitation)

## Key Differences in Integration Approach

| Feature | paper_weight_lab | paper_checker_lab |
|---------|-----------------|-------------------|
| Widget used | Full `PDFUploadWidget` | Only `PDFViewerWidget` |
| Purpose | Document matching/creation | Abstract extraction |
| Output | Document ID | Abstract text + metadata |
| PDF ingestion | Yes (embeddings) | No |

## Test Plan

- [ ] Launch `paper_weight_lab.py` and verify PDF Upload tab displays PDFUploadWidget
- [ ] Test PDF loading, document matching, and selection workflow
- [ ] Verify PDF ingestion checkbox functions correctly
- [ ] Launch `paper_checker_lab.py` and verify PDF Upload tab has split-view layout
- [ ] Test PDF loading shows document in viewer
- [ ] Test abstract extraction workflow completes successfully
- [ ] Verify splitter resizing works correctly
- [ ] Test worker termination on application close

## Files Changed

- `src/bmlibrarian/lab/paper_weight_lab/tabs/pdf_upload_tab.py` - Complete rewrite
- `src/bmlibrarian/lab/paper_checker_lab/tabs/pdf_upload_tab.py` - Added PDF viewer, golden rule fixes
- `src/bmlibrarian/lab/paper_checker_lab/constants.py` - Added PDF upload tab constants