### PR TITLE
Refactor CLI weight override logic

### DIFF
--- a/src/bmlibrarian/agents/systematic_review/data_models.py
+++ b/src/bmlibrarian/agents/systematic_review/data_models.py
@@ -63,14 +63,39 @@ WEIGHT_SUM_TOLERANCE = 0.01  # Allow for floating point precision issues
 DEFAULT_MAX_RESULTS = 500
 
 # Default scoring weights (balanced profile - sum to 1.0)
-# These weights combine both Cochrane and BMLibrarian dimensions
+# These weights combine both Cochrane and BMLibrarian dimensions for comprehensive
+# evidence assessment in systematic reviews.
+
+# Evidence relevance to research question (primary factor in literature review)
+# Highest weight as irrelevant papers provide no value regardless of quality
 DEFAULT_WEIGHT_RELEVANCE = 0.25
+
+# Overall study design and methodology quality (Cochrane core dimension)
+# Second-highest weight reflecting importance of study design hierarchy
 DEFAULT_WEIGHT_STUDY_QUALITY = 0.20
+
+# Methodological rigor assessment (Cochrane dimension)
+# Evaluates adherence to best practices in study execution
 DEFAULT_WEIGHT_METHODOLOGICAL_RIGOR = 0.15
+
+# Sample size adequacy (Cochrane dimension)
+# Lower weight as large samples don't guarantee quality
 DEFAULT_WEIGHT_SAMPLE_SIZE = 0.05
+
+# Publication recency (general dimension)
+# Moderate weight to balance recent findings with established evidence
 DEFAULT_WEIGHT_RECENCY = 0.10
+
+# Replication and reproducibility status (Cochrane dimension)
+# Lower weight due to limited availability of replication data
 DEFAULT_WEIGHT_REPLICATION_STATUS = 0.05
+
+# BMLibrarian paper weight assessment (practical dimension)
+# Integrates multiple quality signals from BMLibrarian's PaperWeightAgent
 DEFAULT_WEIGHT_PAPER_WEIGHT = 0.15
+
+# Source/journal reliability (practical dimension)
+# Lower weight as journal quality varies within publications
 DEFAULT_WEIGHT_SOURCE_RELIABILITY = 0.05
 
 

--- a/tests/test_systematic_review_data_models.py
+++ b/tests/test_systematic_review_data_models.py
@@ -316,6 +316,19 @@ class TestScoringWeights:
         assert weights.paper_weight == DEFAULT_WEIGHT_PAPER_WEIGHT
         assert weights.source_reliability == DEFAULT_WEIGHT_SOURCE_RELIABILITY
 
+    def test_all_presets_valid(self) -> None:
+        """Test all weight presets are mathematically valid (sum to 1.0)."""
+        presets = [
+            ("balanced", ScoringWeights()),
+            ("cochrane_focused", ScoringWeights.cochrane_focused()),
+            ("practical_focused", ScoringWeights.practical_focused()),
+        ]
+        for preset_name, preset in presets:
+            assert preset.validate(), (
+                f"Preset '{preset_name}' weights don't sum to 1.0: "
+                f"sum={sum(preset.to_dict().values()):.4f}"
+            )
+
 
 # =============================================================================
 # PaperData Tests


### PR DESCRIPTION
## Refactor weight override logic and add documentation (PR #200 suggestions)

### Summary
Addresses the minor suggestions from PR #200 code review to improve code quality, documentation, and test coverage.

### Changes

#### 1. CLI Weight Override Helper Function (`systematic_review_cli.py`)
Extracted repetitive weight override logic into a reusable `apply_weight_overrides()` helper function:

```python
def apply_weight_overrides(
    weights: ScoringWeights, args: argparse.Namespace
) -> ScoringWeights:
    overrides: Dict[str, float] = {}
    if args.relevance_weight is not None:
        overrides["relevance"] = args.relevance_weight
    if args.quality_weight is not None:
        overrides["study_quality"] = args.quality_weight
    if overrides:
        return ScoringWeights(**{**weights.to_dict(), **overrides})
    return weights
```

3. Test Coverage Enhancement (test_systematic_review_data_models.py)
Added test_all_presets_valid() to verify all weight presets are mathematically valid:

def test_all_presets_valid(self) -> None:
    """Test all weight presets are mathematically valid (sum to 1.0)."""
    presets = [
        ("balanced", ScoringWeights()),
        ("cochrane_focused", ScoringWeights.cochrane_focused()),
        ("practical_focused", ScoringWeights.practical_focused()),
    ]
    for preset_name, preset in presets:
        assert preset.validate(), (
            f"Preset '{preset_name}' weights don't sum to 1.0: "
            f"sum={sum(preset.to_dict().values()):.4f}"
        )

Test Results
All 10 ScoringWeights tests pass ✓

Golden Rules Compliance
✓ All parameters have type hints (rule #6)
✓ All functions have docstrings (rule #7)
✓ No magic numbers - uses constants (rule #2)
✓ Tests written (rule #13)
✓ Reusable pure function pattern (rule #11)