### PR TITLE
Fix PRISMA2020 plugin document processing workflow

### DIFF
--- a/src/bmlibrarian/agents/prisma2020_agent.py
+++ b/src/bmlibrarian/agents/prisma2020_agent.py
@@ -48,6 +48,7 @@ SUMMARY_SEPARATOR_WIDTH = 80  # Width of separator lines in formatted summaries
 SEMANTIC_SEARCH_THRESHOLD = 0.5  # Minimum similarity for relevant chunks
 SEMANTIC_SEARCH_MAX_CHUNKS = 5  # Maximum chunks to retrieve per item
 LOW_SCORE_THRESHOLD = 1.0  # Items scoring at or below this may benefit from semantic search
+SEMANTIC_CONTEXT_MAX_CHARS = 4000  # Max characters of context to include in re-assessment prompt
 
 # PRISMA item queries for semantic search
 # Maps PRISMA field names to targeted search queries
@@ -1428,7 +1429,7 @@ Original Score: {original_score}/2.0
 Original Explanation: {original_explanation}
 
 Additional Context from Full Text:
-{additional_context[:4000]}
+{additional_context[:SEMANTIC_CONTEXT_MAX_CHARS]}
 
 INSTRUCTIONS:
 Review the additional context and determine if your original assessment should be updated.

--- a/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/prisma2020_lab_tab.py
+++ b/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/prisma2020_lab_tab.py
@@ -288,9 +288,15 @@ class PRISMA2020LabTabWidget(QWidget, IDocumentReceiver):
                 self.worker.terminate()
                 self.worker.wait()
 
-            self.worker = PRISMA2020AssessmentWorker(self.prisma_agent, self.current_document)
+            # Create worker with semantic search enabled
+            self.worker = PRISMA2020AssessmentWorker(
+                self.prisma_agent,
+                self.current_document,
+                use_semantic_search=True  # Enable enhanced assessment
+            )
             self.worker.result_ready.connect(self._on_assessment_complete)
             self.worker.error_occurred.connect(self._on_assessment_error)
+            self.worker.status_update.connect(self._on_status_update)
             self.worker.finished.connect(lambda: self.ui.load_button.setEnabled(True))
             self.worker.start()
 
@@ -400,6 +406,11 @@ class PRISMA2020LabTabWidget(QWidget, IDocumentReceiver):
             f"PRISMA 2020 assessment failed: {error_msg}"
         )
         self._update_status("Assessment failed", SECTION_COLORS['error'])
+
+    def _on_status_update(self, message: str) -> None:
+        """Handle status update from worker thread."""
+        logger.debug(f"Worker status: {message}")
+        self._update_status(message, SECTION_COLORS['info'])
 
     def _display_assessment(self) -> None:
         """Display PRISMA 2020 assessment results in tabular format."""

--- a/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/worker.py
+++ b/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/worker.py
@@ -71,13 +71,17 @@ class PRISMA2020AssessmentWorker(QThread):
 
         Emits result_ready signal on success or error_occurred on failure.
         """
-        doc_id = self.document.get('id', 'unknown')
+        doc_id = self.document.get('id')
         logger.info(f"Starting PRISMA 2020 assessment for document {doc_id}")
 
         try:
-            # Step 1: Check document status
-            self.status_update.emit("Checking document status...")
-            status = self.prisma_agent.get_document_text_status(doc_id)
+            # Step 1: Check document status (only if we have a valid document ID)
+            status = None
+            if doc_id is not None and isinstance(doc_id, int):
+                self.status_update.emit("Checking document status...")
+                status = self.prisma_agent.get_document_text_status(doc_id)
+            else:
+                logger.warning(f"Invalid document ID: {doc_id}, skipping status check")
 
             if status:
                 logger.info(

--- a/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/worker.py
+++ b/src/bmlibrarian/gui/qt/plugins/prisma2020_lab/worker.py
@@ -3,6 +3,11 @@ Worker thread for PRISMA 2020 assessment.
 
 Executes PRISMA 2020 compliance assessment in a background thread
 to prevent UI blocking during long-running LLM operations.
+
+Supports enhanced assessment with semantic search:
+1. Checks if document has full-text embeddings
+2. Creates embeddings if needed and full-text is available
+3. Uses two-pass assessment with semantic search for low-scoring items
 """
 
 import logging
@@ -21,29 +26,48 @@ class PRISMA2020AssessmentWorker(QThread):
     """
     Worker thread for PRISMA 2020 assessment to prevent UI blocking.
 
+    This worker implements an enhanced assessment workflow:
+    1. Check document text status (abstract, full-text, embeddings)
+    2. If full-text exists but no embeddings, create them
+    3. Run two-pass PRISMA assessment with semantic search for unclear items
+
     Signals:
         result_ready: Emitted when assessment completes successfully
         error_occurred: Emitted when assessment fails with error message
+        status_update: Emitted with progress messages during processing
     """
 
     result_ready = Signal(object)  # PRISMA2020Assessment object
     error_occurred = Signal(str)
+    status_update = Signal(str)  # Progress messages
 
-    def __init__(self, prisma_agent: PRISMA2020Agent, document: Dict[str, Any]):
+    def __init__(
+        self,
+        prisma_agent: PRISMA2020Agent,
+        document: Dict[str, Any],
+        use_semantic_search: bool = True
+    ):
         """
         Initialize worker thread.
 
         Args:
             prisma_agent: PRISMA2020Agent instance to use for assessment
             document: Document dictionary with at least 'id', 'title', 'abstract' fields
+            use_semantic_search: If True, use enhanced assessment with semantic search
         """
         super().__init__()
         self.prisma_agent = prisma_agent
         self.document = document
+        self.use_semantic_search = use_semantic_search
 
     def run(self) -> None:
         """
         Execute PRISMA 2020 assessment in background thread.
+
+        Workflow:
+        1. Check document text status
+        2. Embed full-text if available but not yet embedded
+        3. Run assessment (enhanced with semantic search if available)
 
         Emits result_ready signal on success or error_occurred on failure.
         """
@@ -51,13 +75,50 @@ class PRISMA2020AssessmentWorker(QThread):
         logger.info(f"Starting PRISMA 2020 assessment for document {doc_id}")
 
         try:
-            assessment = self.prisma_agent.assess_prisma_compliance(
-                document=self.document,
-                min_confidence=MIN_CONFIDENCE_LAB_MODE  # Show all assessments in lab mode
-            )
-            if assessment:
+            # Step 1: Check document status
+            self.status_update.emit("Checking document status...")
+            status = self.prisma_agent.get_document_text_status(doc_id)
+
+            if status:
                 logger.info(
-                    f"PRISMA 2020 assessment completed for document {doc_id} - "
+                    f"Document {doc_id} status: "
+                    f"abstract={status.has_abstract} ({status.abstract_length} chars), "
+                    f"fulltext={status.has_fulltext} ({status.fulltext_length} chars), "
+                    f"chunks={status.has_fulltext_chunks}"
+                )
+
+                # Step 2: Embed if needed
+                if self.use_semantic_search and status.has_fulltext and not status.has_fulltext_chunks:
+                    self.status_update.emit("Creating full-text embeddings...")
+                    logger.info(f"Embedding full-text for document {doc_id}")
+
+                    embedding_success = self.prisma_agent.ensure_document_embedded(doc_id)
+                    if embedding_success:
+                        self.status_update.emit("Embeddings created successfully")
+                        logger.info(f"Successfully embedded document {doc_id}")
+                    else:
+                        self.status_update.emit("Embedding failed, continuing with basic assessment")
+                        logger.warning(f"Failed to embed document {doc_id}")
+
+            # Step 3: Run assessment
+            if self.use_semantic_search:
+                self.status_update.emit("Running enhanced PRISMA assessment...")
+                assessment = self.prisma_agent.assess_prisma_compliance_with_semantic_search(
+                    document=self.document,
+                    min_confidence=MIN_CONFIDENCE_LAB_MODE,
+                    re_assess_low_scores=True
+                )
+            else:
+                self.status_update.emit("Running PRISMA assessment...")
+                assessment = self.prisma_agent.assess_prisma_compliance(
+                    document=self.document,
+                    min_confidence=MIN_CONFIDENCE_LAB_MODE
+                )
+
+            if assessment:
+                enhanced_note = " (enhanced)" if "[Enhanced" in assessment.suitability_rationale else ""
+                logger.info(
+                    f"PRISMA 2020 assessment{enhanced_note} completed for document {doc_id} - "
                     f"{assessment.overall_compliance_percentage:.1f}% compliance"
                 )
                 self.result_ready.emit(assessment)
@@ -69,6 +130,7 @@ class PRISMA2020AssessmentWorker(QThread):
                     "PRISMA 2020 assessment returned no results "
                     "(document may not be a systematic review)"
                 )
+
         except Exception as e:
             logger.error(
                 f"PRISMA 2020 assessment failed for document {doc_id}: {e}",


### PR DESCRIPTION
Now let me generate the PR message:

## Summary
- Implement two-pass PRISMA 2020 assessment with semantic search for enhanced document analysis
- When a document is sent from context menu, the plugin now: checks embedding status → embeds if needed → processes with semantic search for unclear items
- Low-scoring PRISMA items (≤1.0) are re-assessed using relevant full-text chunks from semantic search

## Test plan
- [ ] Load a systematic review document via the PRISMA 2020 Lab plugin
- [ ] Verify status messages show: "Checking document status...", "Creating full-text embeddings..." (if needed), "Running enhanced PRISMA assessment..."
- [ ] Confirm low-scoring items show "[Updated from X after full-text analysis]" in their explanations when improved
- [ ] Test with a document that has no full-text (should fall back to basic assessment)
- [ ] Test with a document that already has embeddings (should skip embedding step)
- [ ] Verify assessment completes successfully and shows compliance percentage

## Changes

### PRISMA2020Agent (`src/bmlibrarian/agents/prisma2020_agent.py`)

**New constants:**
- `SEMANTIC_SEARCH_THRESHOLD` (0.5): Minimum similarity for relevant chunks
- `SEMANTIC_SEARCH_MAX_CHUNKS` (5): Maximum chunks to retrieve per item
- `LOW_SCORE_THRESHOLD` (1.0): Items at or below this are candidates for re-assessment
- `SEMANTIC_CONTEXT_MAX_CHARS` (4000): Max characters for context in prompts
- `PRISMA_ITEM_QUERIES`: Maps 16 PRISMA fields to targeted search queries

**New dataclass:**
- `DocumentTextStatus`: Tracks document text availability (abstract, full-text, embeddings)

**New methods:**
- `get_document_text_status(document_id)`: Check if document has abstract, full-text, and full-text embeddings
- `ensure_document_embedded(document_id)`: Auto-embed full-text using ChunkEmbedder if not already embedded
- `_semantic_search_document(document_id, query)`: Perform semantic search within a specific document using `semantic.chunksearch_document()`
- `_re_assess_item_with_context(...)`: Re-assess a single PRISMA item with additional context
- `assess_prisma_compliance_with_semantic_search(document)`: **Main new workflow** - two-pass assessment

### Worker (`src/bmlibrarian/gui/qt/plugins/prisma2020_lab/worker.py`)

- Added `status_update` signal for progress messages to UI
- Added `use_semantic_search` parameter (default: True)
- Enhanced workflow: check status → embed if needed → run enhanced assessment
- Added validation for document ID before status check

### Plugin Tab (`src/bmlibrarian/gui/qt/plugins/prisma2020_lab/prisma2020_lab_tab.py`)

- Connected to new `status_update` signal
- Added `_on_status_update` handler to display progress
- Enabled semantic search by default

## Follow-up items
- [ ] Add unit tests for new methods (`test_prisma2020_agent.py`)
- [ ] Add documentation (`doc/users/prisma2020_semantic_search_guide.md`)
- [ ] Add developer documentation (`doc/developers/prisma2020_semantic_search.md`)

