### PR TITLE
Fix thread cleanup in PDF button widget

### DIFF
--- a/src/bmlibrarian/gui/qt/resources/constants.py
+++ b/src/bmlibrarian/gui/qt/resources/constants.py
@@ -144,6 +144,8 @@ class PDFOperationSettings:
     RETRY_DELAY_MS: Final[int] = 1000  # Delay between retries in milliseconds
     DOWNLOAD_TIMEOUT_SECONDS: Final[int] = 30  # Timeout for PDF downloads
     BUTTON_RESET_DELAY_MS: Final[int] = 3000  # Delay before resetting Find PDF button after failure
+    THREAD_GRACEFUL_SHUTDOWN_MS: Final[int] = 5000  # Wait timeout for graceful thread shutdown
+    THREAD_TERMINATE_CLEANUP_MS: Final[int] = 1000  # Brief wait after forced termination
 
 
 # ============================================================================

--- a/src/bmlibrarian/utils/validation.py
+++ b/src/bmlibrarian/utils/validation.py
@@ -184,10 +184,13 @@ def validate_discovery_config(config: Dict[str, Any], strict: bool = False) -> b
         - prefer_open_access (optional): Prefer open access sources (boolean)
         - use_browser_fallback (optional): Use browser for protected PDFs (boolean)
         - browser_headless (optional): Run browser in headless mode (boolean)
+        - skip_resolvers (optional): List of resolvers to skip (list of strings)
+        - use_openathens_proxy (optional): Use OpenAthens proxy as last resort (boolean)
     """
     optional = [
         'timeout', 'browser_timeout', 'prefer_open_access',
-        'use_browser_fallback', 'browser_headless', 'skip_resolvers'
+        'use_browser_fallback', 'browser_headless', 'skip_resolvers',
+        'use_openathens_proxy'
     ]
 
     if not validate_config_dict(config, [], optional, strict):
@@ -208,7 +211,7 @@ def validate_discovery_config(config: Dict[str, Any], strict: bool = False) -> b
             return False
 
     # Validate boolean fields
-    for bool_key in ['prefer_open_access', 'use_browser_fallback', 'browser_headless']:
+    for bool_key in ['prefer_open_access', 'use_browser_fallback', 'browser_headless', 'use_openathens_proxy']:
         if bool_key in config and not isinstance(config[bool_key], bool):
             msg = f"Invalid {bool_key}: must be a boolean"
             if strict:


### PR DESCRIPTION
## Summary

This PR addresses the review issues identified in PR #177:

### 1. Thread Cleanup (Medium Priority) ✅

**Problem:** The `_cleanup_fetch_worker()` method in `PDFButtonWidget` was missing proper timeout handling when aborting threads.

**Solution:**
- Extended graceful shutdown timeout from 1 second to 5 seconds (configurable via `THREAD_GRACEFUL_SHUTDOWN_MS`)
- Added `terminate()` call if thread doesn't respond to abort within timeout
- Added brief 1-second wait after forced termination for cleanup (configurable via `THREAD_TERMINATE_CLEANUP_MS`)
- Added warning log when forced termination occurs
- Moved magic numbers to constants in `PDFOperationSettings` class per golden rules

**Files changed:**
- `src/bmlibrarian/gui/qt/qt_document_card_factory.py`
- `src/bmlibrarian/gui/qt/resources/constants.py`

### 2. IPv6 Validation Gap (Low Priority) ✅

**Problem:** The private network validation in `validate_openathens_url()` only handled IPv4 private addresses.

**Solution:**
- Added `is_private_ip_address()` helper function using Python's `ipaddress` module
- Now validates both IPv4 and IPv6 private/reserved addresses:
  - **IPv4:** 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16
  - **IPv6:** fc00::/7 (unique local), fe80::/10 (link-local), ::1 (loopback)
- Added 13 comprehensive test cases covering all IPv4/IPv6 scenarios

**Files changed:**
- `src/bmlibrarian/utils/url_validation.py`
- `tests/test_openathens_validation.py`

### 3. Configuration Default Consistency ✅

**Problem:** The `use_openathens_proxy` field in `DEFAULT_CONFIG["discovery"]` was not included in the validation function.

**Solution:**
- Added `use_openathens_proxy` to the optional fields list in `validate_discovery_config()`
- Added `use_openathens_proxy` to the boolean validation loop

**Files changed:**
- `src/bmlibrarian/utils/validation.py`

## Test Plan

- [x] All 32 existing OpenAthens validation tests pass
- [x] New IPv6 validation tests pass:
  - `test_ipv4_private_10_rejected`
  - `test_ipv4_private_172_rejected`
  - `test_ipv4_private_192_rejected`
  - `test_ipv4_loopback_rejected`
  - `test_ipv6_loopback_rejected`
  - `test_ipv6_unique_local_rejected`
  - `test_ipv6_link_local_rejected`
  - `test_public_ipv4_accepted`
  - `test_public_ipv6_accepted`
  - `test_is_private_ip_address_helper`
- [x] Verified constants import correctly
- [x] No regression in existing functionality
