### PR TITLE
Add high-level document question answering function and DocumentInterrogationAgent

### DIFF
--- a/doc/developers/document_qa_system.md
+++ b/doc/developers/document_qa_system.md
@@ -1,0 +1,423 @@
+# Document Q&A System Architecture
+
+This document describes the technical architecture of BMLibrarian's document question-answering system.
+
+## Overview
+
+The Document Q&A system provides a high-level function `answer_from_document()` that orchestrates multiple subsystems to answer questions about specific documents in the knowledge base.
+
+## Module Structure
+
+```
+src/bmlibrarian/qa/
+├── __init__.py          # Module exports
+├── data_types.py        # Type definitions (AnswerSource, QAError, etc.)
+└── document_qa.py       # Main implementation
+```
+
+## Data Types
+
+### AnswerSource Enum
+
+Indicates the source of context used for generating answers:
+
+```python
+class AnswerSource(Enum):
+    FULLTEXT_SEMANTIC = "fulltext_semantic"  # Semantic search on full-text chunks
+    ABSTRACT = "abstract"                     # Used document abstract as context
+```
+
+### QAError Enum
+
+Structured error codes with descriptions:
+
+```python
+class QAError(Enum):
+    DOCUMENT_NOT_FOUND = "document_not_found"
+    NO_TEXT_AVAILABLE = "no_text_available"
+    NO_FULLTEXT = "no_fulltext"
+    DOWNLOAD_FAILED = "download_failed"
+    EMBEDDING_FAILED = "embedding_failed"
+    SEMANTIC_SEARCH_FAILED = "semantic_search_failed"
+    LLM_ERROR = "llm_error"
+    DATABASE_ERROR = "database_error"
+    CONFIGURATION_ERROR = "configuration_error"
+
+    @property
+    def description(self) -> str:
+        """Get human-readable description."""
+        ...
+```
+
+### ChunkContext
+
+Represents a chunk of text used as context:
+
+```python
+@dataclass
+class ChunkContext:
+    chunk_no: int
+    text: str
+    score: float
+    chunk_id: Optional[int] = None
+```
+
+### DocumentTextStatus
+
+Status of text availability for a document:
+
+```python
+@dataclass
+class DocumentTextStatus:
+    document_id: int
+    has_abstract: bool = False
+    has_fulltext: bool = False
+    has_abstract_embeddings: bool = False
+    has_fulltext_chunks: bool = False
+    abstract_length: int = 0
+    fulltext_length: int = 0
+    title: Optional[str] = None
+
+    @property
+    def can_use_fulltext_semantic(self) -> bool: ...
+    @property
+    def can_use_abstract_semantic(self) -> bool: ...
+    @property
+    def has_any_text(self) -> bool: ...
+```
+
+### SemanticSearchAnswer
+
+Complete result from document Q&A:
+
+```python
+@dataclass
+class SemanticSearchAnswer:
+    answer: str
+    reasoning: Optional[str] = None
+    source: AnswerSource = AnswerSource.ABSTRACT
+    error: Optional[QAError] = None
+    error_message: Optional[str] = None
+    chunks_used: Optional[List[ChunkContext]] = None
+    model_used: str = ""
+    document_id: int = 0
+    question: str = ""
+    confidence: Optional[float] = None
+
+    @property
+    def success(self) -> bool: ...
+    @property
+    def used_fulltext(self) -> bool: ...
+    def to_dict(self) -> dict: ...
+```
+
+## SQL Functions
+
+### Document-Specific Search Functions
+
+Created in migration `018_create_document_specific_search_functions.sql`:
+
+#### semantic_search_document()
+
+Searches abstract chunks within a specific document:
+
+```sql
+CREATE FUNCTION semantic_search_document(
+    p_document_id INTEGER,
+    query_text TEXT,
+    threshold FLOAT DEFAULT 0.7,
+    result_limit INTEGER DEFAULT 5
+) RETURNS TABLE (
+    chunk_id INTEGER,
+    chunk_no INTEGER,
+    score FLOAT,
+    chunk_text TEXT
+)
+```
+
+**Key Design Points:**
+- Filters by `document_id` **inside** the query (not post-filtering)
+- Uses `emb_1024` table for abstract embeddings
+- Embedding generated via `ollama_embedding()` at runtime
+
+#### semantic.chunksearch_document()
+
+Searches full-text chunks within a specific document:
+
+```sql
+CREATE FUNCTION semantic.chunksearch_document(
+    p_document_id INTEGER,
+    query_text TEXT,
+    threshold FLOAT DEFAULT 0.7,
+    result_limit INTEGER DEFAULT 5
+) RETURNS TABLE (
+    chunk_id INTEGER,
+    chunk_no INTEGER,
+    score FLOAT,
+    chunk_text TEXT
+)
+```
+
+**Key Design Points:**
+- Uses `semantic.chunks` table for full-text embeddings
+- Extracts text on-the-fly via `substr(full_text, start_pos, end_pos)`
+- No redundant text storage (chunks store positions only)
+
+#### get_document_text_status()
+
+Helper function for checking document text availability:
+
+```sql
+CREATE FUNCTION get_document_text_status(p_document_id INTEGER)
+RETURNS TABLE (
+    has_abstract BOOLEAN,
+    has_fulltext BOOLEAN,
+    has_abstract_embeddings BOOLEAN,
+    has_fulltext_chunks BOOLEAN,
+    abstract_length INTEGER,
+    fulltext_length INTEGER
+)
+```
+
+### Why Document-Specific Functions?
+
+The existing `semantic.chunksearch()` function searches the **entire corpus**. Using:
+
+```sql
+SELECT * FROM semantic.chunksearch(...) WHERE document_id = 12345
+```
+
+Would execute the full corpus search first, then filter—defeating the purpose. The document-specific functions pass `document_id` into the query, enabling efficient index-assisted filtering.
+
+## Workflow
+
+```
+answer_from_document(document_id, question)
+    │
+    ├─► 1. Validate inputs
+    │       └─► Return error if question empty
+    │
+    ├─► 2. Get database manager
+    │       └─► Return error if unavailable
+    │
+    ├─► 3. Load configuration
+    │       └─► Merge with defaults
+    │
+    ├─► 4. Get document text status
+    │       └─► Return DOCUMENT_NOT_FOUND if missing
+    │
+    ├─► 5. Check for any text
+    │       └─► Return NO_TEXT_AVAILABLE if none
+    │
+    ├─► 6. If use_fulltext=True:
+    │       │
+    │       ├─► 6a. If no fulltext and download_missing=True:
+    │       │       └─► _download_fulltext_if_needed()
+    │       │           ├─► FullTextFinder.discover_and_download()
+    │       │           └─► (with OpenAthens if use_proxy=True)
+    │       │
+    │       ├─► 6b. If fulltext exists but no chunks:
+    │       │       └─► _embed_fulltext_if_needed()
+    │       │           └─► ChunkEmbedder.chunk_and_embed()
+    │       │
+    │       └─► 6c. If chunks exist:
+    │               └─► _semantic_search_fulltext()
+    │
+    ├─► 7. If no fulltext chunks, fallback to abstract:
+    │       └─► _get_document_abstract()
+    │
+    ├─► 8. Build context from chunks/abstract
+    │
+    ├─► 9. Generate answer via LLM:
+    │       └─► _generate_answer()
+    │           ├─► Check if model supports thinking
+    │           ├─► Call ollama.chat() with think=True if supported
+    │           └─► Extract thinking from response
+    │
+    └─► 10. Return SemanticSearchAnswer
+```
+
+## Thinking Model Support
+
+The system supports thinking/reasoning models (DeepSeek-R1, Qwen, etc.):
+
+### Detection
+
+```python
+thinking_models = ["deepseek-r1", "qwen", "qwq"]
+model_supports_thinking = any(tm in model.lower() for tm in thinking_models)
+```
+
+### Response Handling
+
+1. **Primary**: Check `response["message"]["thinking"]` field
+2. **Fallback**: Extract `<think>...</think>` blocks from content
+
+```python
+def _extract_thinking(response_content: str) -> Tuple[str, Optional[str]]:
+    think_pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+    match = think_pattern.search(response_content)
+    if match:
+        thinking = match.group(1).strip()
+        answer = think_pattern.sub("", response_content).strip()
+        return answer, thinking
+    return response_content.strip(), None
+```
+
+## Configuration
+
+### Config Schema
+
+```json
+{
+  "models": {
+    "document_qa_agent": "gpt-oss:20b"
+  },
+  "agents": {
+    "document_qa": {
+      "temperature": 0.3,
+      "top_p": 0.9,
+      "max_tokens": 2000,
+      "max_chunks": 5,
+      "similarity_threshold": 0.7,
+      "use_fulltext": true,
+      "download_missing_fulltext": true,
+      "use_proxy": true,
+      "use_thinking": true,
+      "embedding_model": "snowflake-arctic-embed2:latest"
+    }
+  }
+}
+```
+
+### Config Integration
+
+The function loads config via:
+
+```python
+from bmlibrarian.config import get_config
+config = get_config()
+qa_config = config.get("document_qa", {})
+model = model or qa_config.get("model", DEFAULT_QA_MODEL)
+```
+
+## Dependencies
+
+### Internal Dependencies
+
+- `bmlibrarian.database`: Database connection management
+- `bmlibrarian.config`: Configuration loading
+- `bmlibrarian.embeddings.chunk_embedder`: Full-text embedding
+- `bmlibrarian.discovery`: PDF discovery and download
+
+### External Dependencies
+
+- `ollama`: LLM inference
+- `psycopg`: PostgreSQL connectivity
+
+## Error Handling
+
+All operations return `SemanticSearchAnswer` with error information:
+
+```python
+# Example error return
+return SemanticSearchAnswer(
+    answer="",
+    error=QAError.DOCUMENT_NOT_FOUND,
+    error_message=f"Document with ID {document_id} not found",
+    document_id=document_id,
+    question=question,
+    model_used=model,
+)
+```
+
+### Error Propagation
+
+1. **Database errors**: Wrapped in `QAError.DATABASE_ERROR`
+2. **LLM errors**: Wrapped in `QAError.LLM_ERROR`
+3. **Download failures**: Logged and proceed to fallback
+
+## Performance Considerations
+
+### Cold Start
+
+First query for a document may be slow due to:
+- PDF download: 10-30 seconds
+- Embedding generation: 2-5 seconds per document
+- Query embedding: 1-2 seconds
+
+### Warm Queries
+
+Subsequent queries are fast:
+- Semantic search: <100ms
+- LLM generation: 2-10 seconds
+
+### Optimization Strategies
+
+1. **Pre-embed documents**: Use `ChunkEmbedder` in batch mode
+2. **Lower `max_chunks`**: Reduce context for faster inference
+3. **Abstract-only mode**: Skip full-text for quick answers
+
+## Testing
+
+### Unit Tests
+
+Located in `tests/qa/`:
+
+```
+tests/qa/
+├── __init__.py
+├── test_data_types.py       # Data type tests
+└── test_document_qa.py      # Function tests (mocked)
+```
+
+### Integration Testing
+
+Requires:
+- PostgreSQL with migration applied
+- Ollama server running
+- Document in database with embeddings
+
+```python
+# Example integration test
+def test_answer_from_document_integration():
+    result = answer_from_document(
+        document_id=12345,  # Known good document
+        question="What is the sample size?"
+    )
+    assert result.success
+    assert len(result.answer) > 0
+```
+
+## Extending the System
+
+### Adding New Source Types
+
+1. Add to `AnswerSource` enum
+2. Implement search function
+3. Update workflow in `answer_from_document()`
+
+### Custom Models
+
+Override via parameter or config:
+
+```python
+result = answer_from_document(
+    document_id=123,
+    question="...",
+    model="my-custom-model:latest"
+)
+```
+
+### Custom Prompts
+
+Currently hardcoded in `_generate_answer()`. To customize:
+1. Add prompt templates to config
+2. Load in `_generate_answer()`
+
+## Related Documentation
+
+- [User Guide](../users/document_qa_guide.md)
+- [Semantic Chunking Guide](../users/semantic_chunking_guide.md)
+- [PDF Discovery System](full_text_discovery_system.md)
+- [Database Schema](../llm/dbschema.md)

--- a/doc/users/document_qa_guide.md
+++ b/doc/users/document_qa_guide.md
@@ -1,0 +1,329 @@
+# Document Q&A Guide
+
+This guide explains how to use BMLibrarian's document question-answering functionality to ask questions about specific documents in your knowledge base.
+
+## Overview
+
+The `answer_from_document()` function provides a high-level interface for answering questions about individual documents. It automatically:
+
+1. Checks what text is available (full-text vs abstract)
+2. Downloads missing full-text PDFs if requested
+3. Generates embeddings if needed
+4. Performs document-specific semantic search
+5. Generates an answer using the LLM
+6. Falls back to abstract if full-text is unavailable
+
+## Quick Start
+
+```python
+from bmlibrarian.qa import answer_from_document
+
+# Ask a question about a specific document
+result = answer_from_document(
+    document_id=12345,
+    question="What are the main findings of this study?"
+)
+
+if result.success:
+    print(f"Answer: {result.answer}")
+    print(f"Source: {result.source.value}")  # 'fulltext_semantic' or 'abstract'
+
+    # If using a thinking model, reasoning is also available
+    if result.reasoning:
+        print(f"Reasoning: {result.reasoning}")
+else:
+    print(f"Error: {result.error_message}")
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `document_id` | int | required | Database ID of the document to query |
+| `question` | str | required | The question to answer |
+| `use_fulltext` | bool | True | Prefer full-text over abstract when available |
+| `download_missing_fulltext` | bool | True | Attempt to download PDFs if full-text is missing |
+| `use_proxy` | bool | True | Use OpenAthens proxy for paywalled content |
+| `model` | str | None | LLM model for answer generation (uses config if None) |
+| `max_chunks` | int | 5 | Maximum context chunks to use |
+| `similarity_threshold` | float | 0.7 | Minimum semantic similarity (0.0-1.0) |
+| `temperature` | float | 0.3 | LLM temperature for generation |
+
+## Return Value
+
+The function returns a `SemanticSearchAnswer` object with these fields:
+
+```python
+@dataclass
+class SemanticSearchAnswer:
+    answer: str                           # The generated answer
+    reasoning: Optional[str]              # Thinking/reasoning (for thinking models)
+    source: AnswerSource                  # FULLTEXT_SEMANTIC or ABSTRACT
+    error: Optional[QAError]              # Error enum if failed
+    error_message: Optional[str]          # Detailed error message
+    chunks_used: Optional[List[ChunkContext]]  # Context chunks used
+    model_used: str                       # LLM model name
+    document_id: int                      # The queried document
+    question: str                         # The original question
+    confidence: Optional[float]           # Confidence score (if available)
+```
+
+### Checking Success
+
+```python
+result = answer_from_document(document_id=123, question="...")
+
+# Using the success property
+if result.success:
+    print(result.answer)
+else:
+    print(f"Failed: {result.error.description}")
+```
+
+### Error Types
+
+The `QAError` enum provides structured error codes:
+
+| Error | Description |
+|-------|-------------|
+| `DOCUMENT_NOT_FOUND` | Document ID doesn't exist in database |
+| `NO_TEXT_AVAILABLE` | Document has neither abstract nor full-text |
+| `NO_FULLTEXT` | Full-text unavailable and no abstract fallback |
+| `DOWNLOAD_FAILED` | Failed to download the full-text PDF |
+| `EMBEDDING_FAILED` | Failed to generate or retrieve embeddings |
+| `SEMANTIC_SEARCH_FAILED` | Semantic search operation failed |
+| `LLM_ERROR` | Error during LLM inference |
+| `DATABASE_ERROR` | Database operation failed |
+| `CONFIGURATION_ERROR` | Invalid configuration |
+
+## Configuration
+
+Configure the document Q&A settings in `~/.bmlibrarian/config.json`:
+
+```json
+{
+  "models": {
+    "document_qa_agent": "gpt-oss:20b"
+  },
+  "agents": {
+    "document_qa": {
+      "temperature": 0.3,
+      "top_p": 0.9,
+      "max_tokens": 2000,
+      "max_chunks": 5,
+      "similarity_threshold": 0.7,
+      "use_fulltext": true,
+      "download_missing_fulltext": true,
+      "use_proxy": true,
+      "use_thinking": true,
+      "embedding_model": "snowflake-arctic-embed2:latest"
+    }
+  }
+}
+```
+
+## Workflow Details
+
+### 1. Text Availability Check
+
+The function first checks what text is available for the document:
+
+```
+┌─────────────────────────────────────┐
+│ get_document_text_status(doc_id)    │
+├─────────────────────────────────────┤
+│ has_abstract: bool                  │
+│ has_fulltext: bool                  │
+│ has_abstract_embeddings: bool       │
+│ has_fulltext_chunks: bool           │
+│ abstract_length: int                │
+│ fulltext_length: int                │
+└─────────────────────────────────────┘
+```
+
+### 2. Full-Text Strategy
+
+When `use_fulltext=True`:
+
+1. **Check for existing full-text chunks** in `semantic.chunks`
+2. **If full-text exists but no chunks**: Run embedding via `ChunkEmbedder`
+3. **If no full-text and `download_missing_fulltext=True`**:
+   - Discover PDF via PMC, Unpaywall, DOI resolution
+   - Download with browser fallback if needed
+   - Use OpenAthens proxy if `use_proxy=True`
+4. **If still no full-text**: Fall back to abstract
+
+### 3. Semantic Search
+
+The function uses document-specific SQL functions that filter at the database level:
+
+```sql
+-- For full-text chunks
+SELECT * FROM semantic.chunksearch_document(
+    p_document_id := 12345,
+    query_text := 'What are the main findings?',
+    threshold := 0.7,
+    result_limit := 5
+);
+
+-- For abstract chunks (fallback)
+SELECT * FROM semantic_search_document(
+    p_document_id := 12345,
+    query_text := 'What are the main findings?',
+    threshold := 0.7,
+    result_limit := 5
+);
+```
+
+### 4. Answer Generation
+
+Context is assembled from the top-scoring chunks:
+
+```
+[Chunk 1, Score: 0.89]
+The study found that regular exercise reduced cardiovascular risk by 30%...
+
+---
+
+[Chunk 2, Score: 0.82]
+Participants who exercised 3+ times per week showed significant improvement...
+```
+
+The LLM then generates an answer using this context.
+
+## Thinking Model Support
+
+For models that support thinking/reasoning (DeepSeek-R1, Qwen, etc.), the function:
+
+1. Enables thinking mode via `think=True` parameter
+2. Extracts reasoning from `response.message.thinking` field
+3. Falls back to extracting `<think>...</think>` blocks from content
+
+```python
+result = answer_from_document(
+    document_id=123,
+    question="What methodology did the authors use?"
+)
+
+if result.reasoning:
+    print("Model's reasoning:")
+    print(result.reasoning)
+    print("\nFinal answer:")
+    print(result.answer)
+```
+
+## Examples
+
+### Basic Usage
+
+```python
+from bmlibrarian.qa import answer_from_document
+
+# Simple question
+result = answer_from_document(
+    document_id=42,
+    question="What sample size was used in this study?"
+)
+print(result.answer)
+```
+
+### Prefer Abstract Only
+
+```python
+# Skip full-text, use abstract directly
+result = answer_from_document(
+    document_id=42,
+    question="What is the main conclusion?",
+    use_fulltext=False
+)
+```
+
+### Offline Mode (No Downloads)
+
+```python
+# Don't attempt to download missing PDFs
+result = answer_from_document(
+    document_id=42,
+    question="Describe the methodology",
+    download_missing_fulltext=False
+)
+```
+
+### Custom Model and Temperature
+
+```python
+result = answer_from_document(
+    document_id=42,
+    question="Summarize the findings",
+    model="medgemma-27b-text-it-Q8_0:latest",
+    temperature=0.1,  # More focused
+    max_chunks=3      # Less context
+)
+```
+
+### Accessing Chunk Details
+
+```python
+result = answer_from_document(document_id=42, question="...")
+
+if result.chunks_used:
+    for chunk in result.chunks_used:
+        print(f"Chunk {chunk.chunk_no} (score: {chunk.score:.2f}):")
+        print(chunk.text[:200])
+        print("---")
+```
+
+## Integration with GUI
+
+For Qt/PySide6 applications, wrap the function call in a worker thread:
+
+```python
+from PySide6.QtCore import QThread, Signal
+
+class QAWorker(QThread):
+    finished = Signal(object)
+
+    def __init__(self, document_id: int, question: str):
+        super().__init__()
+        self.document_id = document_id
+        self.question = question
+
+    def run(self):
+        from bmlibrarian.qa import answer_from_document
+        result = answer_from_document(
+            document_id=self.document_id,
+            question=self.question
+        )
+        self.finished.emit(result)
+```
+
+## Troubleshooting
+
+### "Document not found"
+Verify the document ID exists in your database:
+```sql
+SELECT id, title FROM document WHERE id = 12345;
+```
+
+### "No full-text available"
+Check document status:
+```sql
+SELECT * FROM get_document_text_status(12345);
+```
+
+### Slow Performance
+- Full-text download can take 10-30 seconds
+- Embedding generation takes 2-5 seconds per document
+- Consider pre-embedding documents with `ChunkEmbedder`
+
+### Low Quality Answers
+- Increase `max_chunks` to provide more context
+- Lower `similarity_threshold` to include more chunks
+- Try a larger model (`gpt-oss:20b`)
+
+## See Also
+
+- [Developer Documentation](../developers/document_qa_system.md)
+- [PDF Discovery Guide](pdf_download_guide.md)
+- [Document Embedding Guide](document_embedding_guide.md)
+- [Configuration Guide](settings_migration_guide.md)

--- a/migrations/018_create_document_specific_search_functions.sql
+++ b/migrations/018_create_document_specific_search_functions.sql
@@ -1,0 +1,316 @@
+-- Migration: Create Document-Specific Semantic Search Functions
+-- Description: Creates functions for semantic search within a single document,
+--              supporting both abstract chunks (emb_1024) and full-text chunks (semantic.chunks).
+--              These functions accept document_id as a parameter to filter at the index level,
+--              avoiding inefficient post-filtering of full-corpus search results.
+-- Author: BMLibrarian
+-- Date: 2025-11-24
+
+-- ============================================================================
+-- Drop functions if they exist (idempotent migration)
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS semantic_search_document(INTEGER, TEXT, FLOAT, INTEGER);
+DROP FUNCTION IF EXISTS semantic.chunksearch_document(INTEGER, TEXT, FLOAT, INTEGER);
+
+-- ============================================================================
+-- Create semantic_search_document for abstract chunks (emb_1024 table)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION semantic_search_document(
+    p_document_id INTEGER,
+    query_text TEXT,
+    threshold FLOAT DEFAULT 0.7,
+    result_limit INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+    chunk_id INTEGER,
+    chunk_no INTEGER,
+    score FLOAT,
+    chunk_text TEXT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    query_embedding vector(1024);
+BEGIN
+    -- Validate inputs
+    IF p_document_id IS NULL THEN
+        RAISE EXCEPTION 'document_id cannot be null';
+    END IF;
+
+    IF query_text IS NULL OR query_text = '' THEN
+        RAISE EXCEPTION 'query_text cannot be null or empty';
+    END IF;
+
+    IF threshold < 0.0 OR threshold > 1.0 THEN
+        RAISE EXCEPTION 'threshold must be between 0.0 and 1.0';
+    END IF;
+
+    IF result_limit < 1 THEN
+        RAISE EXCEPTION 'result_limit must be at least 1';
+    END IF;
+
+    -- Generate embedding for the search text using ollama_embedding function
+    query_embedding := ollama_embedding(query_text);
+
+    -- Handle case where embedding generation fails
+    IF query_embedding IS NULL THEN
+        RAISE EXCEPTION 'Failed to generate embedding for query text';
+    END IF;
+
+    -- Search for similar embeddings within the specific document
+    -- Filter by document_id BEFORE similarity calculation for efficiency
+    RETURN QUERY
+    SELECT
+        e.chunk_id,
+        c.chunk_no,
+        (1 - (e.embedding <=> query_embedding))::FLOAT AS similarity_score,
+        c.text AS chunk_text
+    FROM
+        emb_1024 e
+        JOIN chunks c ON e.chunk_id = c.id
+    WHERE
+        c.document_id = p_document_id
+        AND (1 - (e.embedding <=> query_embedding)) >= threshold
+    ORDER BY
+        e.embedding <=> query_embedding
+    LIMIT result_limit;
+END;
+$$;
+
+-- Add function comment
+COMMENT ON FUNCTION semantic_search_document(INTEGER, TEXT, FLOAT, INTEGER) IS
+'Search abstract chunks by semantic similarity within a SINGLE document.
+
+Unlike semantic_search() which searches the entire corpus, this function
+filters by document_id at the query level for efficient single-document Q&A.
+
+Parameters:
+  - p_document_id: The document ID to search within (required)
+  - query_text: Natural language search query
+  - threshold: Minimum similarity score (0.0 to 1.0, default: 0.7)
+  - result_limit: Maximum number of results to return (default: 5)
+
+Returns: Table with chunk_id, chunk_no, similarity score, and chunk text
+
+Technical Details:
+  - Uses ollama_embedding() to generate query embeddings at runtime
+  - Searches the emb_1024 table (abstract embeddings)
+  - Cosine similarity via pgvector <=> operator
+  - document_id filter applied before similarity calculation
+
+Example Usage:
+  -- Find relevant abstract chunks for a question
+  SELECT * FROM semantic_search_document(12345, ''cardiovascular benefits'', 0.75, 5);
+
+  -- Use in document Q&A workflow
+  SELECT chunk_text, score
+  FROM semantic_search_document(12345, ''What are the main findings?'', 0.7, 3)
+  ORDER BY score DESC;';
+
+
+-- ============================================================================
+-- Create semantic.chunksearch_document for full-text chunks
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION semantic.chunksearch_document(
+    p_document_id INTEGER,
+    query_text TEXT,
+    threshold FLOAT DEFAULT 0.7,
+    result_limit INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+    chunk_id INTEGER,
+    chunk_no INTEGER,
+    score FLOAT,
+    chunk_text TEXT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    query_embedding vector(1024);
+BEGIN
+    -- Validate inputs
+    IF p_document_id IS NULL THEN
+        RAISE EXCEPTION 'document_id cannot be null';
+    END IF;
+
+    IF query_text IS NULL OR query_text = '' THEN
+        RAISE EXCEPTION 'query_text cannot be null or empty';
+    END IF;
+
+    IF threshold < 0.0 OR threshold > 1.0 THEN
+        RAISE EXCEPTION 'threshold must be between 0.0 and 1.0';
+    END IF;
+
+    IF result_limit < 1 THEN
+        RAISE EXCEPTION 'result_limit must be at least 1';
+    END IF;
+
+    -- Generate embedding for the search text using ollama_embedding function
+    query_embedding := ollama_embedding(query_text);
+
+    -- Handle case where embedding generation fails
+    IF query_embedding IS NULL THEN
+        RAISE EXCEPTION 'Failed to generate embedding for query text';
+    END IF;
+
+    -- Search for similar embeddings within the specific document
+    -- Filter by document_id BEFORE similarity calculation for efficiency
+    -- Extract chunk text on-the-fly from document.full_text using stored positions
+    RETURN QUERY
+    SELECT
+        c.id AS chunk_id,
+        c.chunk_no,
+        (1 - (c.embedding <=> query_embedding))::FLOAT AS similarity_score,
+        substr(d.full_text, c.start_pos + 1, c.end_pos - c.start_pos + 1) AS chunk_text
+    FROM
+        semantic.chunks c
+        JOIN public.document d ON c.document_id = d.id
+    WHERE
+        c.document_id = p_document_id
+        AND d.withdrawn_date IS NULL
+        AND d.full_text IS NOT NULL
+        AND (1 - (c.embedding <=> query_embedding)) >= threshold
+    ORDER BY
+        c.embedding <=> query_embedding
+    LIMIT result_limit;
+END;
+$$;
+
+-- Add function comment
+COMMENT ON FUNCTION semantic.chunksearch_document(INTEGER, TEXT, FLOAT, INTEGER) IS
+'Search full-text chunks by semantic similarity within a SINGLE document.
+
+Unlike semantic.chunksearch() which searches the entire corpus, this function
+filters by document_id at the query level for efficient single-document Q&A.
+
+Parameters:
+  - p_document_id: The document ID to search within (required)
+  - query_text: Natural language search query
+  - threshold: Minimum similarity score (0.0 to 1.0, default: 0.7)
+  - result_limit: Maximum number of results to return (default: 5)
+
+Returns: Table with chunk_id, chunk_no, similarity score, and chunk text
+
+Technical Details:
+  - Uses ollama_embedding() to generate query embeddings at runtime
+  - Searches the semantic.chunks table (full-text embeddings)
+  - Chunk text extracted on-the-fly via substr() from document.full_text
+  - Cosine similarity via pgvector <=> operator
+  - document_id filter applied before similarity calculation
+  - Automatically excludes withdrawn documents
+
+Example Usage:
+  -- Find relevant full-text chunks for a question
+  SELECT * FROM semantic.chunksearch_document(12345, ''methodology'', 0.75, 5);
+
+  -- Use in document Q&A workflow
+  SELECT chunk_text, score
+  FROM semantic.chunksearch_document(12345, ''What statistical methods were used?'', 0.7, 3)
+  ORDER BY score DESC;';
+
+
+-- ============================================================================
+-- Create helper function to check if document has abstract embeddings
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION has_abstract_embeddings(
+    p_document_id INTEGER,
+    p_model_id INTEGER DEFAULT 1
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN EXISTS (
+        SELECT 1
+        FROM chunks c
+        JOIN emb_1024 e ON c.id = e.chunk_id
+        WHERE c.document_id = p_document_id
+          AND e.model_id = p_model_id
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION has_abstract_embeddings(INTEGER, INTEGER) IS
+'Check if a document has abstract embeddings in the emb_1024 table.
+Used to determine if semantic_search_document() can be used for this document.
+
+Parameters:
+  - p_document_id: The document ID to check
+  - p_model_id: Embedding model ID (default: 1 = snowflake-arctic-embed2)
+
+Returns: TRUE if embeddings exist, FALSE otherwise';
+
+
+-- ============================================================================
+-- Create helper function to get document full-text status
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_document_text_status(
+    p_document_id INTEGER
+)
+RETURNS TABLE (
+    has_abstract BOOLEAN,
+    has_fulltext BOOLEAN,
+    has_abstract_embeddings BOOLEAN,
+    has_fulltext_chunks BOOLEAN,
+    abstract_length INTEGER,
+    fulltext_length INTEGER
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        d.abstract IS NOT NULL AND d.abstract != '' AS has_abstract,
+        d.full_text IS NOT NULL AND d.full_text != '' AS has_fulltext,
+        has_abstract_embeddings(p_document_id) AS has_abstract_embeddings,
+        semantic.has_chunks(p_document_id) AS has_fulltext_chunks,
+        COALESCE(length(d.abstract), 0)::INTEGER AS abstract_length,
+        COALESCE(length(d.full_text), 0)::INTEGER AS fulltext_length
+    FROM public.document d
+    WHERE d.id = p_document_id;
+END;
+$$;
+
+COMMENT ON FUNCTION get_document_text_status(INTEGER) IS
+'Get the text availability status for a document.
+Useful for determining which Q&A strategy to use.
+
+Returns:
+  - has_abstract: TRUE if abstract exists and is non-empty
+  - has_fulltext: TRUE if full_text exists and is non-empty
+  - has_abstract_embeddings: TRUE if abstract embeddings exist in emb_1024
+  - has_fulltext_chunks: TRUE if full-text chunks exist in semantic.chunks
+  - abstract_length: Length of abstract in characters
+  - fulltext_length: Length of full_text in characters
+
+Example:
+  SELECT * FROM get_document_text_status(12345);';
+
+
+-- ============================================================================
+-- Grant appropriate permissions
+-- ============================================================================
+
+-- semantic_search_document permissions
+GRANT EXECUTE ON FUNCTION semantic_search_document(INTEGER, TEXT, FLOAT, INTEGER) TO rwbadmin;
+GRANT EXECUTE ON FUNCTION semantic_search_document(INTEGER, TEXT, FLOAT, INTEGER) TO hherb;
+GRANT EXECUTE ON FUNCTION semantic_search_document(INTEGER, TEXT, FLOAT, INTEGER) TO postgres;
+
+-- semantic.chunksearch_document permissions
+GRANT EXECUTE ON FUNCTION semantic.chunksearch_document(INTEGER, TEXT, FLOAT, INTEGER) TO rwbadmin;
+GRANT EXECUTE ON FUNCTION semantic.chunksearch_document(INTEGER, TEXT, FLOAT, INTEGER) TO hherb;
+GRANT EXECUTE ON FUNCTION semantic.chunksearch_document(INTEGER, TEXT, FLOAT, INTEGER) TO postgres;
+
+-- Helper function permissions
+GRANT EXECUTE ON FUNCTION has_abstract_embeddings(INTEGER, INTEGER) TO rwbadmin;
+GRANT EXECUTE ON FUNCTION has_abstract_embeddings(INTEGER, INTEGER) TO hherb;
+GRANT EXECUTE ON FUNCTION has_abstract_embeddings(INTEGER, INTEGER) TO postgres;
+
+GRANT EXECUTE ON FUNCTION get_document_text_status(INTEGER) TO rwbadmin;
+GRANT EXECUTE ON FUNCTION get_document_text_status(INTEGER) TO hherb;
+GRANT EXECUTE ON FUNCTION get_document_text_status(INTEGER) TO postgres;

--- a/src/bmlibrarian/config.py
+++ b/src/bmlibrarian/config.py
@@ -56,7 +56,7 @@ class UserContext:
 # Must match bmlsettings schema constraints
 VALID_SETTINGS_CATEGORIES = frozenset([
     'models', 'ollama', 'agents', 'database', 'search',
-    'query_generation', 'gui', 'openathens', 'pdf', 'general'
+    'query_generation', 'gui', 'openathens', 'pdf', 'general', 'document_qa'
 ])
 
 
@@ -308,6 +308,7 @@ DEFAULT_CONFIG = {
         "prisma2020_agent": "gpt-oss:20b",  # Use larger model for PRISMA 2020 compliance assessment
         "paper_weight_assessment_agent": "gpt-oss:20b",  # Use larger model for paper weight assessment
         "paper_checker_agent": "gpt-oss:20b",  # Use larger model for abstract fact-checking
+        "document_qa_agent": "gpt-oss:20b",  # Use larger model for document Q&A
 
         # Alternative models for different use cases
         "fast_model": "medgemma4B_it_q8:latest",
@@ -487,6 +488,18 @@ DEFAULT_CONFIG = {
                 "num_abstracts": 2,  # Number of hypothetical abstracts to generate
                 "max_keywords": 10  # Maximum keywords to generate
             }
+        },
+        "document_qa": {
+            "temperature": 0.3,
+            "top_p": 0.9,
+            "max_tokens": 2000,
+            "max_chunks": 5,  # Maximum context chunks to use for answer generation
+            "similarity_threshold": 0.7,  # Minimum similarity for semantic search (0.0-1.0)
+            "use_fulltext": True,  # Prefer full-text over abstract when available
+            "download_missing_fulltext": True,  # Attempt to download PDFs if full-text missing
+            "use_proxy": True,  # Use OpenAthens proxy for paywalled content
+            "use_thinking": True,  # Enable thinking mode for supported models
+            "embedding_model": "snowflake-arctic-embed2:latest"
         },
         "formatting": {
             "require_specific_years": True,  # Use specific years instead of "recent study"

--- a/src/bmlibrarian/qa/__init__.py
+++ b/src/bmlibrarian/qa/__init__.py
@@ -1,0 +1,49 @@
+"""
+Document Question-Answering Module for BMLibrarian.
+
+This module provides high-level functions for answering questions about
+documents in the knowledge base using semantic search and LLM inference.
+
+The main entry point is `answer_from_document()` which handles:
+- Full-text discovery and download (if missing)
+- Semantic embedding generation (if needed)
+- Semantic search within the document
+- Fallback to abstract if full-text unavailable
+- LLM-based answer generation with thinking model support
+
+Example Usage:
+    from bmlibrarian.qa import answer_from_document
+
+    result = answer_from_document(
+        document_id=12345,
+        question="What are the main findings of this study?",
+        use_fulltext=True,
+        download_missing_fulltext=True
+    )
+
+    if result.error:
+        print(f"Error: {result.error}")
+    else:
+        print(f"Answer: {result.answer}")
+        print(f"Source: {result.source.value}")
+        if result.reasoning:
+            print(f"Reasoning: {result.reasoning}")
+"""
+
+from .data_types import (
+    AnswerSource,
+    QAError,
+    ChunkContext,
+    SemanticSearchAnswer,
+    DocumentTextStatus,
+)
+from .document_qa import answer_from_document
+
+__all__ = [
+    "AnswerSource",
+    "QAError",
+    "ChunkContext",
+    "SemanticSearchAnswer",
+    "DocumentTextStatus",
+    "answer_from_document",
+]

--- a/src/bmlibrarian/qa/data_types.py
+++ b/src/bmlibrarian/qa/data_types.py
@@ -1,0 +1,212 @@
+"""
+Data types for the Document Question-Answering module.
+
+This module defines the dataclasses and enums used throughout the QA system,
+following BMLibrarian's type-safe design principles.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, List
+
+
+class AnswerSource(Enum):
+    """
+    Source of context used for generating the answer.
+
+    Indicates whether the answer was derived from full-text semantic search
+    or from the document abstract.
+    """
+
+    FULLTEXT_SEMANTIC = "fulltext_semantic"  # Semantic search on full-text chunks
+    ABSTRACT = "abstract"  # Used document abstract as context
+
+
+class QAError(Enum):
+    """
+    Error types for document Q&A operations.
+
+    Provides structured error codes for programmatic error handling,
+    each with a descriptive message available via `.description`.
+    """
+
+    DOCUMENT_NOT_FOUND = "document_not_found"
+    NO_TEXT_AVAILABLE = "no_text_available"
+    NO_FULLTEXT = "no_fulltext"
+    DOWNLOAD_FAILED = "download_failed"
+    EMBEDDING_FAILED = "embedding_failed"
+    SEMANTIC_SEARCH_FAILED = "semantic_search_failed"
+    LLM_ERROR = "llm_error"
+    DATABASE_ERROR = "database_error"
+    CONFIGURATION_ERROR = "configuration_error"
+
+    @property
+    def description(self) -> str:
+        """Get a human-readable description of the error."""
+        descriptions = {
+            QAError.DOCUMENT_NOT_FOUND: "Document with the specified ID was not found in the database",
+            QAError.NO_TEXT_AVAILABLE: "Document has neither abstract nor full-text available",
+            QAError.NO_FULLTEXT: "Full-text is not available and could not be obtained",
+            QAError.DOWNLOAD_FAILED: "Failed to download the full-text PDF",
+            QAError.EMBEDDING_FAILED: "Failed to generate or retrieve embeddings for the document",
+            QAError.SEMANTIC_SEARCH_FAILED: "Semantic search operation failed",
+            QAError.LLM_ERROR: "Error during LLM inference",
+            QAError.DATABASE_ERROR: "Database operation failed",
+            QAError.CONFIGURATION_ERROR: "Configuration is invalid or missing required settings",
+        }
+        return descriptions.get(self, "Unknown error")
+
+
+@dataclass
+class ChunkContext:
+    """
+    Represents a chunk of text used as context for answering.
+
+    Attributes:
+        chunk_no: Sequential chunk number within the document.
+        text: The actual text content of the chunk.
+        score: Semantic similarity score (0.0 to 1.0).
+        chunk_id: Database ID of the chunk (optional).
+    """
+
+    chunk_no: int
+    text: str
+    score: float
+    chunk_id: Optional[int] = None
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        text_preview = self.text[:50] + "..." if len(self.text) > 50 else self.text
+        return f"ChunkContext(no={self.chunk_no}, score={self.score:.3f}, text='{text_preview}')"
+
+
+@dataclass
+class DocumentTextStatus:
+    """
+    Status of text availability for a document.
+
+    Used to determine which Q&A strategy to use (full-text vs abstract).
+
+    Attributes:
+        document_id: The document's database ID.
+        has_abstract: Whether an abstract exists and is non-empty.
+        has_fulltext: Whether full_text exists and is non-empty.
+        has_abstract_embeddings: Whether abstract embeddings exist in emb_1024.
+        has_fulltext_chunks: Whether full-text chunks exist in semantic.chunks.
+        abstract_length: Length of abstract in characters.
+        fulltext_length: Length of full_text in characters.
+        title: Document title (for error messages).
+    """
+
+    document_id: int
+    has_abstract: bool = False
+    has_fulltext: bool = False
+    has_abstract_embeddings: bool = False
+    has_fulltext_chunks: bool = False
+    abstract_length: int = 0
+    fulltext_length: int = 0
+    title: Optional[str] = None
+
+    @property
+    def can_use_fulltext_semantic(self) -> bool:
+        """Check if full-text semantic search is available."""
+        return self.has_fulltext and self.has_fulltext_chunks
+
+    @property
+    def can_use_abstract_semantic(self) -> bool:
+        """Check if abstract semantic search is available."""
+        return self.has_abstract and self.has_abstract_embeddings
+
+    @property
+    def can_use_abstract_direct(self) -> bool:
+        """Check if abstract can be used directly (without embeddings)."""
+        return self.has_abstract
+
+    @property
+    def has_any_text(self) -> bool:
+        """Check if any text is available for Q&A."""
+        return self.has_abstract or self.has_fulltext
+
+
+@dataclass
+class SemanticSearchAnswer:
+    """
+    Result from document question-answering.
+
+    Contains the generated answer, metadata about how it was generated,
+    and any error information if the operation failed.
+
+    Attributes:
+        answer: The generated answer text. Empty string if error occurred.
+        reasoning: For thinking models, the model's reasoning process.
+            Extracted from `<think>` blocks or `message.thinking` field.
+        source: Which source was used for context (fulltext or abstract).
+        error: Error enum if operation failed, None on success.
+        error_message: Detailed error message with context.
+        chunks_used: List of chunks used as context (for transparency).
+        model_used: Name of the LLM model that generated the answer.
+        document_id: The document that was queried.
+        question: The original question asked.
+        confidence: Optional confidence score (0.0 to 1.0) if model provides it.
+    """
+
+    answer: str
+    reasoning: Optional[str] = None
+    source: AnswerSource = AnswerSource.ABSTRACT
+    error: Optional[QAError] = None
+    error_message: Optional[str] = None
+    chunks_used: Optional[List[ChunkContext]] = None
+    model_used: str = ""
+    document_id: int = 0
+    question: str = ""
+    confidence: Optional[float] = None
+
+    @property
+    def success(self) -> bool:
+        """Check if the Q&A operation succeeded."""
+        return self.error is None and bool(self.answer)
+
+    @property
+    def used_fulltext(self) -> bool:
+        """Check if full-text was used for the answer."""
+        return self.source == AnswerSource.FULLTEXT_SEMANTIC
+
+    def to_dict(self) -> dict:
+        """
+        Convert to dictionary for serialization.
+
+        Returns:
+            Dictionary representation suitable for JSON serialization.
+        """
+        return {
+            "answer": self.answer,
+            "reasoning": self.reasoning,
+            "source": self.source.value,
+            "error": self.error.value if self.error else None,
+            "error_message": self.error_message,
+            "chunks_used": [
+                {
+                    "chunk_no": c.chunk_no,
+                    "text": c.text,
+                    "score": c.score,
+                    "chunk_id": c.chunk_id,
+                }
+                for c in (self.chunks_used or [])
+            ],
+            "model_used": self.model_used,
+            "document_id": self.document_id,
+            "question": self.question,
+            "confidence": self.confidence,
+            "success": self.success,
+        }
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        if self.error:
+            return f"SemanticSearchAnswer(error={self.error.value}, msg='{self.error_message}')"
+        answer_preview = self.answer[:80] + "..." if len(self.answer) > 80 else self.answer
+        return (
+            f"SemanticSearchAnswer(source={self.source.value}, "
+            f"chunks={len(self.chunks_used or [])}, "
+            f"answer='{answer_preview}')"
+        )

--- a/src/bmlibrarian/qa/document_qa.py
+++ b/src/bmlibrarian/qa/document_qa.py
@@ -1,0 +1,746 @@
+"""
+Document Question-Answering for BMLibrarian.
+
+This module provides the `answer_from_document()` function for answering
+questions about specific documents using semantic search and LLM inference.
+
+The function handles the complete workflow:
+1. Check document text availability (full-text vs abstract)
+2. Download missing full-text if requested
+3. Generate embeddings if needed
+4. Perform document-specific semantic search
+5. Generate answer using LLM with optional thinking model support
+6. Fallback to abstract if full-text unavailable
+
+Example:
+    from bmlibrarian.qa import answer_from_document
+
+    result = answer_from_document(
+        document_id=12345,
+        question="What methodology did the authors use?"
+    )
+    print(result.answer)
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional, List, Tuple, TYPE_CHECKING
+
+import ollama
+
+if TYPE_CHECKING:
+    from bmlibrarian.database import DatabaseManager
+
+from .data_types import (
+    AnswerSource,
+    QAError,
+    ChunkContext,
+    SemanticSearchAnswer,
+    DocumentTextStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default configuration constants
+DEFAULT_QA_MODEL = "gpt-oss:20b"
+DEFAULT_EMBEDDING_MODEL = "snowflake-arctic-embed2:latest"
+DEFAULT_MAX_CHUNKS = 5
+DEFAULT_SIMILARITY_THRESHOLD = 0.7
+DEFAULT_TEMPERATURE = 0.3
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+
+# Minimum abstract length to consider usable (characters)
+MIN_ABSTRACT_LENGTH = 50
+
+
+def _get_document_text_status(
+    document_id: int,
+    db_manager: "DatabaseManager",
+) -> Optional[DocumentTextStatus]:
+    """
+    Get text availability status for a document.
+
+    Uses the SQL function get_document_text_status() for efficient checking.
+
+    Args:
+        document_id: The document's database ID.
+        db_manager: Database manager instance.
+
+    Returns:
+        DocumentTextStatus object, or None if document not found.
+    """
+    try:
+        with db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                # Get basic document info
+                cur.execute(
+                    """
+                    SELECT title, abstract, full_text
+                    FROM public.document
+                    WHERE id = %s
+                    """,
+                    (document_id,),
+                )
+                row = cur.fetchone()
+
+                if not row:
+                    return None
+
+                title, abstract, full_text = row
+
+                # Get status from helper function
+                cur.execute(
+                    "SELECT * FROM get_document_text_status(%s)",
+                    (document_id,),
+                )
+                status_row = cur.fetchone()
+
+                if status_row:
+                    (
+                        has_abstract,
+                        has_fulltext,
+                        has_abstract_embeddings,
+                        has_fulltext_chunks,
+                        abstract_length,
+                        fulltext_length,
+                    ) = status_row
+
+                    return DocumentTextStatus(
+                        document_id=document_id,
+                        has_abstract=has_abstract,
+                        has_fulltext=has_fulltext,
+                        has_abstract_embeddings=has_abstract_embeddings,
+                        has_fulltext_chunks=has_fulltext_chunks,
+                        abstract_length=abstract_length,
+                        fulltext_length=fulltext_length,
+                        title=title,
+                    )
+
+                # Fallback if function doesn't exist
+                return DocumentTextStatus(
+                    document_id=document_id,
+                    has_abstract=bool(abstract and abstract.strip()),
+                    has_fulltext=bool(full_text and full_text.strip()),
+                    has_abstract_embeddings=False,
+                    has_fulltext_chunks=False,
+                    abstract_length=len(abstract) if abstract else 0,
+                    fulltext_length=len(full_text) if full_text else 0,
+                    title=title,
+                )
+
+    except Exception as e:
+        logger.error(f"Error getting document text status: {e}")
+        return None
+
+
+def _semantic_search_fulltext(
+    document_id: int,
+    question: str,
+    threshold: float,
+    max_chunks: int,
+    db_manager: "DatabaseManager",
+) -> List[ChunkContext]:
+    """
+    Perform semantic search on full-text chunks within a document.
+
+    Args:
+        document_id: The document's database ID.
+        question: The question to search for.
+        threshold: Minimum similarity threshold (0.0 to 1.0).
+        max_chunks: Maximum number of chunks to return.
+        db_manager: Database manager instance.
+
+    Returns:
+        List of ChunkContext objects sorted by score descending.
+    """
+    try:
+        with db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT chunk_id, chunk_no, score, chunk_text
+                    FROM semantic.chunksearch_document(%s, %s, %s, %s)
+                    ORDER BY score DESC
+                    """,
+                    (document_id, question, threshold, max_chunks),
+                )
+                rows = cur.fetchall()
+
+                return [
+                    ChunkContext(
+                        chunk_id=row[0],
+                        chunk_no=row[1],
+                        score=row[2],
+                        text=row[3],
+                    )
+                    for row in rows
+                ]
+
+    except Exception as e:
+        logger.error(f"Full-text semantic search failed: {e}")
+        return []
+
+
+def _semantic_search_abstract(
+    document_id: int,
+    question: str,
+    threshold: float,
+    max_chunks: int,
+    db_manager: "DatabaseManager",
+) -> List[ChunkContext]:
+    """
+    Perform semantic search on abstract chunks within a document.
+
+    Args:
+        document_id: The document's database ID.
+        question: The question to search for.
+        threshold: Minimum similarity threshold (0.0 to 1.0).
+        max_chunks: Maximum number of chunks to return.
+        db_manager: Database manager instance.
+
+    Returns:
+        List of ChunkContext objects sorted by score descending.
+    """
+    try:
+        with db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT chunk_id, chunk_no, score, chunk_text
+                    FROM semantic_search_document(%s, %s, %s, %s)
+                    ORDER BY score DESC
+                    """,
+                    (document_id, question, threshold, max_chunks),
+                )
+                rows = cur.fetchall()
+
+                return [
+                    ChunkContext(
+                        chunk_id=row[0],
+                        chunk_no=row[1],
+                        score=row[2],
+                        text=row[3],
+                    )
+                    for row in rows
+                ]
+
+    except Exception as e:
+        logger.error(f"Abstract semantic search failed: {e}")
+        return []
+
+
+def _get_document_abstract(document_id: int, db_manager: "DatabaseManager") -> Optional[str]:
+    """
+    Get the abstract text for a document.
+
+    Args:
+        document_id: The document's database ID.
+        db_manager: Database manager instance.
+
+    Returns:
+        Abstract text, or None if not available.
+    """
+    try:
+        with db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT abstract FROM public.document WHERE id = %s",
+                    (document_id,),
+                )
+                row = cur.fetchone()
+                return row[0] if row and row[0] else None
+
+    except Exception as e:
+        logger.error(f"Error getting document abstract: {e}")
+        return None
+
+
+def _embed_fulltext_if_needed(
+    document_id: int,
+    db_manager: "DatabaseManager",
+) -> bool:
+    """
+    Ensure full-text chunks are embedded for a document.
+
+    If the document has full_text but no chunks, triggers embedding.
+
+    Args:
+        document_id: The document's database ID.
+        db_manager: Database manager instance.
+
+    Returns:
+        True if chunks exist or were successfully created, False otherwise.
+    """
+    try:
+        from bmlibrarian.embeddings.chunk_embedder import ChunkEmbedder
+
+        embedder = ChunkEmbedder()
+
+        # Check if chunks already exist
+        if embedder.has_chunks(document_id):
+            logger.debug(f"Document {document_id} already has full-text chunks")
+            return True
+
+        # Check if full_text exists
+        full_text = embedder.get_document_full_text(document_id)
+        if not full_text:
+            logger.warning(f"Document {document_id} has no full_text to embed")
+            return False
+
+        # Generate chunks and embeddings
+        logger.info(f"Embedding full-text for document {document_id}")
+        num_chunks = embedder.chunk_and_embed(document_id, overwrite=False)
+
+        if num_chunks > 0:
+            logger.info(f"Created {num_chunks} chunks for document {document_id}")
+            return True
+        else:
+            logger.warning(f"Failed to create chunks for document {document_id}")
+            return False
+
+    except ImportError:
+        logger.error("ChunkEmbedder not available")
+        return False
+    except Exception as e:
+        logger.error(f"Error embedding full-text: {e}")
+        return False
+
+
+def _download_fulltext_if_needed(
+    document_id: int,
+    db_manager: "DatabaseManager",
+    use_proxy: bool = True,
+    output_dir: Optional[Path] = None,
+) -> bool:
+    """
+    Attempt to download full-text PDF for a document.
+
+    Uses FullTextFinder to discover and download PDFs.
+
+    Args:
+        document_id: The document's database ID.
+        db_manager: Database manager instance.
+        use_proxy: Whether to use OpenAthens proxy if configured.
+        output_dir: Directory for PDF storage (uses default if None).
+
+    Returns:
+        True if full-text was obtained and stored, False otherwise.
+    """
+    try:
+        from bmlibrarian.discovery import download_pdf_for_document
+        from bmlibrarian.config import get_config
+
+        config = get_config()
+
+        # Get document metadata
+        with db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT doi, external_id, title, publication_date
+                    FROM public.document
+                    WHERE id = %s
+                    """,
+                    (document_id,),
+                )
+                row = cur.fetchone()
+
+                if not row:
+                    return False
+
+                doi, pmid, title, pub_date = row
+
+        document = {
+            "id": document_id,
+            "doi": doi,
+            "pmid": pmid,
+            "title": title,
+            "publication_date": pub_date,
+        }
+
+        # Determine output directory
+        if output_dir is None:
+            pdf_base_dir = config.get("pdf", {}).get("base_dir", "~/knowledgebase/pdf")
+            output_dir = Path(pdf_base_dir).expanduser()
+
+        # Get OpenAthens proxy URL if enabled
+        openathens_url = None
+        if use_proxy:
+            openathens_config = config.get("openathens", {})
+            if openathens_config.get("enabled", False):
+                openathens_url = openathens_config.get("institution_url")
+
+        # Attempt download
+        unpaywall_email = config.get("unpaywall_email")
+
+        result = download_pdf_for_document(
+            document=document,
+            output_dir=output_dir,
+            unpaywall_email=unpaywall_email,
+            openathens_proxy_url=openathens_url,
+            use_browser_fallback=True,
+        )
+
+        if result.success and result.file_path:
+            logger.info(f"Downloaded PDF for document {document_id}: {result.file_path}")
+
+            # Extract text from PDF and store in database
+            # This would require PDF text extraction - for now just return success
+            # The actual text extraction should be handled by a separate process
+            return True
+        else:
+            logger.warning(
+                f"Failed to download PDF for document {document_id}: {result.error_message}"
+            )
+            return False
+
+    except ImportError:
+        logger.error("Discovery module not available")
+        return False
+    except Exception as e:
+        logger.error(f"Error downloading full-text: {e}")
+        return False
+
+
+def _extract_thinking(response_content: str) -> Tuple[str, Optional[str]]:
+    """
+    Extract thinking/reasoning from model response.
+
+    Handles both `<think>` blocks (Qwen-style) and strips them from the answer.
+
+    Args:
+        response_content: Raw response from the model.
+
+    Returns:
+        Tuple of (answer_text, reasoning_text or None).
+    """
+    # Pattern for <think>...</think> blocks
+    think_pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+
+    match = think_pattern.search(response_content)
+    if match:
+        thinking = match.group(1).strip()
+        # Remove the thinking block from the answer
+        answer = think_pattern.sub("", response_content).strip()
+        return answer, thinking
+
+    return response_content.strip(), None
+
+
+def _generate_answer(
+    question: str,
+    context: str,
+    model: str,
+    temperature: float,
+    host: str,
+    use_thinking: bool = True,
+) -> Tuple[str, Optional[str], Optional[str]]:
+    """
+    Generate an answer using the LLM.
+
+    Args:
+        question: The question to answer.
+        context: Context text from document chunks or abstract.
+        model: LLM model name.
+        temperature: Model temperature.
+        host: Ollama server URL.
+        use_thinking: Whether to enable thinking mode for supported models.
+
+    Returns:
+        Tuple of (answer, reasoning, error_message).
+    """
+    system_prompt = """You are a biomedical research assistant helping to answer questions about scientific documents.
+
+Your task:
+1. Read the provided context from the document carefully
+2. Answer the question based ONLY on the information in the context
+3. If the context doesn't contain enough information to answer, say so clearly
+4. Be concise but complete in your answer
+5. Cite specific details from the context when relevant
+
+If you cannot answer the question from the given context, explain what information is missing."""
+
+    user_prompt = f"""Context from document:
+{context}
+
+Question: {question}
+
+Please answer the question based on the context provided."""
+
+    try:
+        client = ollama.Client(host=host)
+
+        # Check if model supports thinking
+        # DeepSeek-R1 and similar models support the think parameter
+        thinking_models = ["deepseek-r1", "qwen", "qwq"]
+        model_supports_thinking = any(tm in model.lower() for tm in thinking_models)
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+
+        # Use think parameter if supported
+        if use_thinking and model_supports_thinking:
+            response = client.chat(
+                model=model,
+                messages=messages,
+                options={"temperature": temperature},
+                think=True,
+            )
+
+            content = response["message"]["content"]
+            # Check for thinking field in response
+            thinking = response["message"].get("thinking")
+
+            if thinking:
+                return content.strip(), thinking.strip(), None
+
+            # Fallback: extract from content if not in separate field
+            answer, extracted_thinking = _extract_thinking(content)
+            return answer, extracted_thinking, None
+
+        else:
+            # Standard chat without thinking
+            response = client.chat(
+                model=model,
+                messages=messages,
+                options={"temperature": temperature},
+            )
+
+            content = response["message"]["content"]
+            # Still try to extract thinking blocks if present
+            answer, extracted_thinking = _extract_thinking(content)
+            return answer, extracted_thinking, None
+
+    except ollama.ResponseError as e:
+        error_msg = f"Ollama error: {e}"
+        logger.error(error_msg)
+        return "", None, error_msg
+    except Exception as e:
+        error_msg = f"LLM generation error: {e}"
+        logger.error(error_msg)
+        return "", None, error_msg
+
+
+def answer_from_document(
+    document_id: int,
+    question: str,
+    *,
+    use_fulltext: bool = True,
+    download_missing_fulltext: bool = True,
+    use_proxy: bool = True,
+    model: Optional[str] = None,
+    max_chunks: int = DEFAULT_MAX_CHUNKS,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    temperature: float = DEFAULT_TEMPERATURE,
+    ollama_host: Optional[str] = None,
+) -> SemanticSearchAnswer:
+    """
+    Answer a question about a specific document using semantic search and LLM.
+
+    This function provides a complete workflow for document Q&A:
+    1. Checks what text is available (full-text vs abstract)
+    2. Optionally downloads missing full-text
+    3. Generates embeddings if needed
+    4. Performs document-specific semantic search
+    5. Generates an answer using the LLM
+    6. Falls back to abstract if full-text unavailable
+
+    Args:
+        document_id: Database ID of the document to query.
+        question: The question to answer about the document.
+        use_fulltext: If True, prefer full-text over abstract. Default True.
+        download_missing_fulltext: If True and full-text missing, attempt download.
+            Default True.
+        use_proxy: If True and download needed, use OpenAthens proxy if configured.
+            Default True.
+        model: LLM model for answer generation. Uses config default if None.
+        max_chunks: Maximum number of context chunks to use. Default 5.
+        similarity_threshold: Minimum semantic similarity (0.0-1.0). Default 0.7.
+        temperature: LLM temperature for generation. Default 0.3.
+        ollama_host: Ollama server URL. Uses config default if None.
+
+    Returns:
+        SemanticSearchAnswer with the answer and metadata.
+
+    Example:
+        >>> result = answer_from_document(
+        ...     document_id=12345,
+        ...     question="What are the main findings?"
+        ... )
+        >>> if result.success:
+        ...     print(result.answer)
+        ... else:
+        ...     print(f"Error: {result.error_message}")
+    """
+    # Validate inputs
+    if not question or not question.strip():
+        return SemanticSearchAnswer(
+            answer="",
+            error=QAError.CONFIGURATION_ERROR,
+            error_message="Question cannot be empty",
+            document_id=document_id,
+            question=question,
+        )
+
+    # Get database manager
+    try:
+        from bmlibrarian.database import get_db_manager
+
+        db_manager = get_db_manager()
+    except ImportError:
+        return SemanticSearchAnswer(
+            answer="",
+            error=QAError.DATABASE_ERROR,
+            error_message="Database module not available",
+            document_id=document_id,
+            question=question,
+        )
+
+    # Get configuration
+    try:
+        from bmlibrarian.config import get_config
+
+        config = get_config()
+        qa_config = config.get("agents", {}).get("document_qa", {})
+        models_config = config.get("models", {})
+        ollama_config = config.get("ollama", {})
+    except ImportError:
+        qa_config = {}
+        models_config = {}
+        ollama_config = {}
+
+    # Resolve parameters from config (following BMLibrarian conventions)
+    model = model or models_config.get("document_qa_agent", DEFAULT_QA_MODEL)
+    ollama_host = ollama_host or ollama_config.get("host", DEFAULT_OLLAMA_HOST)
+
+    # Get document text status
+    status = _get_document_text_status(document_id, db_manager)
+    if status is None:
+        return SemanticSearchAnswer(
+            answer="",
+            error=QAError.DOCUMENT_NOT_FOUND,
+            error_message=f"Document with ID {document_id} not found",
+            document_id=document_id,
+            question=question,
+            model_used=model,
+        )
+
+    # Check if we have any text at all
+    if not status.has_any_text:
+        return SemanticSearchAnswer(
+            answer="",
+            error=QAError.NO_TEXT_AVAILABLE,
+            error_message=f"Document '{status.title}' has no abstract or full-text",
+            document_id=document_id,
+            question=question,
+            model_used=model,
+        )
+
+    # Determine strategy
+    chunks: List[ChunkContext] = []
+    source = AnswerSource.ABSTRACT
+    context_text = ""
+
+    if use_fulltext:
+        # Try to use full-text
+        if not status.has_fulltext and download_missing_fulltext:
+            # Attempt to download
+            logger.info(f"Attempting to download full-text for document {document_id}")
+            if _download_fulltext_if_needed(document_id, db_manager, use_proxy):
+                # Refresh status after download
+                status = _get_document_text_status(document_id, db_manager)
+
+        if status.has_fulltext:
+            # Ensure embeddings exist
+            if not status.has_fulltext_chunks:
+                logger.info(f"Generating embeddings for document {document_id}")
+                if _embed_fulltext_if_needed(document_id, db_manager):
+                    status.has_fulltext_chunks = True
+
+            if status.has_fulltext_chunks:
+                # Perform full-text semantic search
+                chunks = _semantic_search_fulltext(
+                    document_id,
+                    question,
+                    similarity_threshold,
+                    max_chunks,
+                    db_manager,
+                )
+                if chunks:
+                    source = AnswerSource.FULLTEXT_SEMANTIC
+                    context_text = "\n\n---\n\n".join(
+                        f"[Chunk {c.chunk_no + 1}, Score: {c.score:.2f}]\n{c.text}"
+                        for c in chunks
+                    )
+                    logger.info(
+                        f"Using {len(chunks)} full-text chunks for document {document_id}"
+                    )
+
+    # Fallback to abstract if no full-text chunks
+    if not chunks:
+        if status.has_abstract:
+            abstract = _get_document_abstract(document_id, db_manager)
+            if abstract and len(abstract) >= MIN_ABSTRACT_LENGTH:
+                source = AnswerSource.ABSTRACT
+                context_text = abstract
+                # Create a pseudo-chunk for tracking
+                chunks = [
+                    ChunkContext(
+                        chunk_no=0,
+                        text=abstract,
+                        score=1.0,
+                    )
+                ]
+                logger.info(f"Using abstract for document {document_id}")
+            else:
+                return SemanticSearchAnswer(
+                    answer="",
+                    error=QAError.NO_TEXT_AVAILABLE,
+                    error_message="Abstract is too short or unavailable",
+                    document_id=document_id,
+                    question=question,
+                    model_used=model,
+                )
+        else:
+            return SemanticSearchAnswer(
+                answer="",
+                error=QAError.NO_FULLTEXT,
+                error_message="No full-text available and no abstract fallback",
+                document_id=document_id,
+                question=question,
+                model_used=model,
+            )
+
+    # Generate answer
+    answer, reasoning, error = _generate_answer(
+        question=question,
+        context=context_text,
+        model=model,
+        temperature=temperature,
+        host=ollama_host,
+    )
+
+    if error:
+        return SemanticSearchAnswer(
+            answer="",
+            error=QAError.LLM_ERROR,
+            error_message=error,
+            source=source,
+            chunks_used=chunks,
+            document_id=document_id,
+            question=question,
+            model_used=model,
+        )
+
+    return SemanticSearchAnswer(
+        answer=answer,
+        reasoning=reasoning,
+        source=source,
+        chunks_used=chunks,
+        document_id=document_id,
+        question=question,
+        model_used=model,
+    )

--- a/tests/qa/__init__.py
+++ b/tests/qa/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the document Q&A module."""

--- a/tests/qa/test_data_types.py
+++ b/tests/qa/test_data_types.py
@@ -1,0 +1,206 @@
+"""Tests for qa/data_types.py."""
+
+import pytest
+from bmlibrarian.qa.data_types import (
+    AnswerSource,
+    QAError,
+    ChunkContext,
+    SemanticSearchAnswer,
+    DocumentTextStatus,
+)
+
+
+class TestAnswerSource:
+    """Tests for AnswerSource enum."""
+
+    def test_values(self):
+        """Test that all expected values exist."""
+        assert AnswerSource.FULLTEXT_SEMANTIC.value == "fulltext_semantic"
+        assert AnswerSource.ABSTRACT.value == "abstract"
+
+    def test_enum_members(self):
+        """Test enum has exactly the expected members."""
+        members = list(AnswerSource)
+        assert len(members) == 2
+
+
+class TestQAError:
+    """Tests for QAError enum."""
+
+    def test_all_errors_have_descriptions(self):
+        """Test that all errors have descriptions."""
+        for error in QAError:
+            assert error.description, f"{error.name} has no description"
+            assert isinstance(error.description, str)
+
+    def test_specific_descriptions(self):
+        """Test specific error descriptions."""
+        assert "not found" in QAError.DOCUMENT_NOT_FOUND.description.lower()
+        assert "download" in QAError.DOWNLOAD_FAILED.description.lower()
+        assert "llm" in QAError.LLM_ERROR.description.lower()
+
+
+class TestChunkContext:
+    """Tests for ChunkContext dataclass."""
+
+    def test_basic_creation(self):
+        """Test creating a ChunkContext."""
+        chunk = ChunkContext(chunk_no=0, text="Test text", score=0.85)
+        assert chunk.chunk_no == 0
+        assert chunk.text == "Test text"
+        assert chunk.score == 0.85
+        assert chunk.chunk_id is None
+
+    def test_with_chunk_id(self):
+        """Test creating with chunk_id."""
+        chunk = ChunkContext(chunk_no=1, text="More text", score=0.75, chunk_id=123)
+        assert chunk.chunk_id == 123
+
+    def test_repr_short_text(self):
+        """Test repr with short text."""
+        chunk = ChunkContext(chunk_no=0, text="Short", score=0.9)
+        repr_str = repr(chunk)
+        assert "ChunkContext" in repr_str
+        assert "Short" in repr_str
+        assert "0.900" in repr_str
+
+    def test_repr_long_text(self):
+        """Test repr truncates long text."""
+        long_text = "A" * 100
+        chunk = ChunkContext(chunk_no=0, text=long_text, score=0.5)
+        repr_str = repr(chunk)
+        assert "..." in repr_str
+        assert len(repr_str) < len(long_text) + 50
+
+
+class TestDocumentTextStatus:
+    """Tests for DocumentTextStatus dataclass."""
+
+    def test_basic_creation(self):
+        """Test creating a DocumentTextStatus."""
+        status = DocumentTextStatus(document_id=123)
+        assert status.document_id == 123
+        assert status.has_abstract is False
+        assert status.has_fulltext is False
+
+    def test_can_use_fulltext_semantic(self):
+        """Test fulltext semantic availability check."""
+        # Neither fulltext nor chunks
+        status = DocumentTextStatus(document_id=1)
+        assert status.can_use_fulltext_semantic is False
+
+        # Has fulltext but no chunks
+        status = DocumentTextStatus(document_id=1, has_fulltext=True)
+        assert status.can_use_fulltext_semantic is False
+
+        # Has both
+        status = DocumentTextStatus(
+            document_id=1, has_fulltext=True, has_fulltext_chunks=True
+        )
+        assert status.can_use_fulltext_semantic is True
+
+    def test_can_use_abstract_semantic(self):
+        """Test abstract semantic availability check."""
+        status = DocumentTextStatus(
+            document_id=1, has_abstract=True, has_abstract_embeddings=True
+        )
+        assert status.can_use_abstract_semantic is True
+
+        status = DocumentTextStatus(document_id=1, has_abstract=True)
+        assert status.can_use_abstract_semantic is False
+
+    def test_has_any_text(self):
+        """Test any text availability check."""
+        status = DocumentTextStatus(document_id=1)
+        assert status.has_any_text is False
+
+        status = DocumentTextStatus(document_id=1, has_abstract=True)
+        assert status.has_any_text is True
+
+        status = DocumentTextStatus(document_id=1, has_fulltext=True)
+        assert status.has_any_text is True
+
+
+class TestSemanticSearchAnswer:
+    """Tests for SemanticSearchAnswer dataclass."""
+
+    def test_successful_answer(self):
+        """Test creating a successful answer."""
+        answer = SemanticSearchAnswer(
+            answer="The study found positive results.",
+            source=AnswerSource.FULLTEXT_SEMANTIC,
+            model_used="gpt-oss:20b",
+            document_id=123,
+            question="What were the results?",
+        )
+        assert answer.success is True
+        assert answer.error is None
+        assert answer.used_fulltext is True
+
+    def test_error_answer(self):
+        """Test creating an error answer."""
+        answer = SemanticSearchAnswer(
+            answer="",
+            error=QAError.DOCUMENT_NOT_FOUND,
+            error_message="Document 999 not found",
+            document_id=999,
+            question="What is this?",
+        )
+        assert answer.success is False
+        assert answer.error == QAError.DOCUMENT_NOT_FOUND
+
+    def test_with_reasoning(self):
+        """Test answer with thinking/reasoning."""
+        answer = SemanticSearchAnswer(
+            answer="The methodology was sound.",
+            reasoning="First, I analyzed the methods section...",
+            source=AnswerSource.FULLTEXT_SEMANTIC,
+        )
+        assert answer.reasoning is not None
+        assert "analyzed" in answer.reasoning
+
+    def test_to_dict(self):
+        """Test serialization to dictionary."""
+        chunks = [ChunkContext(chunk_no=0, text="Context text", score=0.8)]
+        answer = SemanticSearchAnswer(
+            answer="Result",
+            source=AnswerSource.ABSTRACT,
+            chunks_used=chunks,
+            model_used="test-model",
+            document_id=1,
+            question="Test?",
+        )
+
+        d = answer.to_dict()
+        assert d["answer"] == "Result"
+        assert d["source"] == "abstract"
+        assert d["success"] is True
+        assert len(d["chunks_used"]) == 1
+        assert d["chunks_used"][0]["score"] == 0.8
+
+    def test_repr_success(self):
+        """Test repr for successful answer."""
+        answer = SemanticSearchAnswer(
+            answer="Short answer",
+            source=AnswerSource.ABSTRACT,
+        )
+        repr_str = repr(answer)
+        assert "SemanticSearchAnswer" in repr_str
+        assert "abstract" in repr_str
+
+    def test_repr_error(self):
+        """Test repr for error answer."""
+        answer = SemanticSearchAnswer(
+            answer="",
+            error=QAError.LLM_ERROR,
+            error_message="Model failed",
+        )
+        repr_str = repr(answer)
+        assert "error=llm_error" in repr_str
+
+    def test_long_answer_repr_truncation(self):
+        """Test that long answers are truncated in repr."""
+        long_answer = "X" * 200
+        answer = SemanticSearchAnswer(answer=long_answer)
+        repr_str = repr(answer)
+        assert "..." in repr_str


### PR DESCRIPTION
## Summary

Add `answer_from_document()` - a high-level function for answering questions about specific documents in the knowledge base using semantic search and LLM inference.

- Implements complete Q&A workflow: text availability check → optional PDF download → embedding → semantic search → LLM answer generation
- Creates document-specific SQL functions that filter at query level (not post-filtering) for efficient single-document search
- Supports thinking models (DeepSeek-R1, Qwen) with automatic reasoning extraction
- Provides structured error handling via `QAError` enum with descriptions
- Falls back gracefully from full-text to abstract when needed

## Changes

### New Module: `src/bmlibrarian/qa/`
- **`data_types.py`**: Type-safe dataclasses (`SemanticSearchAnswer`, `ChunkContext`, `DocumentTextStatus`) and enums (`AnswerSource`, `QAError`)
- **`document_qa.py`**: Main `answer_from_document()` function with helper functions for each workflow step

### SQL Migration: `migrations/018_create_document_specific_search_functions.sql`
- `semantic_search_document()` - Search abstract chunks by document_id
- `semantic.chunksearch_document()` - Search full-text chunks by document_id
- `get_document_text_status()` - Check text/embedding availability
- `has_abstract_embeddings()` - Check if abstract embeddings exist

### Configuration
- Added `document_qa` to `VALID_SETTINGS_CATEGORIES`
- Added `document_qa_agent` model entry
- Added `agents.document_qa` config section with all parameters

### Documentation
- User guide: `doc/users/document_qa_guide.md`
- Developer docs: `doc/developers/document_qa_system.md`

### Tests
- 19 unit tests for data types (all passing)

## Usage Example

```python
from bmlibrarian.qa import answer_from_document

result = answer_from_document(
    document_id=12345,
    question="What are the main findings of this study?"
)

if result.success:
    print(result.answer)
    if result.reasoning:  # For thinking models
        print(f"Reasoning: {result.reasoning}")
else:
    print(f"Error: {result.error_message}")
Test Plan
 All 19 data type unit tests passing
 Module imports successfully
 Integration test with real document (requires database)
 Test with thinking model (DeepSeek-R1)
 Apply SQL migration to database
Golden Rules Compliance
 Input validation (question not empty, document exists)
 No magic numbers (all constants defined)
 No hardcoded paths (uses config)
 Ollama communication via ollama library
 Database via DatabaseManager
 All parameters have type hints
 All functions have docstrings
 All errors logged and reported
 Documentation in doc/users and doc/developers