### PR TITLE
Verify review tabs functionality after merge

### DIFF
--- a/src/bmlibrarian/gui/qt/plugins/systematic_review/report_preview_widget.py
+++ b/src/bmlibrarian/gui/qt/plugins/systematic_review/report_preview_widget.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
 
 from bmlibrarian.gui.qt.widgets.markdown_viewer import MarkdownViewer
 from bmlibrarian.gui.qt.resources.styles.dpi_scale import scale_px
+from bmlibrarian.gui.qt.resources.styles.stylesheet_generator import StylesheetGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,11 @@ class ReportPreviewWidget(QWidget):
         header_layout.setContentsMargins(0, 0, 0, 0)
 
         title_label = QLabel("Report Preview")
-        title_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        style_gen = StylesheetGenerator()
+        title_label.setStyleSheet(style_gen.label_stylesheet(
+            font_size_key='font_large',
+            bold=True
+        ))
         header_layout.addWidget(title_label)
 
         header_layout.addStretch()
@@ -102,10 +107,8 @@ class ReportPreviewWidget(QWidget):
         self.raw_view.setReadOnly(True)
         self.raw_view.setPlaceholderText(PLACEHOLDER_TEXT)
         self.raw_view.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
-        # Use monospace font for raw markdown
-        self.raw_view.setStyleSheet(
-            "QTextEdit { font-family: 'Consolas', 'Monaco', 'Courier New', monospace; }"
-        )
+        # Use monospace font for raw markdown via stylesheet generator
+        self.raw_view.setStyleSheet(style_gen.code_text_stylesheet())
         self.tab_widget.addTab(self.raw_view, TAB_RAW)
 
         layout.addWidget(self.tab_widget)

--- a/src/bmlibrarian/gui/qt/plugins/systematic_review/systematic_review_tab.py
+++ b/src/bmlibrarian/gui/qt/plugins/systematic_review/systematic_review_tab.py
@@ -1004,7 +1004,7 @@ class SystematicReviewTabWidget(QWidget):
         self.details_text.clear()
 
         # Reset report view
-        self.report_viewer.set_markdown(
+        self.report_preview.set_report(
             "# Report\n\n"
             "*Processing... The report will appear here when the review completes.*"
         )


### PR DESCRIPTION
## Summary

This PR fixes issues discovered when verifying the merge of `claude/add-review-tabs-012dK5PibhoYKfCW6h1vkFAt` into master.

### Issues Fixed

1. **Merge Conflict Resolution Error** (`systematic_review_tab.py:1007`)
   - The merge left a reference to `self.report_viewer.set_markdown()` but the widget was renamed to `self.report_preview` and uses `set_report()` method
   - This would have caused an `AttributeError` at runtime when starting/resuming a systematic review

2. **Golden Rule Violations** (`report_preview_widget.py`)
   - **Rule #9 & #10**: Replaced inline stylesheet with hardcoded `14px` font size with `StylesheetGenerator.label_stylesheet()`
   - **Rule #9 & #19**: Replaced inline stylesheet with hardcoded font-family (`'Consolas', 'Monaco', 'Courier New', monospace`) with `StylesheetGenerator.code_text_stylesheet()` which uses the cross-platform `FONT_FAMILY_MONOSPACE` constant

### Changes

| File | Change |
|------|--------|
| `systematic_review_tab.py` | `report_viewer.set_markdown()` → `report_preview.set_report()` |
| `report_preview_widget.py` | Use `StylesheetGenerator` for title label and raw markdown viewer styling |

### Verification

- ✅ Python syntax validation passed for all modified files
- ✅ No merge conflict markers found in codebase
- ✅ All other files from the original merge are intact and correct

## Test plan

- [ ] Launch `systematic_review_gui.py` and start a new review
- [ ] Verify the Report tab displays properly during and after review
- [ ] Resume from a checkpoint and verify report preview works
- [ ] Verify title "Report Preview" label uses correct DPI-scaled font size
- [ ] Verify raw markdown view uses correct monospace font on all platforms
