### PR TITLE
Add full text PDF discovery system with OpenAthens

### DIFF
--- a/doc/developers/full_text_discovery_system.md
+++ b/doc/developers/full_text_discovery_system.md
@@ -1,0 +1,523 @@
+# Full-Text Discovery System - Developer Documentation
+
+This document describes the architecture and implementation details of the full-text PDF discovery system in BMLibrarian.
+
+## Architecture Overview
+
+The discovery system uses a resolver-based architecture where each source type is implemented as a separate resolver class. The `FullTextFinder` orchestrates these resolvers and manages the download process.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      FullTextFinder                          │
+│  (Orchestrates discovery and download)                       │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐       │
+│  │   PMC    │ │Unpaywall │ │   DOI    │ │ Direct   │ ...   │
+│  │ Resolver │ │ Resolver │ │ Resolver │ │   URL    │       │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘       │
+│        │            │            │            │              │
+│        └────────────┴────────────┴────────────┘              │
+│                          │                                   │
+│                    BaseResolver                              │
+│              (Abstract base class)                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Module Structure
+
+```
+src/bmlibrarian/discovery/
+├── __init__.py          # Module exports
+├── data_types.py        # Type-safe dataclasses and enums
+├── resolvers.py         # Resolver implementations
+└── full_text_finder.py  # Orchestrator
+
+tests/discovery/
+├── __init__.py
+├── test_data_types.py   # Data type tests
+└── test_resolvers.py    # Resolver tests
+```
+
+## Data Types
+
+### Enums
+
+```python
+class SourceType(Enum):
+    """Type of PDF source."""
+    DIRECT_URL = "direct_url"    # Direct PDF URL from database
+    DOI_REDIRECT = "doi_redirect"  # PDF URL via DOI resolution
+    PMC = "pmc"                  # PubMed Central
+    UNPAYWALL = "unpaywall"      # Unpaywall API
+    OPENATHENS = "openathens"    # OpenAthens institutional proxy
+    BROWSER = "browser"          # Browser-based download
+    UNKNOWN = "unknown"
+
+class AccessType(Enum):
+    """Type of access for the PDF."""
+    OPEN = "open"                # Freely accessible (OA)
+    INSTITUTIONAL = "institutional"  # Requires institutional access
+    SUBSCRIPTION = "subscription"    # Requires subscription
+    UNKNOWN = "unknown"
+
+class ResolutionStatus(Enum):
+    """Status of a resolution attempt."""
+    SUCCESS = "success"
+    NOT_FOUND = "not_found"
+    ACCESS_DENIED = "access_denied"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+    SKIPPED = "skipped"
+```
+
+### Core Dataclasses
+
+#### DocumentIdentifiers
+
+Input for discovery operations:
+
+```python
+@dataclass
+class DocumentIdentifiers:
+    doc_id: Optional[int] = None    # Database ID
+    doi: Optional[str] = None       # Digital Object Identifier
+    pmid: Optional[str] = None      # PubMed ID
+    pmcid: Optional[str] = None     # PubMed Central ID
+    title: Optional[str] = None     # Document title
+    pdf_url: Optional[str] = None   # Existing URL from database
+
+    def has_identifiers(self) -> bool:
+        """Check if document has any usable identifiers."""
+        return any([self.doi, self.pmid, self.pmcid, self.title])
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentIdentifiers":
+        """Create from dictionary (e.g., database row)."""
+```
+
+#### PDFSource
+
+Represents a discovered PDF source:
+
+```python
+@dataclass
+class PDFSource:
+    url: str                        # PDF URL
+    source_type: SourceType         # Source type
+    access_type: AccessType         # Access requirements
+    priority: int = 0               # Lower = higher priority
+    license: Optional[str] = None   # License URL if known
+    version: Optional[str] = None   # e.g., "published", "accepted"
+    is_best_oa: bool = False        # From Unpaywall
+    host_type: Optional[str] = None # e.g., "publisher", "repository"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+```
+
+#### DiscoveryResult
+
+Complete discovery result:
+
+```python
+@dataclass
+class DiscoveryResult:
+    identifiers: DocumentIdentifiers
+    sources: List[PDFSource] = field(default_factory=list)
+    resolution_results: List[ResolutionResult] = field(default_factory=list)
+    best_source: Optional[PDFSource] = None
+    total_duration_ms: float = 0.0
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def has_open_access(self) -> bool: ...
+    def get_open_access_sources(self) -> List[PDFSource]: ...
+    def get_sources_by_type(self, source_type: SourceType) -> List[PDFSource]: ...
+    def select_best_source(self) -> Optional[PDFSource]: ...
+```
+
+## Resolver Architecture
+
+### Base Resolver
+
+All resolvers inherit from `BaseResolver`:
+
+```python
+class BaseResolver(ABC):
+    """Abstract base class for PDF source resolvers."""
+
+    def __init__(self, timeout: int = DEFAULT_TIMEOUT):
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': USER_AGENT,
+            'Accept': 'application/json, text/html, application/pdf, */*'
+        })
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Resolver name for logging and identification."""
+        pass
+
+    @abstractmethod
+    def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
+        """Resolve document identifiers to PDF sources."""
+        pass
+
+    def _create_result(
+        self,
+        status: ResolutionStatus,
+        sources: Optional[List[PDFSource]] = None,
+        error_message: Optional[str] = None,
+        duration_ms: float = 0.0,
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> ResolutionResult:
+        """Helper to create ResolutionResult."""
+```
+
+### Implementing a New Resolver
+
+```python
+class MyResolver(BaseResolver):
+    """Custom resolver implementation."""
+
+    @property
+    def name(self) -> str:
+        return "my_resolver"
+
+    def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
+        start_time = time.time()
+
+        # Check if we have required identifiers
+        if not identifiers.doi:
+            return self._create_result(
+                ResolutionStatus.SKIPPED,
+                duration_ms=(time.time() - start_time) * 1000
+            )
+
+        # Perform resolution logic
+        try:
+            sources = self._find_sources(identifiers.doi)
+
+            if not sources:
+                return self._create_result(
+                    ResolutionStatus.NOT_FOUND,
+                    duration_ms=(time.time() - start_time) * 1000
+                )
+
+            return self._create_result(
+                ResolutionStatus.SUCCESS,
+                sources=sources,
+                duration_ms=(time.time() - start_time) * 1000
+            )
+
+        except Exception as e:
+            return self._create_result(
+                ResolutionStatus.ERROR,
+                error_message=str(e),
+                duration_ms=(time.time() - start_time) * 1000
+            )
+```
+
+## Built-in Resolvers
+
+### PMCResolver
+
+Queries PubMed Central for open access PDFs:
+
+- Uses PMC OA web service API
+- Converts PMID → PMCID if needed
+- Falls back to constructed URLs
+
+**Priority**: 5-6 (highest priority for OA)
+
+### UnpaywallResolver
+
+Queries Unpaywall API for open access versions:
+
+- Requires email address
+- Returns best OA location and alternatives
+- Rich metadata (license, version, evidence)
+
+**Priority**: 1-3 (best source)
+
+### DOIResolver
+
+Resolves DOIs via CrossRef and doi.org:
+
+- CrossRef API for structured metadata
+- Content negotiation for direct PDF links
+- Detects Creative Commons licenses
+
+**Priority**: 15-20 (medium)
+
+### DirectURLResolver
+
+Uses existing PDF URLs from database:
+
+- Simple URL validation
+- No external requests
+- Good for known working URLs
+
+**Priority**: 10 (medium)
+
+### OpenAthensResolver
+
+Constructs proxy URLs for institutional access:
+
+- Works with OpenAthensAuth for authentication
+- Last resort for paywalled content
+- Requires institutional subscription
+
+**Priority**: 50 (lowest - only when OA unavailable)
+
+## FullTextFinder
+
+The orchestrator coordinates resolvers and manages downloads:
+
+```python
+class FullTextFinder:
+    def __init__(
+        self,
+        unpaywall_email: Optional[str] = None,
+        openathens_proxy_url: Optional[str] = None,
+        openathens_auth: Optional[Any] = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        prefer_open_access: bool = True,
+        skip_resolvers: Optional[List[str]] = None
+    ): ...
+
+    def discover(
+        self,
+        identifiers: DocumentIdentifiers,
+        stop_on_first_oa: bool = True,
+        progress_callback: Optional[Callable[[str, str], None]] = None
+    ) -> DiscoveryResult: ...
+
+    def discover_and_download(
+        self,
+        identifiers: DocumentIdentifiers,
+        output_path: Path,
+        max_attempts: int = 3,
+        progress_callback: Optional[Callable[[str, str], None]] = None
+    ) -> DownloadResult: ...
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "FullTextFinder": ...
+```
+
+### Discovery Flow
+
+1. Validate identifiers
+2. Iterate through resolvers in priority order
+3. For each resolver:
+   - Call `resolve()` method
+   - Add unique sources to result
+   - If OA source found and `prefer_open_access=True`, stop early
+4. Sort sources by priority
+5. Select best source
+
+### Download Flow
+
+1. Call `discover()` to find sources
+2. Try downloading from each source in priority order
+3. For each source:
+   - Add OpenAthens cookies if needed
+   - Download with exponential backoff retry
+   - Verify content type (reject HTML)
+   - Verify PDF magic bytes
+4. Return first successful download or failure
+
+## Configuration
+
+### JSON Configuration
+
+```json
+{
+  "unpaywall_email": "your@email.com",
+  "discovery": {
+    "timeout": 30,
+    "prefer_open_access": true,
+    "skip_resolvers": []
+  },
+  "openathens": {
+    "enabled": true,
+    "institution_url": "https://institution.openathens.net"
+  }
+}
+```
+
+### Constants
+
+```python
+# resolvers.py
+DEFAULT_TIMEOUT = 30  # seconds
+USER_AGENT = "Mozilla/5.0 ..."
+
+# full_text_finder.py
+DEFAULT_UNPAYWALL_EMAIL = "bmlibrarian@example.com"
+```
+
+## Testing
+
+### Unit Tests
+
+Tests are in `tests/discovery/`:
+
+```bash
+# Run all discovery tests
+uv run pytest tests/discovery/ -v
+
+# Run specific test
+uv run pytest tests/discovery/test_resolvers.py::TestPMCResolver -v
+```
+
+### Test Structure
+
+```python
+class TestMyResolver:
+    """Tests for MyResolver."""
+
+    def test_resolve_with_identifier(self):
+        """Test successful resolution."""
+        resolver = MyResolver()
+        identifiers = DocumentIdentifiers(doi="10.1234/test")
+
+        result = resolver.resolve(identifiers)
+
+        assert result.status == ResolutionStatus.SUCCESS
+        assert len(result.sources) >= 1
+
+    def test_resolve_without_identifier(self):
+        """Test when required identifier is missing."""
+        resolver = MyResolver()
+        identifiers = DocumentIdentifiers(pmid="12345")
+
+        result = resolver.resolve(identifiers)
+
+        assert result.status == ResolutionStatus.SKIPPED
+
+    @patch('bmlibrarian.discovery.resolvers.requests.Session.get')
+    def test_resolve_api_response(self, mock_get):
+        """Test parsing API responses."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {...}
+        mock_get.return_value = mock_response
+
+        resolver = MyResolver()
+        result = resolver.resolve(DocumentIdentifiers(doi="10.1234/test"))
+
+        assert result.status == ResolutionStatus.SUCCESS
+```
+
+## Integration with BMLibrarian
+
+### With PDF Manager
+
+```python
+from bmlibrarian.utils.pdf_manager import PDFManager
+from bmlibrarian.discovery import FullTextFinder, DocumentIdentifiers
+
+finder = FullTextFinder(unpaywall_email="your@email.com")
+pdf_manager = PDFManager()
+
+# Discover and download
+identifiers = DocumentIdentifiers.from_dict(document)
+result = finder.discover(identifiers)
+
+if result.best_source:
+    # Use PDF manager for storage
+    pdf_path = pdf_manager.get_pdf_path(document['id'])
+    download = finder.discover_and_download(identifiers, pdf_path)
+```
+
+### With Database
+
+```python
+from bmlibrarian.database import DatabaseManager
+
+db = DatabaseManager()
+finder = FullTextFinder(unpaywall_email="your@email.com")
+
+# Get documents needing PDFs
+documents = db.execute_query("""
+    SELECT id, doi, pmid, pmcid, title, pdf_url
+    FROM documents
+    WHERE local_pdf_path IS NULL
+    LIMIT 100
+""")
+
+for doc in documents:
+    identifiers = DocumentIdentifiers.from_dict(doc)
+    result = finder.discover_and_download(
+        identifiers,
+        output_path=Path(f"pdfs/{doc['id']}.pdf")
+    )
+
+    if result.success:
+        db.execute_query(
+            "UPDATE documents SET local_pdf_path = %s WHERE id = %s",
+            [result.file_path, doc['id']]
+        )
+```
+
+## Error Handling
+
+### Resolution Errors
+
+Each resolver handles its own errors and returns appropriate `ResolutionStatus`:
+
+- `SUCCESS` - Sources found
+- `NOT_FOUND` - No sources found
+- `SKIPPED` - Missing required identifiers
+- `ERROR` - API/network error
+- `ACCESS_DENIED` - Authentication required
+- `TIMEOUT` - Request timed out
+
+### Download Errors
+
+The download system handles:
+
+- HTTP errors (401, 403, 404, etc.)
+- Content type validation (reject HTML)
+- PDF validation (magic bytes check)
+- Connection errors with retry
+- Timeouts with retry
+
+## Performance Considerations
+
+### Early Exit
+
+When `prefer_open_access=True` and `stop_on_first_oa=True`, the system stops searching after finding an OA source:
+
+```python
+result = finder.discover(
+    identifiers,
+    stop_on_first_oa=True  # Stop after PMC/Unpaywall finds OA
+)
+```
+
+### Skip Resolvers
+
+Skip slow or unnecessary resolvers:
+
+```python
+finder = FullTextFinder(
+    skip_resolvers=['doi']  # Skip DOI resolution
+)
+```
+
+### Timeout Configuration
+
+```python
+finder = FullTextFinder(timeout=15)  # Faster failures
+```
+
+## Future Improvements
+
+1. **Caching** - Add response caching for repeated lookups
+2. **Rate Limiting** - Implement per-source rate limiting
+3. **Browser Resolver** - Playwright-based resolver for Cloudflare-protected sites
+4. **Title Search** - Resolver based on title matching
+5. **Async Support** - Async resolver execution for parallel queries
+6. **Metrics** - Success rate tracking per resolver

--- a/doc/users/full_text_discovery_guide.md
+++ b/doc/users/full_text_discovery_guide.md
@@ -1,0 +1,325 @@
+# Full-Text PDF Discovery Guide
+
+BMLibrarian includes a full-text discovery system that finds and downloads PDF versions of academic papers through legal channels. The system prioritizes open access sources and optionally supports institutional access via OpenAthens authentication.
+
+## Overview
+
+The discovery system searches multiple sources in order of preference:
+
+1. **PubMed Central (PMC)** - Verified open access repository
+2. **Unpaywall** - Open access aggregator covering millions of papers
+3. **DOI Resolution** - CrossRef and doi.org content negotiation
+4. **Direct URL** - Existing PDF URLs from the database
+5. **OpenAthens** - Institutional proxy (if configured and authenticated)
+
+## Quick Start
+
+### Basic Usage
+
+```python
+from bmlibrarian.discovery import FullTextFinder, DocumentIdentifiers
+
+# Create finder with your email (required for Unpaywall)
+finder = FullTextFinder(unpaywall_email="your@email.com")
+
+# Discover PDF sources by DOI
+identifiers = DocumentIdentifiers(doi="10.1038/nature12373")
+result = finder.discover(identifiers)
+
+# Check results
+if result.best_source:
+    print(f"Best source: {result.best_source.url}")
+    print(f"Access type: {result.best_source.access_type.value}")
+    print(f"Source: {result.best_source.source_type.value}")
+```
+
+### Download PDFs
+
+```python
+from pathlib import Path
+
+# Discover and download in one step
+download_result = finder.discover_and_download(
+    identifiers,
+    output_path=Path("paper.pdf")
+)
+
+if download_result.success:
+    print(f"Downloaded: {download_result.file_path}")
+    print(f"Size: {download_result.file_size} bytes")
+else:
+    print(f"Failed: {download_result.error_message}")
+```
+
+### Convenience Function
+
+```python
+from bmlibrarian.discovery import discover_full_text
+
+# Quick discovery without creating a finder instance
+result = discover_full_text(
+    doi="10.1038/nature12373",
+    unpaywall_email="your@email.com"
+)
+```
+
+## Document Identifiers
+
+You can search using any combination of identifiers:
+
+```python
+from bmlibrarian.discovery import DocumentIdentifiers
+
+# From individual identifiers
+identifiers = DocumentIdentifiers(
+    doi="10.1038/nature12373",
+    pmid="23831764",
+    pmcid="PMC3749849",
+    title="CRISPR-Cas systems for editing"
+)
+
+# From database row
+row = {'id': 123, 'doi': '10.1038/nature12373', 'pmid': '23831764'}
+identifiers = DocumentIdentifiers.from_dict(row)
+```
+
+## Configuration
+
+### Basic Configuration
+
+```python
+finder = FullTextFinder(
+    unpaywall_email="your@email.com",  # Required for Unpaywall API
+    timeout=30,                         # HTTP request timeout (seconds)
+    prefer_open_access=True,            # Prioritize OA sources
+    skip_resolvers=['doi']              # Skip specific resolvers
+)
+```
+
+### With OpenAthens
+
+```python
+from bmlibrarian.utils.openathens_auth import OpenAthensAuth, OpenAthensConfig
+
+# Configure OpenAthens
+oa_config = OpenAthensConfig(
+    institution_url="https://your-institution.openathens.net"
+)
+oa_auth = OpenAthensAuth(oa_config)
+
+# Authenticate (opens browser for login)
+import asyncio
+asyncio.run(oa_auth.login_interactive())
+
+# Create finder with OpenAthens
+finder = FullTextFinder(
+    unpaywall_email="your@email.com",
+    openathens_proxy_url="https://your-institution.openathens.net",
+    openathens_auth=oa_auth
+)
+```
+
+### From Configuration File
+
+Add to your `~/.bmlibrarian/config.json`:
+
+```json
+{
+  "unpaywall_email": "your@email.com",
+  "discovery": {
+    "timeout": 30,
+    "prefer_open_access": true,
+    "skip_resolvers": []
+  },
+  "openathens": {
+    "enabled": true,
+    "institution_url": "https://your-institution.openathens.net"
+  }
+}
+```
+
+Then load:
+
+```python
+from bmlibrarian.discovery import FullTextFinder
+from bmlibrarian.config import load_config
+
+config = load_config()
+finder = FullTextFinder.from_config(config)
+```
+
+## Understanding Results
+
+### Discovery Result
+
+```python
+result = finder.discover(identifiers)
+
+# All found sources (sorted by priority)
+for source in result.sources:
+    print(f"URL: {source.url}")
+    print(f"Type: {source.source_type.value}")
+    print(f"Access: {source.access_type.value}")
+    print(f"Priority: {source.priority}")
+
+# Best source (selected automatically)
+print(f"Best: {result.best_source}")
+
+# Open access check
+if result.has_open_access():
+    oa_sources = result.get_open_access_sources()
+    print(f"Found {len(oa_sources)} OA sources")
+
+# Resolution details
+for resolution in result.resolution_results:
+    print(f"{resolution.resolver_name}: {resolution.status.value}")
+    print(f"  Duration: {resolution.duration_ms:.1f}ms")
+```
+
+### Source Types
+
+| Type | Description | Typical Priority |
+|------|-------------|------------------|
+| `pmc` | PubMed Central | 5-6 (highest) |
+| `unpaywall` | Unpaywall OA | 1-3 |
+| `doi_redirect` | DOI resolution | 15-20 |
+| `direct_url` | Database URL | 10 |
+| `openathens` | Institutional | 50 (lowest) |
+
+### Access Types
+
+| Type | Description |
+|------|-------------|
+| `open` | Freely accessible (OA) |
+| `institutional` | Requires institutional access |
+| `subscription` | Requires subscription |
+| `unknown` | Access level not determined |
+
+## Progress Tracking
+
+Monitor discovery progress with callbacks:
+
+```python
+def on_progress(resolver: str, status: str):
+    print(f"[{resolver}] {status}")
+
+result = finder.discover(
+    identifiers,
+    progress_callback=on_progress
+)
+```
+
+Status values:
+- `resolving` - Currently querying resolver
+- `found` - Sources found
+- `not_found` - No sources found
+- `found_oa` - Open access source found (early exit)
+- `error` - Resolver failed
+
+## Batch Processing
+
+Process multiple documents efficiently:
+
+```python
+from bmlibrarian.discovery import FullTextFinder, DocumentIdentifiers
+from pathlib import Path
+
+finder = FullTextFinder(unpaywall_email="your@email.com")
+
+documents = [
+    {"doi": "10.1038/nature12373", "id": 1},
+    {"doi": "10.1126/science.1231143", "id": 2},
+    # ... more documents
+]
+
+output_dir = Path("pdfs")
+output_dir.mkdir(exist_ok=True)
+
+for doc in documents:
+    identifiers = DocumentIdentifiers.from_dict(doc)
+    result = finder.discover_and_download(
+        identifiers,
+        output_path=output_dir / f"{doc['id']}.pdf"
+    )
+
+    status = "OK" if result.success else f"FAILED: {result.error_message}"
+    print(f"[{doc['id']}] {status}")
+```
+
+## Best Practices
+
+### 1. Provide Your Email
+
+Always provide a real email address for the Unpaywall API. This is required by their terms of service and helps them contact you if there are issues.
+
+### 2. Respect Rate Limits
+
+The system includes exponential backoff for retries, but you should still:
+- Add delays between batch requests
+- Avoid hammering servers with rapid requests
+- Use caching where possible
+
+### 3. Use Multiple Identifiers
+
+When available, provide multiple identifiers (DOI, PMID, PMCID) to maximize discovery success.
+
+### 4. Check Access Types
+
+Before downloading, check the access type:
+
+```python
+if result.best_source.access_type == AccessType.OPEN:
+    # Safe to download without authentication
+    pass
+elif result.best_source.access_type == AccessType.INSTITUTIONAL:
+    # Requires OpenAthens authentication
+    pass
+```
+
+### 5. Handle Failures Gracefully
+
+```python
+result = finder.discover_and_download(identifiers, output_path)
+
+if not result.success:
+    if "access denied" in result.error_message.lower():
+        # Try with OpenAthens if available
+        pass
+    elif "not found" in result.error_message.lower():
+        # Document may not have PDF available
+        pass
+    else:
+        # Network or other error, may retry
+        pass
+```
+
+## Troubleshooting
+
+### No Sources Found
+
+1. Verify the identifiers are correct
+2. Check if the paper is too new (not yet indexed)
+3. Try alternative identifiers (PMID if DOI fails)
+4. Some papers simply don't have PDFs available
+
+### Access Denied
+
+1. Paper may be paywalled - configure OpenAthens
+2. Check your institutional subscription
+3. Some publishers block automated downloads
+
+### Download Validation Fails
+
+1. Server may be returning HTML login page
+2. Temporary server issue - retry later
+3. PDF may be corrupted at source
+
+### Slow Performance
+
+1. Reduce timeout for faster failures
+2. Skip slow resolvers: `skip_resolvers=['doi']`
+3. Enable early exit: `stop_on_first_oa=True`
+
+## API Reference
+
+See the [developer documentation](../developers/full_text_discovery_system.md) for detailed API reference and architecture information.

--- a/src/bmlibrarian/discovery/__init__.py
+++ b/src/bmlibrarian/discovery/__init__.py
@@ -1,149 +1,75 @@
 """Full-text discovery module for BMLibrarian.
 
- 
-
 Provides tools for finding and downloading PDF full-text from multiple sources,
-
 prioritizing open access when available.
 
- 
-
 Example usage:
-
     from bmlibrarian.discovery import FullTextFinder, DocumentIdentifiers
 
- 
-
     # Create finder
-
     finder = FullTextFinder(unpaywall_email="your@email.com")
 
- 
-
     # Discover PDF sources
-
     identifiers = DocumentIdentifiers(doi="10.1234/example")
-
     result = finder.discover(identifiers)
 
- 
-
     # Get best source
-
     if result.best_source:
-
         print(f"Best source: {result.best_source.url}")
-
         print(f"Access type: {result.best_source.access_type.value}")
 
- 
-
     # Or discover and download in one step
-
     from pathlib import Path
-
     download_result = finder.discover_and_download(
-
         identifiers,
-
         output_path=Path("paper.pdf")
-
     )
-
 """
 
- 
-
 from .data_types import (
-
     SourceType,
-
     AccessType,
-
     ResolutionStatus,
-
     PDFSource,
-
     ResolutionResult,
-
     DocumentIdentifiers,
-
     DiscoveryResult,
-
     DownloadResult
-
 )
-
- 
 
 from .resolvers import (
-
     BaseResolver,
-
     DirectURLResolver,
-
     DOIResolver,
-
     PMCResolver,
-
     UnpaywallResolver,
-
     OpenAthensResolver
-
 )
-
- 
 
 from .full_text_finder import (
-
     FullTextFinder,
-
     discover_full_text
-
 )
 
- 
-
 __all__ = [
-
     # Data types
-
     'SourceType',
-
     'AccessType',
-
     'ResolutionStatus',
-
     'PDFSource',
-
     'ResolutionResult',
-
     'DocumentIdentifiers',
-
     'DiscoveryResult',
-
     'DownloadResult',
-
     # Resolvers
-
     'BaseResolver',
-
     'DirectURLResolver',
-
     'DOIResolver',
-
     'PMCResolver',
-
     'UnpaywallResolver',
-
     'OpenAthensResolver',
-
     # Main classes
-
     'FullTextFinder',
-
     # Convenience functions
-
     'discover_full_text',
-
 ]

--- a/src/bmlibrarian/discovery/data_types.py
+++ b/src/bmlibrarian/discovery/data_types.py
@@ -1,355 +1,178 @@
 """Data types for full-text discovery module.
 
- 
-
 Defines type-safe dataclasses for PDF discovery, resolution results,
-
 and source metadata.
-
 """
 
- 
-
 from dataclasses import dataclass, field
-
 from datetime import datetime
-
 from enum import Enum
-
 from typing import Optional, List, Dict, Any
 
- 
-
- 
 
 class SourceType(Enum):
-
     """Type of PDF source."""
 
- 
-
     DIRECT_URL = "direct_url"  # Direct PDF URL from database
-
     DOI_REDIRECT = "doi_redirect"  # PDF URL via DOI resolution
-
     PMC = "pmc"  # PubMed Central
-
     UNPAYWALL = "unpaywall"  # Unpaywall API
-
     OPENATHENS = "openathens"  # OpenAthens institutional proxy
-
     BROWSER = "browser"  # Browser-based download (Cloudflare bypass)
-
     UNKNOWN = "unknown"
 
- 
-
- 
 
 class AccessType(Enum):
-
     """Type of access for the PDF."""
 
- 
-
     OPEN = "open"  # Freely accessible (OA)
-
     INSTITUTIONAL = "institutional"  # Requires institutional access
-
     SUBSCRIPTION = "subscription"  # Requires subscription
-
     UNKNOWN = "unknown"
 
- 
-
- 
 
 class ResolutionStatus(Enum):
-
     """Status of a resolution attempt."""
 
- 
-
     SUCCESS = "success"
-
     NOT_FOUND = "not_found"
-
     ACCESS_DENIED = "access_denied"
-
     TIMEOUT = "timeout"
-
     ERROR = "error"
-
     SKIPPED = "skipped"
 
- 
-
- 
 
 @dataclass
-
 class PDFSource:
-
     """Represents a discovered PDF source."""
 
- 
-
     url: str
-
     source_type: SourceType
-
     access_type: AccessType
-
     priority: int = 0  # Lower is higher priority (0 = highest)
-
     license: Optional[str] = None
-
     version: Optional[str] = None  # e.g., "published", "accepted", "submitted"
-
     is_best_oa: bool = False  # From Unpaywall: is this the best OA location?
-
     host_type: Optional[str] = None  # e.g., "publisher", "repository"
-
     metadata: Dict[str, Any] = field(default_factory=dict)
-
- 
 
     def __lt__(self, other: "PDFSource") -> bool:
-
         """Compare sources by priority (for sorting)."""
-
         return self.priority < other.priority
 
- 
-
- 
 
 @dataclass
-
 class ResolutionResult:
-
     """Result of a single resolution attempt."""
 
- 
-
     resolver_name: str
-
     status: ResolutionStatus
-
     sources: List[PDFSource] = field(default_factory=list)
-
     error_message: Optional[str] = None
-
     duration_ms: float = 0.0
-
     metadata: Dict[str, Any] = field(default_factory=dict)
 
- 
-
- 
 
 @dataclass
-
 class DocumentIdentifiers:
-
     """Identifiers for a document."""
 
- 
-
     doc_id: Optional[int] = None
-
     doi: Optional[str] = None
-
     pmid: Optional[str] = None
-
     pmcid: Optional[str] = None
-
     title: Optional[str] = None
-
     pdf_url: Optional[str] = None  # Existing URL from database
 
- 
-
     def has_identifiers(self) -> bool:
-
         """Check if document has any usable identifiers."""
-
         return any([self.doi, self.pmid, self.pmcid, self.title])
 
- 
-
     @classmethod
-
     def from_dict(cls, data: Dict[str, Any]) -> "DocumentIdentifiers":
-
         """Create from dictionary (e.g., database row)."""
-
         return cls(
-
             doc_id=data.get('id'),
-
             doi=data.get('doi'),
-
             pmid=data.get('pmid') or data.get('pubmed_id'),
-
             pmcid=data.get('pmcid') or data.get('pmc_id'),
-
             title=data.get('title'),
-
             pdf_url=data.get('pdf_url')
-
         )
 
- 
-
- 
 
 @dataclass
-
 class DiscoveryResult:
-
     """Complete result of full-text discovery for a document."""
 
- 
-
     identifiers: DocumentIdentifiers
-
     sources: List[PDFSource] = field(default_factory=list)
-
     resolution_results: List[ResolutionResult] = field(default_factory=list)
-
     best_source: Optional[PDFSource] = None
-
     total_duration_ms: float = 0.0
-
     timestamp: datetime = field(default_factory=datetime.now)
 
- 
-
     def has_open_access(self) -> bool:
-
         """Check if any open access source was found."""
-
         return any(s.access_type == AccessType.OPEN for s in self.sources)
 
- 
-
     def get_open_access_sources(self) -> List[PDFSource]:
-
         """Get all open access sources."""
-
         return [s for s in self.sources if s.access_type == AccessType.OPEN]
 
- 
-
     def get_sources_by_type(self, source_type: SourceType) -> List[PDFSource]:
-
         """Get sources of a specific type."""
-
         return [s for s in self.sources if s.source_type == source_type]
 
- 
-
     def select_best_source(self) -> Optional[PDFSource]:
-
         """Select the best source based on priority.
 
- 
-
         Priority order:
-
         1. Open access sources (sorted by priority)
-
         2. Institutional access sources
-
         3. Other sources
 
- 
-
         Returns:
-
             Best PDFSource, or None if no sources available
-
         """
-
         if not self.sources:
-
             return None
 
- 
-
         # Separate by access type
-
         open_sources = sorted(
-
             [s for s in self.sources if s.access_type == AccessType.OPEN],
-
             key=lambda s: s.priority
-
         )
-
- 
 
         institutional_sources = sorted(
-
             [s for s in self.sources if s.access_type == AccessType.INSTITUTIONAL],
-
             key=lambda s: s.priority
-
         )
-
- 
 
         other_sources = sorted(
-
             [s for s in self.sources if s.access_type not in (AccessType.OPEN, AccessType.INSTITUTIONAL)],
-
             key=lambda s: s.priority
-
         )
 
- 
-
         # Return first available in priority order
-
         if open_sources:
-
             return open_sources[0]
-
         if institutional_sources:
-
             return institutional_sources[0]
-
         if other_sources:
-
             return other_sources[0]
-
- 
 
         return None
 
- 
-
- 
 
 @dataclass
-
 class DownloadResult:
-
     """Result of a PDF download attempt."""
 
- 
-
     success: bool
-
     source: Optional[PDFSource] = None
-
     file_path: Optional[str] = None
-
     file_size: int = 0
-
     error_message: Optional[str] = None
-
     duration_ms: float = 0.0
-
     attempts: int = 1

--- a/src/bmlibrarian/discovery/full_text_finder.py
+++ b/src/bmlibrarian/discovery/full_text_finder.py
@@ -1,905 +1,453 @@
 """Full-text discovery orchestrator.
 
- 
-
 Coordinates multiple resolvers to find and download PDF full-text
-
 for documents, prioritizing open access sources.
-
 """
 
- 
-
 import logging
-
 import time
-
 from pathlib import Path
-
 from typing import Optional, List, Dict, Any, Callable
-
- 
 
 import requests
 
- 
-
 from .data_types import (
-
     PDFSource, DiscoveryResult, DownloadResult, DocumentIdentifiers,
-
     ResolutionStatus, SourceType, AccessType
-
 )
-
 from .resolvers import (
-
     BaseResolver, DirectURLResolver, DOIResolver,
-
     PMCResolver, UnpaywallResolver, OpenAthensResolver
-
 )
-
- 
 
 logger = logging.getLogger(__name__)
 
- 
-
 # Default configuration
-
 DEFAULT_TIMEOUT = 30
-
 DEFAULT_UNPAYWALL_EMAIL = "bmlibrarian@example.com"
 
- 
-
- 
 
 class FullTextFinder:
-
     """Orchestrates full-text PDF discovery from multiple sources.
 
- 
-
     Tries resolvers in order of preference:
-
     1. PubMed Central (verified open access)
-
     2. Unpaywall (open access aggregator)
-
     3. DOI resolution (CrossRef, doi.org)
-
     4. Direct URL (from database)
-
     5. OpenAthens proxy (institutional access, if configured)
-
     """
 
- 
-
     def __init__(
-
         self,
-
         unpaywall_email: Optional[str] = None,
-
         openathens_proxy_url: Optional[str] = None,
-
         openathens_auth: Optional[Any] = None,
-
         timeout: int = DEFAULT_TIMEOUT,
-
         prefer_open_access: bool = True,
-
         skip_resolvers: Optional[List[str]] = None
-
     ):
-
         """Initialize FullTextFinder.
 
- 
-
         Args:
-
             unpaywall_email: Email for Unpaywall API (required for Unpaywall)
-
             openathens_proxy_url: Base URL for OpenAthens proxy
-
             openathens_auth: OpenAthensAuth instance for authenticated downloads
-
             timeout: HTTP request timeout in seconds
-
             prefer_open_access: If True, prioritize OA sources over others
-
             skip_resolvers: List of resolver names to skip
-
         """
-
         self.timeout = timeout
-
         self.prefer_open_access = prefer_open_access
-
         self.openathens_auth = openathens_auth
-
         self.skip_resolvers = set(skip_resolvers or [])
 
- 
-
         # Initialize resolvers in priority order
-
         self.resolvers: List[BaseResolver] = []
 
- 
-
         # PMC - highest priority for OA
-
         if 'pmc' not in self.skip_resolvers:
-
             self.resolvers.append(PMCResolver(timeout=timeout))
 
- 
-
         # Unpaywall - excellent OA coverage
-
         if 'unpaywall' not in self.skip_resolvers:
-
             email = unpaywall_email or DEFAULT_UNPAYWALL_EMAIL
-
             self.resolvers.append(UnpaywallResolver(email=email, timeout=timeout))
 
- 
-
         # DOI resolution
-
         if 'doi' not in self.skip_resolvers:
-
             self.resolvers.append(DOIResolver(timeout=timeout))
 
- 
-
         # Direct URL from database
-
         if 'direct_url' not in self.skip_resolvers:
-
             self.resolvers.append(DirectURLResolver(timeout=timeout))
 
- 
-
         # OpenAthens - last resort for paywalled content
-
         if 'openathens' not in self.skip_resolvers and openathens_proxy_url:
-
             self.resolvers.append(OpenAthensResolver(
-
                 proxy_base_url=openathens_proxy_url,
-
                 timeout=timeout
-
             ))
 
- 
-
         # HTTP session for downloads
-
         self.session = requests.Session()
-
         self.session.headers.update({
-
             'User-Agent': (
-
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
-
                 'AppleWebKit/537.36 (KHTML, like Gecko) '
-
                 'Chrome/131.0.0.0 Safari/537.36'
-
             ),
-
             'Accept': 'application/pdf,*/*'
-
         })
 
- 
-
     def discover(
-
         self,
-
         identifiers: DocumentIdentifiers,
-
         stop_on_first_oa: bool = True,
-
         progress_callback: Optional[Callable[[str, str], None]] = None
-
     ) -> DiscoveryResult:
-
         """Discover PDF sources for a document.
 
- 
-
         Args:
-
             identifiers: Document identifiers (DOI, PMID, etc.)
-
             stop_on_first_oa: Stop searching after finding first OA source
-
             progress_callback: Optional callback(resolver_name, status)
 
- 
-
         Returns:
-
             DiscoveryResult with all found sources
-
         """
-
         start_time = time.time()
 
- 
-
         result = DiscoveryResult(
-
             identifiers=identifiers,
-
             sources=[],
-
             resolution_results=[]
-
         )
 
- 
-
         if not identifiers.has_identifiers():
-
             logger.warning("No usable identifiers provided")
-
             result.total_duration_ms = (time.time() - start_time) * 1000
-
             return result
 
- 
-
         # Run each resolver
-
         for resolver in self.resolvers:
-
             if progress_callback:
-
                 progress_callback(resolver.name, "resolving")
 
- 
-
             try:
-
                 resolution = resolver.resolve(identifiers)
-
                 result.resolution_results.append(resolution)
 
- 
-
                 if resolution.status == ResolutionStatus.SUCCESS:
-
                     # Add sources, avoiding duplicates
-
                     for source in resolution.sources:
-
                         if not self._is_duplicate_source(source, result.sources):
-
                             result.sources.append(source)
 
- 
-
                     # Check if we should stop early
-
                     if stop_on_first_oa and self.prefer_open_access:
-
                         oa_sources = [s for s in resolution.sources
-
                                      if s.access_type == AccessType.OPEN]
-
                         if oa_sources:
-
                             logger.info(f"Found OA source via {resolver.name}, stopping search")
-
                             if progress_callback:
-
                                 progress_callback(resolver.name, "found_oa")
-
                             break
 
- 
-
                 if progress_callback:
-
                     status = "found" if resolution.sources else "not_found"
-
                     progress_callback(resolver.name, status)
 
- 
-
             except Exception as e:
-
                 logger.error(f"Resolver {resolver.name} failed: {e}")
-
                 if progress_callback:
-
                     progress_callback(resolver.name, "error")
 
- 
-
         # Sort sources by priority
-
         result.sources.sort(key=lambda s: s.priority)
 
- 
-
         # Select best source
-
         result.best_source = result.select_best_source()
-
         result.total_duration_ms = (time.time() - start_time) * 1000
-
- 
 
         return result
 
- 
-
     def discover_and_download(
-
         self,
-
         identifiers: DocumentIdentifiers,
-
         output_path: Path,
-
         max_attempts: int = 3,
-
         progress_callback: Optional[Callable[[str, str], None]] = None
-
     ) -> DownloadResult:
-
         """Discover PDF sources and download the best one.
 
- 
-
         Args:
-
             identifiers: Document identifiers
-
             output_path: Path to save PDF file
-
             max_attempts: Maximum download attempts per source
-
             progress_callback: Optional callback(stage, status)
 
- 
-
         Returns:
-
             DownloadResult with download status
-
         """
-
         start_time = time.time()
 
- 
-
         # First, discover sources
-
         if progress_callback:
-
             progress_callback("discovery", "starting")
 
- 
-
         discovery = self.discover(
-
             identifiers,
-
             stop_on_first_oa=self.prefer_open_access,
-
             progress_callback=progress_callback
-
         )
 
- 
-
         if not discovery.sources:
-
             return DownloadResult(
-
                 success=False,
-
                 error_message="No PDF sources found",
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
-
- 
 
         # Try downloading from each source in priority order
-
         if progress_callback:
-
             progress_callback("download", "starting")
 
- 
-
         for source in discovery.sources:
-
             result = self._download_from_source(
-
                 source=source,
-
                 output_path=output_path,
-
                 max_attempts=max_attempts
-
             )
 
- 
-
             if result.success:
-
                 result.duration_ms = (time.time() - start_time) * 1000
-
                 if progress_callback:
-
                     progress_callback("download", "success")
-
                 return result
-
- 
 
             logger.debug(f"Download failed from {source.source_type.value}: {result.error_message}")
 
- 
-
         # All sources failed
-
         if progress_callback:
-
             progress_callback("download", "failed")
 
- 
-
         return DownloadResult(
-
             success=False,
-
             error_message=f"All {len(discovery.sources)} sources failed",
-
             duration_ms=(time.time() - start_time) * 1000,
-
             attempts=len(discovery.sources)
-
         )
 
- 
-
     def _download_from_source(
-
         self,
-
         source: PDFSource,
-
         output_path: Path,
-
         max_attempts: int
-
     ) -> DownloadResult:
-
         """Download PDF from a specific source.
 
- 
-
         Args:
-
             source: PDFSource to download from
-
             output_path: Path to save file
-
             max_attempts: Maximum retry attempts
 
- 
-
         Returns:
-
             DownloadResult
-
         """
-
         start_time = time.time()
 
- 
-
         # Prepare headers and cookies
-
         headers = dict(self.session.headers)
-
         cookies = {}
 
- 
-
         # Use OpenAthens auth if available and source is institutional
-
         if (source.source_type == SourceType.OPENATHENS or
-
             source.access_type == AccessType.INSTITUTIONAL):
-
             if self.openathens_auth and self.openathens_auth.is_authenticated():
-
                 # Get user agent from session
-
                 session_ua = self.openathens_auth.get_user_agent()
-
                 if session_ua:
-
                     headers['User-Agent'] = session_ua
 
- 
-
                 # Get cookies
-
                 for cookie in self.openathens_auth.get_cookies():
-
                     cookies[cookie['name']] = cookie['value']
-
- 
 
                 logger.info("Using OpenAthens authenticated session")
 
- 
-
         # Attempt download with retries
-
         last_error = None
-
         for attempt in range(max_attempts):
-
             try:
-
                 if attempt > 0:
-
                     logger.info(f"Retry attempt {attempt + 1}/{max_attempts}")
-
                     time.sleep(2 ** attempt)  # Exponential backoff
 
- 
-
                 response = self.session.get(
-
                     source.url,
-
                     headers=headers,
-
                     cookies=cookies,
-
                     timeout=self.timeout,
-
                     stream=True,
-
                     allow_redirects=True
-
                 )
-
                 response.raise_for_status()
 
- 
-
                 # Verify content type
-
                 content_type = response.headers.get('content-type', '').lower()
-
                 if 'html' in content_type and 'pdf' not in content_type:
-
                     # Got HTML instead of PDF - likely a login page
-
                     last_error = "Received HTML instead of PDF (access denied?)"
-
                     continue
-
- 
 
                 # Create output directory if needed
-
                 output_path.parent.mkdir(parents=True, exist_ok=True)
 
- 
-
                 # Save file
-
                 total_size = 0
-
                 with open(output_path, 'wb') as f:
-
                     for chunk in response.iter_content(chunk_size=8192):
-
                         if chunk:
-
                             f.write(chunk)
-
                             total_size += len(chunk)
 
- 
-
                 # Verify file was written
-
                 if total_size == 0:
-
                     last_error = "Downloaded file is empty"
-
                     if output_path.exists():
-
                         output_path.unlink()
-
                     continue
-
- 
 
                 # Verify it's actually a PDF
-
                 if not self._verify_pdf(output_path):
-
                     last_error = "Downloaded file is not a valid PDF"
-
                     output_path.unlink()
-
                     continue
-
- 
 
                 logger.info(f"Downloaded PDF ({total_size} bytes) from {source.source_type.value}")
 
- 
-
                 return DownloadResult(
-
                     success=True,
-
                     source=source,
-
                     file_path=str(output_path),
-
                     file_size=total_size,
-
                     duration_ms=(time.time() - start_time) * 1000,
-
                     attempts=attempt + 1
-
                 )
 
- 
-
             except requests.exceptions.HTTPError as e:
-
                 if e.response.status_code in [401, 403]:
-
                     last_error = f"Access denied (HTTP {e.response.status_code})"
-
                     break  # Don't retry on auth errors
-
                 elif e.response.status_code == 404:
-
                     last_error = "PDF not found (HTTP 404)"
-
                     break
-
                 else:
-
                     last_error = f"HTTP error: {e}"
 
- 
-
             except requests.exceptions.Timeout:
-
                 last_error = "Download timeout"
 
- 
-
             except requests.exceptions.ConnectionError as e:
-
                 last_error = f"Connection error: {e}"
 
- 
-
             except Exception as e:
-
                 last_error = str(e)
 
- 
-
         return DownloadResult(
-
             success=False,
-
             source=source,
-
             error_message=last_error,
-
             duration_ms=(time.time() - start_time) * 1000,
-
             attempts=max_attempts
-
         )
-
- 
 
     def _verify_pdf(self, file_path: Path) -> bool:
-
         """Verify that a file is a valid PDF.
 
- 
-
         Args:
-
             file_path: Path to file
 
- 
-
         Returns:
-
             True if file appears to be a valid PDF
-
         """
-
         try:
-
             with open(file_path, 'rb') as f:
-
                 header = f.read(8)
-
                 # PDF files start with %PDF-
-
                 return header.startswith(b'%PDF-')
-
         except Exception:
-
             return False
 
- 
-
     def _is_duplicate_source(
-
         self,
-
         source: PDFSource,
-
         existing: List[PDFSource]
-
     ) -> bool:
-
         """Check if source URL already exists in list."""
-
         return any(s.url == source.url for s in existing)
 
- 
-
     @classmethod
-
     def from_config(cls, config: Dict[str, Any]) -> "FullTextFinder":
-
         """Create FullTextFinder from configuration dictionary.
 
- 
-
         Args:
-
             config: Configuration dictionary with keys:
-
                 - unpaywall_email: Email for Unpaywall API
-
                 - openathens.institution_url: OpenAthens proxy URL
-
                 - openathens.enabled: Whether to enable OpenAthens
-
                 - discovery.timeout: Request timeout
-
                 - discovery.prefer_open_access: Prefer OA sources
-
                 - discovery.skip_resolvers: List of resolvers to skip
 
- 
-
         Returns:
-
             Configured FullTextFinder instance
-
         """
-
         discovery_config = config.get('discovery', {})
-
         openathens_config = config.get('openathens', {})
 
- 
-
         openathens_url = None
-
         if openathens_config.get('enabled', False):
-
             openathens_url = openathens_config.get('institution_url')
 
- 
-
         return cls(
-
             unpaywall_email=config.get('unpaywall_email'),
-
             openathens_proxy_url=openathens_url,
-
             timeout=discovery_config.get('timeout', DEFAULT_TIMEOUT),
-
             prefer_open_access=discovery_config.get('prefer_open_access', True),
-
             skip_resolvers=discovery_config.get('skip_resolvers')
-
         )
 
- 
-
- 
 
 def discover_full_text(
-
     doi: Optional[str] = None,
-
     pmid: Optional[str] = None,
-
     pmcid: Optional[str] = None,
-
     title: Optional[str] = None,
-
     pdf_url: Optional[str] = None,
-
     unpaywall_email: Optional[str] = None
-
 ) -> DiscoveryResult:
-
     """Convenience function to discover PDF sources.
 
- 
-
     Args:
-
         doi: Document DOI
-
         pmid: PubMed ID
-
         pmcid: PubMed Central ID
-
         title: Document title
-
         pdf_url: Direct PDF URL
-
         unpaywall_email: Email for Unpaywall API
 
- 
-
     Returns:
-
         DiscoveryResult with found sources
-
     """
-
     identifiers = DocumentIdentifiers(
-
         doi=doi,
-
         pmid=pmid,
-
         pmcid=pmcid,
-
         title=title,
-
         pdf_url=pdf_url
-
     )
 
- 
-
     finder = FullTextFinder(unpaywall_email=unpaywall_email)
-
     return finder.discover(identifiers)

--- a/src/bmlibrarian/discovery/resolvers.py
+++ b/src/bmlibrarian/discovery/resolvers.py
@@ -1,1267 +1,633 @@
 """PDF source resolvers for full-text discovery.
 
- 
-
 Implements various strategies for finding PDF URLs from document identifiers.
-
 """
 
- 
-
 import logging
-
 import re
-
 import time
-
 from abc import ABC, abstractmethod
-
 from typing import Optional, List, Dict, Any
-
 from urllib.parse import urlparse, quote
-
- 
 
 import requests
 
- 
-
 from .data_types import (
-
     PDFSource, ResolutionResult, ResolutionStatus,
-
     SourceType, AccessType, DocumentIdentifiers
-
 )
-
- 
 
 logger = logging.getLogger(__name__)
 
- 
-
 # Default timeout for HTTP requests (seconds)
-
 DEFAULT_TIMEOUT = 30
 
- 
-
 # User agent for requests
-
 USER_AGENT = (
-
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
-
     'AppleWebKit/537.36 (KHTML, like Gecko) '
-
     'Chrome/131.0.0.0 Safari/537.36'
-
 )
 
- 
-
- 
 
 class BaseResolver(ABC):
-
     """Abstract base class for PDF source resolvers."""
 
- 
-
     def __init__(self, timeout: int = DEFAULT_TIMEOUT):
-
         """Initialize resolver.
 
- 
-
         Args:
-
             timeout: HTTP request timeout in seconds
-
         """
-
         self.timeout = timeout
-
         self.session = requests.Session()
-
         self.session.headers.update({
-
             'User-Agent': USER_AGENT,
-
             'Accept': 'application/json, text/html, application/pdf, */*'
-
         })
 
- 
-
     @property
-
     @abstractmethod
-
     def name(self) -> str:
-
         """Resolver name for logging and identification."""
-
         pass
 
- 
-
     @abstractmethod
-
     def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
-
         """Resolve document identifiers to PDF sources.
 
- 
-
         Args:
-
             identifiers: Document identifiers (DOI, PMID, etc.)
 
- 
-
         Returns:
-
             ResolutionResult with found sources
-
         """
-
         pass
 
- 
-
     def _create_result(
-
         self,
-
         status: ResolutionStatus,
-
         sources: Optional[List[PDFSource]] = None,
-
         error_message: Optional[str] = None,
-
         duration_ms: float = 0.0,
-
         metadata: Optional[Dict[str, Any]] = None
-
     ) -> ResolutionResult:
-
         """Helper to create ResolutionResult."""
-
         return ResolutionResult(
-
             resolver_name=self.name,
-
             status=status,
-
             sources=sources or [],
-
             error_message=error_message,
-
             duration_ms=duration_ms,
-
             metadata=metadata or {}
-
         )
 
- 
-
- 
 
 class DirectURLResolver(BaseResolver):
-
     """Resolver that uses existing PDF URL from database."""
 
- 
-
     @property
-
     def name(self) -> str:
-
         return "direct_url"
 
- 
-
     def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
-
         """Check if document has a direct PDF URL."""
-
         start_time = time.time()
-
- 
 
         if not identifiers.pdf_url:
-
             return self._create_result(
-
                 ResolutionStatus.NOT_FOUND,
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
-
- 
 
         # Validate URL format
-
         try:
-
             parsed = urlparse(identifiers.pdf_url)
-
             if not parsed.scheme or not parsed.netloc:
-
                 return self._create_result(
-
                     ResolutionStatus.ERROR,
-
                     error_message=f"Invalid URL format: {identifiers.pdf_url}",
-
                     duration_ms=(time.time() - start_time) * 1000
-
                 )
-
         except Exception as e:
-
             return self._create_result(
-
                 ResolutionStatus.ERROR,
-
                 error_message=str(e),
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
-
- 
 
         # Create source - assume open access if URL exists
-
         source = PDFSource(
-
             url=identifiers.pdf_url,
-
             source_type=SourceType.DIRECT_URL,
-
             access_type=AccessType.UNKNOWN,  # Will be determined during download
-
             priority=10  # Medium priority - prefer verified OA sources
-
         )
-
- 
 
         return self._create_result(
-
             ResolutionStatus.SUCCESS,
-
             sources=[source],
-
             duration_ms=(time.time() - start_time) * 1000
-
         )
 
- 
-
- 
 
 class DOIResolver(BaseResolver):
-
     """Resolver that finds PDFs via DOI resolution."""
 
- 
-
     DOI_API_URL = "https://doi.org"
-
     CROSSREF_API_URL = "https://api.crossref.org/works"
 
- 
-
     @property
-
     def name(self) -> str:
-
         return "doi"
 
- 
-
     def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
-
         """Resolve DOI to find PDF URL."""
-
         start_time = time.time()
-
- 
 
         if not identifiers.doi:
-
             return self._create_result(
-
                 ResolutionStatus.SKIPPED,
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
-
- 
 
         doi = self._normalize_doi(identifiers.doi)
-
         sources = []
-
- 
 
         # Try CrossRef API first (provides structured metadata)
-
         crossref_sources = self._resolve_via_crossref(doi)
-
         sources.extend(crossref_sources)
 
- 
-
         # Try DOI.org content negotiation
-
         doi_sources = self._resolve_via_doi_org(doi)
-
         sources.extend(doi_sources)
 
- 
-
         if not sources:
-
             return self._create_result(
-
                 ResolutionStatus.NOT_FOUND,
-
                 duration_ms=(time.time() - start_time) * 1000,
-
                 metadata={'doi': doi}
-
             )
 
- 
-
         return self._create_result(
-
             ResolutionStatus.SUCCESS,
-
             sources=sources,
-
             duration_ms=(time.time() - start_time) * 1000,
-
             metadata={'doi': doi}
-
         )
-
- 
 
     def _normalize_doi(self, doi: str) -> str:
-
         """Normalize DOI format."""
-
         # Remove common prefixes
-
         doi = doi.strip()
-
         for prefix in ['https://doi.org/', 'http://doi.org/', 'doi:', 'DOI:']:
-
             if doi.lower().startswith(prefix.lower()):
-
                 doi = doi[len(prefix):]
-
         return doi.strip()
 
- 
-
     def _resolve_via_crossref(self, doi: str) -> List[PDFSource]:
-
         """Query CrossRef API for PDF links."""
-
         sources = []
 
- 
-
         try:
-
             url = f"{self.CROSSREF_API_URL}/{quote(doi, safe='')}"
-
             response = self.session.get(url, timeout=self.timeout)
 
- 
-
             if response.status_code == 200:
-
                 data = response.json()
-
                 message = data.get('message', {})
 
- 
-
                 # Check for PDF links
-
                 links = message.get('link', [])
-
                 for link in links:
-
                     content_type = link.get('content-type', '')
-
                     link_url = link.get('URL', '')
 
- 
-
                     if 'pdf' in content_type.lower() and link_url:
-
                         sources.append(PDFSource(
-
                             url=link_url,
-
                             source_type=SourceType.DOI_REDIRECT,
-
                             access_type=AccessType.UNKNOWN,
-
                             priority=20,
-
                             version=link.get('content-version'),
-
                             metadata={'crossref_type': content_type}
-
                         ))
 
- 
-
                 # Check for license (indicates OA)
-
                 licenses = message.get('license', [])
-
                 for lic in licenses:
-
                     lic_url = lic.get('URL', '')
-
                     if 'creativecommons' in lic_url.lower():
-
                         # Mark sources as open access
-
                         for source in sources:
-
                             source.access_type = AccessType.OPEN
-
                             source.license = lic_url
 
- 
-
         except requests.RequestException as e:
-
             logger.debug(f"CrossRef API error for DOI {doi}: {e}")
-
         except Exception as e:
-
             logger.warning(f"Error parsing CrossRef response for DOI {doi}: {e}")
 
- 
-
         return sources
-
- 
 
     def _resolve_via_doi_org(self, doi: str) -> List[PDFSource]:
-
         """Resolve DOI via doi.org to find landing page/PDF."""
-
         sources = []
 
- 
-
         try:
-
             # Request with content negotiation for application/pdf
-
             headers = {'Accept': 'application/pdf'}
-
             url = f"{self.DOI_API_URL}/{quote(doi, safe='')}"
 
- 
-
             response = self.session.head(
-
                 url,
-
                 headers=headers,
-
                 timeout=self.timeout,
-
                 allow_redirects=True
-
             )
-
- 
 
             # Check if we got redirected to a PDF
-
             final_url = response.url
-
             content_type = response.headers.get('content-type', '').lower()
 
- 
-
             if 'pdf' in content_type or final_url.endswith('.pdf'):
-
                 sources.append(PDFSource(
-
                     url=final_url,
-
                     source_type=SourceType.DOI_REDIRECT,
-
                     access_type=AccessType.UNKNOWN,
-
                     priority=15,
-
                     metadata={'resolved_from': 'doi.org'}
-
                 ))
 
- 
-
         except requests.RequestException as e:
-
             logger.debug(f"DOI.org resolution error for {doi}: {e}")
 
- 
-
         return sources
 
- 
-
- 
 
 class PMCResolver(BaseResolver):
-
     """Resolver for PubMed Central open access PDFs."""
 
- 
-
     PMC_API_URL = "https://www.ncbi.nlm.nih.gov/pmc/utils/oa/oa.fcgi"
-
     PMC_PDF_BASE = "https://www.ncbi.nlm.nih.gov/pmc/articles"
-
     EUTILS_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
- 
-
     @property
-
     def name(self) -> str:
-
         return "pmc"
 
- 
-
     def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
-
         """Resolve via PubMed Central."""
-
         start_time = time.time()
 
- 
-
         # Try PMCID first, then PMID, then DOI
-
         pmcid = identifiers.pmcid
-
         pmid = identifiers.pmid
-
         doi = identifiers.doi
 
- 
-
         sources = []
-
- 
 
         # If we have PMCID, use it directly
-
         if pmcid:
-
             sources.extend(self._resolve_by_pmcid(pmcid))
 
- 
-
         # If we have PMID but no PMCID, try to find PMCID
-
         if not pmcid and pmid:
-
             pmcid = self._pmid_to_pmcid(pmid)
-
             if pmcid:
-
                 sources.extend(self._resolve_by_pmcid(pmcid))
-
- 
 
         # Try DOI lookup in PMC
-
         if not sources and doi:
-
             pmcid = self._doi_to_pmcid(doi)
-
             if pmcid:
-
                 sources.extend(self._resolve_by_pmcid(pmcid))
 
- 
-
         if not sources:
-
             return self._create_result(
-
                 ResolutionStatus.NOT_FOUND,
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
-
- 
 
         return self._create_result(
-
             ResolutionStatus.SUCCESS,
-
             sources=sources,
-
             duration_ms=(time.time() - start_time) * 1000,
-
             metadata={'pmcid': pmcid}
-
         )
 
- 
-
     def _normalize_pmcid(self, pmcid: str) -> str:
-
         """Normalize PMCID format."""
-
         pmcid = pmcid.strip().upper()
-
         if not pmcid.startswith('PMC'):
-
             pmcid = f'PMC{pmcid}'
-
         return pmcid
 
- 
-
     def _resolve_by_pmcid(self, pmcid: str) -> List[PDFSource]:
-
         """Get PDF URL for a PMCID."""
-
         pmcid = self._normalize_pmcid(pmcid)
-
         sources = []
 
- 
-
         # Try OA web service first
-
         try:
-
             params = {'id': pmcid}
-
             response = self.session.get(
-
                 self.PMC_API_URL,
-
                 params=params,
-
                 timeout=self.timeout
-
             )
 
- 
-
             if response.status_code == 200:
-
                 # Parse XML response
-
                 import xml.etree.ElementTree as ET
-
                 root = ET.fromstring(response.content)
 
- 
-
                 for record in root.findall('.//record'):
-
                     # Check for PDF link
-
                     for link in record.findall('.//link'):
-
                         if link.get('format') == 'pdf':
-
                             pdf_url = link.get('href')
-
                             if pdf_url:
-
                                 sources.append(PDFSource(
-
                                     url=pdf_url,
-
                                     source_type=SourceType.PMC,
-
                                     access_type=AccessType.OPEN,
-
                                     priority=5,  # High priority - verified OA
-
                                     is_best_oa=True,
-
                                     host_type='repository',
-
                                     metadata={'pmcid': pmcid}
-
                                 ))
 
- 
-
         except Exception as e:
-
             logger.debug(f"PMC OA service error for {pmcid}: {e}")
 
- 
-
         # Fallback: construct direct PDF URL
-
         if not sources:
-
             pdf_url = f"{self.PMC_PDF_BASE}/{pmcid}/pdf/"
-
             sources.append(PDFSource(
-
                 url=pdf_url,
-
                 source_type=SourceType.PMC,
-
                 access_type=AccessType.OPEN,
-
                 priority=6,
-
                 host_type='repository',
-
                 metadata={'pmcid': pmcid, 'constructed': True}
-
             ))
-
- 
 
         return sources
 
- 
-
     def _pmid_to_pmcid(self, pmid: str) -> Optional[str]:
-
         """Convert PMID to PMCID using ID converter."""
-
         try:
-
             url = f"{self.EUTILS_BASE}/elink.fcgi"
-
             params = {
-
                 'dbfrom': 'pubmed',
-
                 'db': 'pmc',
-
                 'id': pmid,
-
                 'retmode': 'json'
-
             }
 
- 
-
             response = self.session.get(url, params=params, timeout=self.timeout)
-
             if response.status_code == 200:
-
                 data = response.json()
-
                 linksets = data.get('linksets', [])
-
                 for linkset in linksets:
-
                     for linksetdb in linkset.get('linksetdbs', []):
-
                         if linksetdb.get('dbto') == 'pmc':
-
                             links = linksetdb.get('links', [])
-
                             if links:
-
                                 return f"PMC{links[0]}"
 
- 
-
         except Exception as e:
-
             logger.debug(f"PMID to PMCID conversion error: {e}")
 
- 
-
         return None
-
- 
 
     def _doi_to_pmcid(self, doi: str) -> Optional[str]:
-
         """Find PMCID for a DOI via PubMed search."""
-
         try:
-
             # Search PubMed for the DOI
-
             url = f"{self.EUTILS_BASE}/esearch.fcgi"
-
             params = {
-
                 'db': 'pubmed',
-
                 'term': f'{doi}[doi]',
-
                 'retmode': 'json'
-
             }
 
- 
-
             response = self.session.get(url, params=params, timeout=self.timeout)
-
             if response.status_code == 200:
-
                 data = response.json()
-
                 id_list = data.get('esearchresult', {}).get('idlist', [])
-
                 if id_list:
-
                     pmid = id_list[0]
-
                     return self._pmid_to_pmcid(pmid)
 
- 
-
         except Exception as e:
-
             logger.debug(f"DOI to PMCID conversion error: {e}")
-
- 
 
         return None
 
- 
-
- 
 
 class UnpaywallResolver(BaseResolver):
-
     """Resolver using Unpaywall API for open access versions."""
-
- 
 
     API_URL = "https://api.unpaywall.org/v2"
 
- 
-
     def __init__(self, email: str, timeout: int = DEFAULT_TIMEOUT):
-
         """Initialize Unpaywall resolver.
 
- 
-
         Args:
-
             email: Email address for Unpaywall API (required)
-
             timeout: HTTP request timeout
-
         """
-
         super().__init__(timeout)
-
         self.email = email
 
- 
-
     @property
-
     def name(self) -> str:
-
         return "unpaywall"
 
- 
-
     def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
-
         """Query Unpaywall for open access PDF."""
-
         start_time = time.time()
 
- 
-
         if not identifiers.doi:
-
             return self._create_result(
-
                 ResolutionStatus.SKIPPED,
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
 
- 
-
         doi = identifiers.doi.strip()
-
         # Remove common prefixes
-
         for prefix in ['https://doi.org/', 'http://doi.org/', 'doi:']:
-
             if doi.lower().startswith(prefix.lower()):
-
                 doi = doi[len(prefix):]
 
- 
-
         try:
-
             url = f"{self.API_URL}/{quote(doi, safe='')}"
-
             params = {'email': self.email}
-
- 
 
             response = self.session.get(url, params=params, timeout=self.timeout)
 
- 
-
             if response.status_code == 404:
-
                 return self._create_result(
-
                     ResolutionStatus.NOT_FOUND,
-
                     duration_ms=(time.time() - start_time) * 1000
-
                 )
-
- 
 
             if response.status_code != 200:
-
                 return self._create_result(
-
                     ResolutionStatus.ERROR,
-
                     error_message=f"API error: {response.status_code}",
-
                     duration_ms=(time.time() - start_time) * 1000
-
                 )
-
- 
 
             data = response.json()
-
             sources = self._parse_unpaywall_response(data)
 
- 
-
             if not sources:
-
                 return self._create_result(
-
                     ResolutionStatus.NOT_FOUND,
-
                     duration_ms=(time.time() - start_time) * 1000,
-
                     metadata={'is_oa': data.get('is_oa', False)}
-
                 )
 
- 
-
             return self._create_result(
-
                 ResolutionStatus.SUCCESS,
-
                 sources=sources,
-
                 duration_ms=(time.time() - start_time) * 1000,
-
                 metadata={
-
                     'is_oa': data.get('is_oa', False),
-
                     'oa_status': data.get('oa_status')
-
                 }
-
             )
-
- 
 
         except requests.RequestException as e:
-
             return self._create_result(
-
                 ResolutionStatus.ERROR,
-
                 error_message=str(e),
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
 
- 
-
     def _parse_unpaywall_response(self, data: Dict[str, Any]) -> List[PDFSource]:
-
         """Parse Unpaywall API response into PDFSource objects."""
-
         sources = []
 
- 
-
         # Check best OA location first
-
         best_oa = data.get('best_oa_location')
-
         if best_oa and best_oa.get('url_for_pdf'):
-
             sources.append(self._location_to_source(best_oa, is_best=True, priority=1))
 
- 
-
         # Add other OA locations
-
         oa_locations = data.get('oa_locations', [])
-
         for i, location in enumerate(oa_locations):
-
             if location.get('url_for_pdf'):
-
                 # Skip if same as best_oa
-
                 if best_oa and location.get('url_for_pdf') == best_oa.get('url_for_pdf'):
-
                     continue
-
                 sources.append(self._location_to_source(location, is_best=False, priority=2 + i))
-
- 
 
         return sources
 
- 
-
     def _location_to_source(
-
         self,
-
         location: Dict[str, Any],
-
         is_best: bool,
-
         priority: int
-
     ) -> PDFSource:
-
         """Convert Unpaywall location to PDFSource."""
-
         return PDFSource(
-
             url=location['url_for_pdf'],
-
             source_type=SourceType.UNPAYWALL,
-
             access_type=AccessType.OPEN,
-
             priority=priority,
-
             license=location.get('license'),
-
             version=location.get('version'),
-
             is_best_oa=is_best,
-
             host_type=location.get('host_type'),
-
             metadata={
-
                 'evidence': location.get('evidence'),
-
                 'pmh_id': location.get('pmh_id'),
-
                 'repository_institution': location.get('repository_institution')
-
             }
-
         )
 
- 
-
- 
 
 class OpenAthensResolver(BaseResolver):
-
     """Resolver that constructs OpenAthens proxy URLs for institutional access."""
 
- 
-
     def __init__(
-
         self,
-
         proxy_base_url: str,
-
         timeout: int = DEFAULT_TIMEOUT
-
     ):
-
         """Initialize OpenAthens resolver.
 
- 
-
         Args:
-
             proxy_base_url: Base URL for OpenAthens proxy (e.g., "https://proxy.openathens.net")
-
             timeout: HTTP request timeout
-
         """
-
         super().__init__(timeout)
-
         self.proxy_base_url = proxy_base_url.rstrip('/')
 
- 
-
     @property
-
     def name(self) -> str:
-
         return "openathens"
 
- 
-
     def resolve(self, identifiers: DocumentIdentifiers) -> ResolutionResult:
-
         """Generate OpenAthens proxy URL for document."""
-
         start_time = time.time()
 
- 
-
         # Need either DOI or direct PDF URL
-
         target_url = None
 
- 
-
         if identifiers.pdf_url:
-
             target_url = identifiers.pdf_url
-
         elif identifiers.doi:
-
             # Construct DOI URL
-
             doi = identifiers.doi.strip()
-
             for prefix in ['https://doi.org/', 'http://doi.org/', 'doi:']:
-
                 if doi.lower().startswith(prefix.lower()):
-
                     doi = doi[len(prefix):]
-
             target_url = f"https://doi.org/{doi}"
 
- 
-
         if not target_url:
-
             return self._create_result(
-
                 ResolutionStatus.SKIPPED,
-
                 duration_ms=(time.time() - start_time) * 1000
-
             )
 
- 
-
         # Construct proxy URL
-
         proxy_url = self._construct_proxy_url(target_url)
 
- 
-
         source = PDFSource(
-
             url=proxy_url,
-
             source_type=SourceType.OPENATHENS,
-
             access_type=AccessType.INSTITUTIONAL,
-
             priority=50,  # Lower priority than OA sources
-
             metadata={
-
                 'original_url': target_url,
-
                 'proxy_base': self.proxy_base_url
-
             }
-
         )
-
- 
 
         return self._create_result(
-
             ResolutionStatus.SUCCESS,
-
             sources=[source],
-
             duration_ms=(time.time() - start_time) * 1000
-
         )
 
- 
-
     def _construct_proxy_url(self, target_url: str) -> str:
-
         """Construct OpenAthens proxy URL.
 
- 
-
         Args:
-
             target_url: Original URL to proxy
 
- 
-
         Returns:
-
             Proxied URL
-
         """
-
         # Standard OpenAthens proxy format
-
         # Some institutions use: proxy.example.com/login?url=<target>
-
         # Others use: <target-domain>.proxy.example.com
-
         # We'll use the login redirect format which is more universal
-
         encoded_url = quote(target_url, safe='')
-
         return f"{self.proxy_base_url}/login?url={encoded_url}"
-
- 

--- a/tests/discovery/__init__.py
+++ b/tests/discovery/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for full-text discovery module."""

--- a/tests/discovery/test_data_types.py
+++ b/tests/discovery/test_data_types.py
@@ -1,547 +1,274 @@
 """Tests for discovery data types."""
 
- 
-
 import pytest
-
 from datetime import datetime
 
- 
-
 from bmlibrarian.discovery.data_types import (
-
     SourceType, AccessType, ResolutionStatus,
-
     PDFSource, ResolutionResult, DocumentIdentifiers,
-
     DiscoveryResult, DownloadResult
-
 )
 
- 
-
- 
 
 class TestDocumentIdentifiers:
-
     """Tests for DocumentIdentifiers dataclass."""
 
- 
-
     def test_has_identifiers_with_doi(self):
-
         """Test has_identifiers returns True when DOI is present."""
-
         ids = DocumentIdentifiers(doi="10.1234/test")
-
         assert ids.has_identifiers() is True
-
- 
 
     def test_has_identifiers_with_pmid(self):
-
         """Test has_identifiers returns True when PMID is present."""
-
         ids = DocumentIdentifiers(pmid="12345678")
-
         assert ids.has_identifiers() is True
-
- 
 
     def test_has_identifiers_with_pmcid(self):
-
         """Test has_identifiers returns True when PMCID is present."""
-
         ids = DocumentIdentifiers(pmcid="PMC1234567")
-
         assert ids.has_identifiers() is True
-
- 
 
     def test_has_identifiers_with_title(self):
-
         """Test has_identifiers returns True when title is present."""
-
         ids = DocumentIdentifiers(title="Test Paper")
-
         assert ids.has_identifiers() is True
 
- 
-
     def test_has_identifiers_empty(self):
-
         """Test has_identifiers returns False when no identifiers."""
-
         ids = DocumentIdentifiers()
-
         assert ids.has_identifiers() is False
-
- 
 
     def test_has_identifiers_only_pdf_url(self):
-
         """Test has_identifiers returns False with only pdf_url."""
-
         ids = DocumentIdentifiers(pdf_url="https://example.com/paper.pdf")
-
         assert ids.has_identifiers() is False
 
- 
-
     def test_from_dict(self):
-
         """Test creating identifiers from dictionary."""
-
         data = {
-
             'id': 123,
-
             'doi': '10.1234/test',
-
             'pmid': '12345678',
-
             'title': 'Test Paper',
-
             'pdf_url': 'https://example.com/paper.pdf'
-
         }
-
         ids = DocumentIdentifiers.from_dict(data)
-
- 
 
         assert ids.doc_id == 123
-
         assert ids.doi == '10.1234/test'
-
         assert ids.pmid == '12345678'
-
         assert ids.title == 'Test Paper'
-
         assert ids.pdf_url == 'https://example.com/paper.pdf'
 
- 
-
     def test_from_dict_with_pubmed_id(self):
-
         """Test creating identifiers with pubmed_id alias."""
-
         data = {'pubmed_id': '12345678'}
-
         ids = DocumentIdentifiers.from_dict(data)
-
         assert ids.pmid == '12345678'
 
- 
-
- 
 
 class TestPDFSource:
-
     """Tests for PDFSource dataclass."""
 
- 
-
     def test_create_source(self):
-
         """Test creating a PDF source."""
-
         source = PDFSource(
-
             url="https://example.com/paper.pdf",
-
             source_type=SourceType.PMC,
-
             access_type=AccessType.OPEN,
-
             priority=5
-
         )
-
- 
 
         assert source.url == "https://example.com/paper.pdf"
-
         assert source.source_type == SourceType.PMC
-
         assert source.access_type == AccessType.OPEN
-
         assert source.priority == 5
 
- 
-
     def test_source_ordering(self):
-
         """Test that sources can be sorted by priority."""
-
         source1 = PDFSource(
-
             url="https://example.com/1.pdf",
-
             source_type=SourceType.PMC,
-
             access_type=AccessType.OPEN,
-
             priority=5
-
         )
-
         source2 = PDFSource(
-
             url="https://example.com/2.pdf",
-
             source_type=SourceType.DOI_REDIRECT,
-
             access_type=AccessType.UNKNOWN,
-
             priority=20
-
         )
-
         source3 = PDFSource(
-
             url="https://example.com/3.pdf",
-
             source_type=SourceType.UNPAYWALL,
-
             access_type=AccessType.OPEN,
-
             priority=1
-
         )
-
- 
 
         sorted_sources = sorted([source1, source2, source3])
 
- 
-
         assert sorted_sources[0].priority == 1
-
         assert sorted_sources[1].priority == 5
-
         assert sorted_sources[2].priority == 20
 
- 
-
- 
 
 class TestDiscoveryResult:
-
     """Tests for DiscoveryResult dataclass."""
 
- 
-
     def test_has_open_access_true(self):
-
         """Test has_open_access returns True when OA source exists."""
-
         result = DiscoveryResult(
-
             identifiers=DocumentIdentifiers(doi="10.1234/test"),
-
             sources=[
-
                 PDFSource(
-
                     url="https://pmc.ncbi.nlm.nih.gov/articles/PMC123/pdf/",
-
                     source_type=SourceType.PMC,
-
                     access_type=AccessType.OPEN,
-
                     priority=5
-
                 )
-
             ]
-
         )
-
- 
 
         assert result.has_open_access() is True
 
- 
-
     def test_has_open_access_false(self):
-
         """Test has_open_access returns False when no OA source."""
-
         result = DiscoveryResult(
-
             identifiers=DocumentIdentifiers(doi="10.1234/test"),
-
             sources=[
-
                 PDFSource(
-
                     url="https://example.com/paper.pdf",
-
                     source_type=SourceType.DIRECT_URL,
-
                     access_type=AccessType.SUBSCRIPTION,
-
                     priority=10
-
                 )
-
             ]
-
         )
-
- 
 
         assert result.has_open_access() is False
 
- 
-
     def test_get_open_access_sources(self):
-
         """Test filtering to only OA sources."""
-
         result = DiscoveryResult(
-
             identifiers=DocumentIdentifiers(doi="10.1234/test"),
-
             sources=[
-
                 PDFSource(
-
                     url="https://pmc.ncbi.nlm.nih.gov/pdf",
-
                     source_type=SourceType.PMC,
-
                     access_type=AccessType.OPEN,
-
                     priority=5
-
                 ),
-
                 PDFSource(
-
                     url="https://publisher.com/pdf",
-
                     source_type=SourceType.DOI_REDIRECT,
-
                     access_type=AccessType.SUBSCRIPTION,
-
                     priority=20
-
                 ),
-
                 PDFSource(
-
                     url="https://unpaywall.org/pdf",
-
                     source_type=SourceType.UNPAYWALL,
-
                     access_type=AccessType.OPEN,
-
                     priority=1
-
                 )
-
             ]
-
         )
-
- 
 
         oa_sources = result.get_open_access_sources()
 
- 
-
         assert len(oa_sources) == 2
-
         assert all(s.access_type == AccessType.OPEN for s in oa_sources)
 
- 
-
     def test_select_best_source_prefers_open_access(self):
-
         """Test that select_best_source prefers OA over other types."""
-
         result = DiscoveryResult(
-
             identifiers=DocumentIdentifiers(doi="10.1234/test"),
-
             sources=[
-
                 PDFSource(
-
                     url="https://pmc.ncbi.nlm.nih.gov/pdf",
-
                     source_type=SourceType.PMC,
-
                     access_type=AccessType.OPEN,
-
                     priority=5
-
                 ),
-
                 PDFSource(
-
                     url="https://proxy.example.com/pdf",
-
                     source_type=SourceType.OPENATHENS,
-
                     access_type=AccessType.INSTITUTIONAL,
-
                     priority=1  # Lower priority number = higher priority
-
                 )
-
             ]
-
         )
-
- 
 
         best = result.select_best_source()
 
- 
-
         # Even though institutional has lower priority number,
-
         # OA should be preferred
-
         assert best.access_type == AccessType.OPEN
 
- 
-
     def test_select_best_source_empty(self):
-
         """Test select_best_source returns None when no sources."""
-
         result = DiscoveryResult(
-
             identifiers=DocumentIdentifiers(doi="10.1234/test"),
-
             sources=[]
-
         )
-
- 
 
         assert result.select_best_source() is None
 
- 
-
- 
 
 class TestResolutionResult:
-
     """Tests for ResolutionResult dataclass."""
 
- 
-
     def test_create_result(self):
-
         """Test creating a resolution result."""
-
         result = ResolutionResult(
-
             resolver_name="pmc",
-
             status=ResolutionStatus.SUCCESS,
-
             sources=[
-
                 PDFSource(
-
                     url="https://pmc.ncbi.nlm.nih.gov/pdf",
-
                     source_type=SourceType.PMC,
-
                     access_type=AccessType.OPEN,
-
                     priority=5
-
                 )
-
             ],
-
             duration_ms=150.5
-
         )
-
- 
 
         assert result.resolver_name == "pmc"
-
         assert result.status == ResolutionStatus.SUCCESS
-
         assert len(result.sources) == 1
-
         assert result.duration_ms == 150.5
 
- 
-
- 
 
 class TestDownloadResult:
-
     """Tests for DownloadResult dataclass."""
 
- 
-
     def test_success_result(self):
-
         """Test creating a successful download result."""
-
         source = PDFSource(
-
             url="https://pmc.ncbi.nlm.nih.gov/pdf",
-
             source_type=SourceType.PMC,
-
             access_type=AccessType.OPEN,
-
             priority=5
-
         )
-
- 
 
         result = DownloadResult(
-
             success=True,
-
             source=source,
-
             file_path="/tmp/paper.pdf",
-
             file_size=1024000
-
         )
-
- 
 
         assert result.success is True
-
         assert result.file_size == 1024000
-
         assert result.error_message is None
 
- 
-
     def test_failure_result(self):
-
         """Test creating a failed download result."""
-
         result = DownloadResult(
-
             success=False,
-
             error_message="Access denied"
-
         )
 
- 
-
         assert result.success is False
-
         assert result.error_message == "Access denied"
-
         assert result.file_path is None

--- a/tests/discovery/test_resolvers.py
+++ b/tests/discovery/test_resolvers.py
@@ -1,391 +1,196 @@
 """Tests for discovery resolvers."""
 
- 
-
 import pytest
-
 from unittest.mock import Mock, patch, MagicMock
 
- 
-
 from bmlibrarian.discovery.data_types import (
-
     DocumentIdentifiers, ResolutionStatus, SourceType, AccessType
-
 )
-
 from bmlibrarian.discovery.resolvers import (
-
     DirectURLResolver, DOIResolver, PMCResolver,
-
     UnpaywallResolver, OpenAthensResolver
-
 )
 
- 
-
- 
 
 class TestDirectURLResolver:
-
     """Tests for DirectURLResolver."""
 
- 
-
     def test_resolve_with_url(self):
-
         """Test resolving when pdf_url is present."""
-
         resolver = DirectURLResolver()
-
         identifiers = DocumentIdentifiers(
-
             pdf_url="https://example.com/paper.pdf"
-
         )
 
- 
-
         result = resolver.resolve(identifiers)
 
- 
-
         assert result.status == ResolutionStatus.SUCCESS
-
         assert len(result.sources) == 1
-
         assert result.sources[0].url == "https://example.com/paper.pdf"
-
         assert result.sources[0].source_type == SourceType.DIRECT_URL
 
- 
-
     def test_resolve_without_url(self):
-
         """Test resolving when pdf_url is missing."""
-
         resolver = DirectURLResolver()
-
         identifiers = DocumentIdentifiers(doi="10.1234/test")
-
- 
 
         result = resolver.resolve(identifiers)
 
- 
-
         assert result.status == ResolutionStatus.NOT_FOUND
-
         assert len(result.sources) == 0
 
- 
-
     def test_resolve_invalid_url(self):
-
         """Test resolving with invalid URL format."""
-
         resolver = DirectURLResolver()
-
         identifiers = DocumentIdentifiers(pdf_url="not-a-valid-url")
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.ERROR
-
         assert "Invalid URL" in result.error_message
 
- 
-
- 
 
 class TestDOIResolver:
-
     """Tests for DOIResolver."""
 
- 
-
     def test_normalize_doi(self):
-
         """Test DOI normalization."""
-
         resolver = DOIResolver()
-
- 
 
         assert resolver._normalize_doi("10.1234/test") == "10.1234/test"
-
         assert resolver._normalize_doi("https://doi.org/10.1234/test") == "10.1234/test"
-
         assert resolver._normalize_doi("doi:10.1234/test") == "10.1234/test"
-
         assert resolver._normalize_doi("  10.1234/test  ") == "10.1234/test"
 
- 
-
     def test_resolve_without_doi(self):
-
         """Test resolving when DOI is missing."""
-
         resolver = DOIResolver()
-
         identifiers = DocumentIdentifiers(pmid="12345678")
-
- 
 
         result = resolver.resolve(identifiers)
 
- 
-
         assert result.status == ResolutionStatus.SKIPPED
 
- 
-
- 
 
 class TestPMCResolver:
-
     """Tests for PMCResolver."""
 
- 
-
     def test_normalize_pmcid(self):
-
         """Test PMCID normalization."""
-
         resolver = PMCResolver()
-
- 
 
         assert resolver._normalize_pmcid("PMC1234567") == "PMC1234567"
-
         assert resolver._normalize_pmcid("pmc1234567") == "PMC1234567"
-
         assert resolver._normalize_pmcid("1234567") == "PMC1234567"
 
- 
-
     def test_resolve_without_identifiers(self):
-
         """Test resolving when no PMC-related identifiers."""
-
         resolver = PMCResolver()
-
         identifiers = DocumentIdentifiers(title="Some Paper")
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.NOT_FOUND
 
- 
-
- 
 
 class TestUnpaywallResolver:
-
     """Tests for UnpaywallResolver."""
 
- 
-
     def test_resolve_without_doi(self):
-
         """Test resolving when DOI is missing."""
-
         resolver = UnpaywallResolver(email="test@example.com")
-
         identifiers = DocumentIdentifiers(pmid="12345678")
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.SKIPPED
 
- 
-
     @patch('bmlibrarian.discovery.resolvers.requests.Session.get')
-
     def test_resolve_with_oa_result(self, mock_get):
-
         """Test resolving when Unpaywall returns OA location."""
-
         mock_response = Mock()
-
         mock_response.status_code = 200
-
         mock_response.json.return_value = {
-
             'is_oa': True,
-
             'oa_status': 'gold',
-
             'best_oa_location': {
-
                 'url_for_pdf': 'https://example.com/oa.pdf',
-
                 'license': 'cc-by',
-
                 'version': 'publishedVersion',
-
                 'host_type': 'publisher'
-
             },
-
             'oa_locations': []
-
         }
-
         mock_get.return_value = mock_response
 
- 
-
         resolver = UnpaywallResolver(email="test@example.com")
-
         identifiers = DocumentIdentifiers(doi="10.1234/test")
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.SUCCESS
-
         assert len(result.sources) == 1
-
         assert result.sources[0].url == "https://example.com/oa.pdf"
-
         assert result.sources[0].access_type == AccessType.OPEN
-
         assert result.sources[0].is_best_oa is True
 
- 
-
     @patch('bmlibrarian.discovery.resolvers.requests.Session.get')
-
     def test_resolve_not_found(self, mock_get):
-
         """Test resolving when article not in Unpaywall."""
-
         mock_response = Mock()
-
         mock_response.status_code = 404
-
         mock_get.return_value = mock_response
 
- 
-
         resolver = UnpaywallResolver(email="test@example.com")
-
         identifiers = DocumentIdentifiers(doi="10.1234/test")
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.NOT_FOUND
 
- 
-
- 
 
 class TestOpenAthensResolver:
-
     """Tests for OpenAthensResolver."""
 
- 
-
     def test_construct_proxy_url(self):
-
         """Test OpenAthens proxy URL construction."""
-
         resolver = OpenAthensResolver(proxy_base_url="https://proxy.example.com")
-
- 
 
         proxy_url = resolver._construct_proxy_url("https://publisher.com/paper.pdf")
 
- 
-
         assert proxy_url.startswith("https://proxy.example.com/login?url=")
-
         assert "publisher.com" in proxy_url
 
- 
-
     def test_resolve_with_doi(self):
-
         """Test resolving with DOI constructs proxy URL."""
-
         resolver = OpenAthensResolver(proxy_base_url="https://proxy.example.com")
-
         identifiers = DocumentIdentifiers(doi="10.1234/test")
 
- 
-
         result = resolver.resolve(identifiers)
 
- 
-
         assert result.status == ResolutionStatus.SUCCESS
-
         assert len(result.sources) == 1
-
         assert result.sources[0].source_type == SourceType.OPENATHENS
-
         assert result.sources[0].access_type == AccessType.INSTITUTIONAL
-
         assert "doi.org" in result.sources[0].url
 
- 
-
     def test_resolve_with_pdf_url(self):
-
         """Test resolving with existing PDF URL uses that URL."""
-
         resolver = OpenAthensResolver(proxy_base_url="https://proxy.example.com")
-
         identifiers = DocumentIdentifiers(
-
             pdf_url="https://publisher.com/paper.pdf"
-
         )
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.SUCCESS
-
         assert "publisher.com" in result.sources[0].metadata['original_url']
 
- 
-
     def test_resolve_without_identifiers(self):
-
         """Test resolving without usable identifiers."""
-
         resolver = OpenAthensResolver(proxy_base_url="https://proxy.example.com")
-
         identifiers = DocumentIdentifiers(title="Some Paper")
 
- 
-
         result = resolver.resolve(identifiers)
-
- 
 
         assert result.status == ResolutionStatus.SKIPPED


### PR DESCRIPTION
## Full-Text PDF Discovery System - Cleanup and Documentation

### Summary
- Clean up code formatting in discovery module (remove double-spacing artifacts)
- Relocate test files to proper `tests/` directory structure
- Add comprehensive user and developer documentation
- Update CLAUDE.md with discovery module information

### Changes

#### Code Cleanup
- Fixed double-spaced formatting in all discovery module files (`__init__.py`, `data_types.py`, `resolvers.py`, `full_text_finder.py`)
- Removed ~900 extraneous blank lines while preserving code structure

#### Test Relocation
- Moved `test_data_types.py` from `src/bmlibrarian/discovery/` to `tests/discovery/`
- Moved `test_resolvers.py` from `src/bmlibrarian/discovery/` to `tests/discovery/`
- Added `tests/discovery/__init__.py`

#### Documentation
- **User Guide** (`doc/users/full_text_discovery_guide.md`): Complete usage guide covering quick start, configuration, source types, batch processing, and troubleshooting
- **Developer Docs** (`doc/developers/full_text_discovery_system.md`): Architecture overview, resolver implementation pattern, data types, and integration examples
- **CLAUDE.md**: Added discovery module to project structure and new "Full-Text PDF Discovery" section

### Discovery Module Overview
The discovery system finds PDF full-text through legal channels, prioritizing open access:

1. **PubMed Central** - Verified OA repository (highest priority)
2. **Unpaywall** - OA aggregator via API
3. **DOI Resolution** - CrossRef and doi.org content negotiation
4. **Direct URL** - Existing URLs from database
5. **OpenAthens** - Institutional proxy (lowest priority)

### Test Plan
- [x] Verify module imports work correctly
- [x] Verify test files are in correct location (`tests/discovery/`)
- [ ] Run full test suite: `uv run pytest tests/discovery/ -v`
- [ ] Manual test with real DOI/PMID lookups