### PR TITLE
Improve import validation robustness

### DIFF
--- a/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/assessment_display.py
+++ b/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/assessment_display.py
@@ -16,7 +16,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QFont, QColor
 
 from bmlibrarian.agents.prisma2020_agent import PRISMA2020Assessment
-from ...resources.styles import StylesheetGenerator, scale_px
+from ...resources.styles import StylesheetGenerator, scale_px, get_font_scale
 from .constants import ITEM_LABELS, SEPARATOR_COLOR
 from .score_utils import (
     get_score_color,
@@ -370,17 +370,18 @@ def create_item_row(
     score_badge = QLabel(get_score_text(score))
     score_badge.setAlignment(Qt.AlignCenter)
     score_badge.setFixedWidth(scale_px(120))
+    s = get_font_scale()
     score_badge.setStyleSheet(
-        stylesheet_gen.custom(f"""
+        f"""
             QLabel {{
                 background-color: {get_score_color(score)};
                 color: white;
                 font-weight: bold;
-                font-size: {{font_small}}pt;
-                padding: {{padding_tiny}}px;
-                border-radius: {{radius_small}}px;
+                font-size: {s['font_small']}pt;
+                padding: {s['padding_tiny']}px;
+                border-radius: {s['radius_small']}px;
             }}
-        """)
+        """
     )
 
     header_row.addWidget(item_label)

--- a/src/bmlibrarian/gui/qt/plugins/study_assessment/study_assessment_tab.py
+++ b/src/bmlibrarian/gui/qt/plugins/study_assessment/study_assessment_tab.py
@@ -767,17 +767,18 @@ class StudyAssessmentTabWidget(QWidget, IDocumentReceiver):
         risk_badge = QLabel(risk_level.upper())
         risk_badge.setAlignment(Qt.AlignCenter)
         risk_badge.setFixedWidth(scale_px(100))
+        s = get_font_scale()
         risk_badge.setStyleSheet(
-            self.stylesheet_gen.custom(f"""
+            f"""
                 QLabel {{
                     background-color: {BIAS_RISK_COLORS.get(risk_level.lower(), BIAS_RISK_COLORS['unclear'])};
                     color: white;
                     font-weight: bold;
-                    font-size: {{font_small}}pt;
-                    padding: {{padding_tiny}}px;
-                    border-radius: {{radius_small}}px;
+                    font-size: {s['font_small']}pt;
+                    padding: {s['padding_tiny']}px;
+                    border-radius: {s['radius_small']}px;
                 }}
-            """)
+            """
         )
 
         row.addWidget(type_label)

--- a/src/bmlibrarian/gui/qt/widgets/pdf_upload_widget.py
+++ b/src/bmlibrarian/gui/qt/widgets/pdf_upload_widget.py
@@ -185,14 +185,12 @@ class PDFUploadWidget(QWidget):
         self.quick_match_frame = QFrame()
         self.quick_match_frame.setFrameStyle(QFrame.Box | QFrame.Plain)
         self.quick_match_frame.setStyleSheet(
-            self.style_gen.custom(
-                f"QFrame {{ "
-                f"background-color: {ThemeColors.SUCCESS_BG}; "
-                f"border: 1px solid {ThemeColors.SUCCESS_BORDER}; "
-                f"border-radius: {{radius_small}}px; "
-                f"padding: {{padding_small}}px; "
-                f"}}"
-            )
+            f"QFrame {{ "
+            f"background-color: {ThemeColors.SUCCESS_BG}; "
+            f"border: 1px solid {ThemeColors.SUCCESS_BORDER}; "
+            f"border-radius: {s['radius_small']}px; "
+            f"padding: {s['padding_small']}px; "
+            f"}}"
         )
         quick_match_layout = QVBoxLayout(self.quick_match_frame)
 


### PR DESCRIPTION
## Summary

- Fix `KeyError: ' background-color'` crash in PDFUploadWidget caused by f-string/`custom()` method conflict
- Improve import validation and error handling in PDFViewerWidget per PR #164 code review feedback

## Changes

### PDFViewerWidget (`pdf_viewer.py`)
- **Import validation logging**: Log when PyMuPDF is unavailable so users understand text extraction limitations
- **File type validation**: Validate `.pdf` extension before loading to prevent obscure errors
- **Page navigation fallback**: Add warning log when `pageNavigator()` returns None
- **Race condition protection**: Guard `_on_page_changed` against calls before document is loaded

### Stylesheet Fix (`pdf_upload_widget.py`, `assessment_display.py`, `study_assessment_tab.py`)
- **Root cause**: `StylesheetGenerator.custom()` uses `str.format()` internally, which conflicts with f-strings that produce literal CSS braces `{`/`}`
- **Fix**: Replace `custom()` calls with direct f-string interpolation using `get_font_scale()` dictionary access
- **Compliance**: Still uses DPI-scaled values and centralized ThemeColors - no hardcoded pixel values

## Test Plan

- [ ] Launch `paper_weight_lab.py` - should no longer crash with KeyError
- [ ] Open PDF in any Qt PDF viewer widget - verify file type validation works
- [ ] Try loading a non-PDF file - should show "Not a PDF file" error
- [ ] Verify PDF navigation works correctly
- [ ] Check logs for PyMuPDF availability message when text extraction is attempted