### PR TITLE
Add find PDF button to document cards

### DIFF
--- a/src/bmlibrarian/config.py
+++ b/src/bmlibrarian/config.py
@@ -56,7 +56,8 @@ class UserContext:
 # Must match bmlsettings schema constraints
 VALID_SETTINGS_CATEGORIES = frozenset([
     'models', 'ollama', 'agents', 'database', 'search',
-    'query_generation', 'gui', 'openathens', 'pdf', 'general', 'document_qa'
+    'query_generation', 'gui', 'openathens', 'pdf', 'general', 'document_qa',
+    'discovery'
 ])
 
 
@@ -582,6 +583,14 @@ DEFAULT_CONFIG = {
         "auto_login": True,  # Automatically login on startup if session expired
         "login_timeout": 300,  # Maximum seconds to wait for login completion (default: 300 = 5 minutes)
         "headless": False  # Run browser in headless mode for login (False = visible for 2FA)
+    },
+    "discovery": {
+        "timeout": 30,  # HTTP request timeout in seconds
+        "prefer_open_access": True,  # Prioritize open access sources
+        "use_browser_fallback": True,  # Use browser automation when HTTP fails (Cloudflare bypass)
+        "browser_headless": True,  # Run browser in headless mode for PDF downloads
+        "browser_timeout": 60000,  # Browser operation timeout in milliseconds
+        "use_openathens_proxy": False  # Use OpenAthens proxy as last resort for paywalled content
     }
 }
 
@@ -1141,6 +1150,21 @@ def get_openathens_config() -> Dict[str, Any]:
         - headless (bool): Run browser in headless mode
     """
     return get_config().get("openathens", DEFAULT_CONFIG["openathens"])
+
+
+def get_discovery_config() -> Dict[str, Any]:
+    """Get PDF discovery configuration.
+
+    Returns:
+        Dictionary with discovery configuration:
+        - timeout (int): HTTP request timeout in seconds
+        - prefer_open_access (bool): Prioritize open access sources
+        - use_browser_fallback (bool): Use browser when HTTP fails
+        - browser_headless (bool): Run browser in headless mode
+        - browser_timeout (int): Browser timeout in milliseconds
+        - use_openathens_proxy (bool): Use OpenAthens as last resort
+    """
+    return get_config().get("discovery", DEFAULT_CONFIG["discovery"])
 
 
 def get_paper_weight_config() -> Dict[str, Any]:

--- a/src/bmlibrarian/gui/qt/resources/constants.py
+++ b/src/bmlibrarian/gui/qt/resources/constants.py
@@ -23,6 +23,13 @@ class PDFButtonColors:
     UPLOAD_BG: Final[str] = "#388E3C"  # Green - Upload manual
     UPLOAD_BG_HOVER: Final[str] = "#2E7D32"  # Darker green
 
+    FIND_BG: Final[str] = "#8e44ad"  # Purple - Find PDF via discovery
+    FIND_BG_HOVER: Final[str] = "#9b59b6"  # Lighter purple
+    FIND_BG_PRESSED: Final[str] = "#7d3c98"  # Darker purple
+
+    DISABLED_BG: Final[str] = "#bdc3c7"  # Gray - Disabled state
+    DISABLED_TEXT: Final[str] = "#7f8c8d"  # Muted gray text
+
     TEXT_COLOR: Final[str] = "white"
 
 
@@ -120,6 +127,7 @@ class PDFOperationSettings:
     RETRY_ATTEMPTS: Final[int] = 3  # Number of retry attempts for failed operations
     RETRY_DELAY_MS: Final[int] = 1000  # Delay between retries in milliseconds
     DOWNLOAD_TIMEOUT_SECONDS: Final[int] = 30  # Timeout for PDF downloads
+    BUTTON_RESET_DELAY_MS: Final[int] = 3000  # Delay before resetting Find PDF button after failure
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add "Find PDF" button to document cards that triggers PDF discovery workflow
- Button appears next to Upload button when no local PDF exists and the document has discoverable identifiers (DOI, PMID, or pdf_url)
- Add user-configurable OpenAthens proxy toggle in the config GUI for PDF discovery

## Changes

### Document Card Factory (`qt_document_card_factory.py`)
- Add new `pdf_discovered` signal to `PDFButtonWidget`
- Add `_create_find_pdf_button()` method for purple "🔍 Find PDF" button
- Add `_handle_find_pdf_click()` with visual feedback (Searching.../Found/Not Found)
- Add `_execute_pdf_discovery()` using `FullTextFinder` to search:
  - PMC (PubMed Central)
  - Unpaywall
  - DOI resolution
  - Direct URL
  - OpenAthens (if enabled in config)
- Automatic database update with `pdf_filename` after successful download

### Configuration (`config.py`)
- Add new `discovery` section to `DEFAULT_CONFIG`:
  - `timeout`: HTTP request timeout (default: 30s)
  - `prefer_open_access`: Prioritize OA sources (default: True)
  - `use_browser_fallback`: Browser automation for protected sites (default: True)
  - `browser_headless`: Headless browser mode (default: True)
  - `browser_timeout`: Browser timeout in ms (default: 60000)
  - `use_openathens_proxy`: Enable OpenAthens as last resort (default: False)
- Add `'discovery'` to `VALID_SETTINGS_CATEGORIES` for database storage
- Add `get_discovery_config()` convenience function

### Config GUI (`general_settings_widget.py`)
- Add "PDF Discovery Settings" group with toggles for all discovery options
- User-configurable OpenAthens proxy toggle for paywalled content

### Constants (`constants.py`)
- Add `PDFButtonColors.FIND_*` constants for Find PDF button styling
- Add `PDFButtonColors.DISABLED_*` constants for disabled state
- Add `PDFOperationSettings.BUTTON_RESET_DELAY_MS` constant

## Test plan

- [ ] Launch config GUI (`uv run python bmlibrarian_config_gui.py`) and verify new "PDF Discovery Settings" group appears in General Settings
- [ ] Toggle "Use OpenAthens for Discovery" and save configuration
- [ ] Load research GUI and search for documents
- [ ] For documents without local PDFs, verify "🔍 Find PDF" button appears next to Upload
- [ ] Click "Find PDF" and verify button shows "Searching..." then "✓ Found" or "✗ Not Found"
- [ ] Verify successful discovery transitions Upload button to View button
- [ ] Verify database is updated with pdf_filename after successful download