### PR TITLE
Fix hardcoded canvas page size in decorations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ Since this project uses `uv` for package management:
   - `uv run python export_to_pdf.py report.md -o report.pdf` - Export markdown to PDF with default settings
   - `uv run python export_to_pdf.py report.md -o report.pdf --title "Research" --author "Dr. Smith"` - Export with custom metadata
   - `uv run python export_to_pdf.py report.md -o report.pdf --research-report --citation-count 45` - Export as BMLibrarian research report
-  - `uv run python export_to_pdf.py report.md -o report.pdf --a4 --font-size 12` - Export with A4 format and custom font size
+  - `uv run python export_to_pdf.py report.md -o report.pdf --letter --font-size 12` - Export with US Letter format and custom font size
 - **GUI Applications**:
   - `uv run python setup_wizard.py` - PySide6 setup wizard for initial database configuration and data import
   - `uv run python bmlibrarian_research_gui.py` - Desktop research application with visual workflow progress and report preview
@@ -310,14 +310,14 @@ exporter.export_report(
 ### Command-Line Tool
 
 ```bash
-# Basic export
+# Basic export (uses A4 paper size by default - international standard)
 uv run python export_to_pdf.py report.md -o report.pdf
 
-# With metadata and A4 format
+# With metadata and US Letter format
 uv run python export_to_pdf.py report.md -o report.pdf \
     --title "Research Report" \
     --author "Dr. Smith" \
-    --a4 --font-size 12
+    --letter --font-size 12
 
 # Research report format with metadata
 uv run python export_to_pdf.py report.md -o report.pdf \

--- a/doc/users/pdf_export_guide.md
+++ b/doc/users/pdf_export_guide.md
@@ -106,7 +106,7 @@ exporter = PDFExporter(config)
 ### Available Configuration Options
 
 #### Page Settings
-- `page_size`: `letter` (default) or `A4`
+- `page_size`: `A4` (default, international standard) or `letter` (US)
 - `margin_left`, `margin_right`, `margin_top`, `margin_bottom`: Margins in inches
 - Default margins: 0.75" left/right, 1.0" top, 0.75" bottom
 
@@ -275,7 +275,7 @@ def main():
     parser.add_argument('--title', help='Document title')
     parser.add_argument('--author', default='BMLibrarian', help='Author name')
     parser.add_argument('--font-size', type=int, default=11, help='Base font size')
-    parser.add_argument('--a4', action='store_true', help='Use A4 instead of Letter')
+    parser.add_argument('--letter', action='store_true', help='Use US Letter instead of A4 (default)')
 
     args = parser.parse_args()
 
@@ -284,7 +284,7 @@ def main():
 
     # Configure exporter
     config = PDFExportConfig(
-        page_size=A4 if args.a4 else letter,
+        page_size=letter if args.letter else A4,
         base_font_size=args.font_size,
         title=args.title
     )

--- a/export_to_pdf.py
+++ b/export_to_pdf.py
@@ -7,17 +7,17 @@ Convert markdown files to professional PDF documents using ReportLab.
 Usage:
     uv run python export_to_pdf.py report.md -o report.pdf
     uv run python export_to_pdf.py report.md -o report.pdf --title "Research Report"
-    uv run python export_to_pdf.py report.md -o report.pdf --title "Study" --author "Dr. Smith" --a4
+    uv run python export_to_pdf.py report.md -o report.pdf --title "Study" --author "Dr. Smith" --letter
 
 Examples:
-    # Basic export
+    # Basic export (uses A4 paper size by default - international standard)
     uv run python export_to_pdf.py my_report.md -o output.pdf
 
     # With custom title and author
     uv run python export_to_pdf.py research.md -o research.pdf --title "COVID-19 Study" --author "Research Team"
 
-    # Use A4 paper size with larger font
-    uv run python export_to_pdf.py report.md -o report.pdf --a4 --font-size 12
+    # Use US Letter paper size with larger font
+    uv run python export_to_pdf.py report.md -o report.pdf --letter --font-size 12
 
     # From BMLibrarian research report
     uv run python export_to_pdf.py reports/cardiovascular_2025.md -o cardiovascular.pdf --research-report
@@ -41,7 +41,7 @@ def main():
 Examples:
   %(prog)s report.md -o report.pdf
   %(prog)s report.md -o report.pdf --title "Research Report" --author "Dr. Smith"
-  %(prog)s report.md -o report.pdf --a4 --font-size 12
+  %(prog)s report.md -o report.pdf --letter --font-size 12
   %(prog)s report.md -o report.pdf --research-report
         """
     )
@@ -80,9 +80,9 @@ Examples:
 
     # Page settings
     parser.add_argument(
-        '--a4',
+        '--letter',
         action='store_true',
-        help='Use A4 paper size instead of Letter'
+        help='Use US Letter paper size instead of A4 (international default)'
     )
     parser.add_argument(
         '--font-size',
@@ -151,7 +151,7 @@ Examples:
 
     # Configure exporter
     config = PDFExportConfig(
-        page_size=A4 if args.a4 else letter,
+        page_size=letter if args.letter else A4,
         base_font_size=args.font_size,
         title=args.title,
         author=args.author,

--- a/src/bmlibrarian/exporters/pdf_exporter.py
+++ b/src/bmlibrarian/exporters/pdf_exporter.py
@@ -37,8 +37,8 @@ class PDFExportError(Exception):
 class PDFExportConfig:
     """Configuration for PDF export"""
 
-    # Page settings
-    page_size: tuple = field(default=letter)  # letter or A4
+    # Page settings (A4 default for international standard, user-configurable)
+    page_size: tuple = field(default=A4)  # A4 (international) or letter (US)
     margin_left: float = field(default=0.75 * inch)
     margin_right: float = field(default=0.75 * inch)
     margin_top: float = field(default=1.0 * inch)
@@ -270,8 +270,9 @@ class NumberedCanvas(canvas.Canvas):
             footer_text = f"Page {page_num} of {num_pages}"
             self.setFont('Helvetica', self.config.header_footer_font_size)
             self.setFillColorRGB(0.5, 0.5, 0.5)
+            # Use actual page width from canvas, not hardcoded letter size
             self.drawRightString(
-                letter[0] - self.config.margin_right,
+                self._pagesize[0] - self.config.margin_right,
                 self.config.margin_bottom / 2,
                 footer_text
             )
@@ -280,9 +281,10 @@ class NumberedCanvas(canvas.Canvas):
         if self.config.include_header and self.config.title and page_num > 1:
             self.setFont('Helvetica-Oblique', self.config.header_footer_font_size)
             self.setFillColorRGB(0.5, 0.5, 0.5)
+            # Use actual page height from canvas, not hardcoded letter size
             self.drawString(
                 self.config.margin_left,
-                letter[1] - self.config.margin_top / 2,
+                self._pagesize[1] - self.config.margin_top / 2,
                 self.config.title
             )
 

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -280,6 +280,11 @@ WHERE year > 2020;
         assert result.parent.exists()
         assert result.stat().st_size > 0
 
+    def test_default_page_size_is_a4(self):
+        """Test that default page size is A4 (international standard)"""
+        config = PDFExportConfig()
+        assert config.page_size == A4, "Default page size should be A4"
+
     def test_letter_vs_a4_page_size(self, basic_markdown, temp_output_dir):
         """Test different page sizes"""
         # Letter size


### PR DESCRIPTION
## Summary

- Fix hardcoded `letter` page size in `NumberedCanvas.draw_page_decorations()` that ignored user configuration
- Change default page size from US Letter to A4 (international standard)
- Update CLI flag from `--a4` to `--letter` to reflect new default

## Changes

### Bug Fix: Canvas Page Size Hardcoding
The `NumberedCanvas.draw_page_decorations()` method was using hardcoded `letter` page dimensions for positioning headers and footers, regardless of the configured `page_size`. This caused incorrect positioning when using A4 or other page sizes.

**Fixed by:** Using `self._pagesize[0]` and `self._pagesize[1]` instead of `letter[0]` and `letter[1]`

### Default Page Size Change
Changed default page size from US Letter to A4 to acknowledge international standards. Most of the world uses metric settings and A4 is the ISO standard.

### CLI Updates
- Changed `--a4` flag to `--letter` (A4 is now default)
- Updated help text and usage examples

### Documentation Updates
- Updated CLAUDE.md with new CLI examples
- Updated doc/users/pdf_export_guide.md with correct defaults and examples

### Test Coverage
- Added `test_default_page_size_is_a4` to verify the new default

## Test plan

- [ ] Run `uv run python -m pytest tests/test_pdf_export.py -v` to verify all PDF export tests pass
- [ ] Test PDF generation with default settings (should produce A4 document)
- [ ] Test PDF generation with `--letter` flag (should produce US Letter document)
- [ ] Verify headers/footers are correctly positioned on both A4 and Letter page sizes
