### PR TITLE
Fix N+1 query pattern in agent scoring

### DIFF
--- a/src/bmlibrarian/agents/systematic_review/config.py
+++ b/src/bmlibrarian/agents/systematic_review/config.py
@@ -58,6 +58,10 @@ DEFAULT_MAX_RETRIES = 3
 DEFAULT_CHECKPOINT_ENABLED = True
 DEFAULT_CHECKPOINT_DIR = "~/.bmlibrarian/checkpoints"
 
+# Checkpoint display constants (used for progress reporting)
+CHECKPOINT_TITLE_TRUNCATE_LENGTH = 80  # Max characters for paper title display
+CHECKPOINT_SAMPLE_TITLES_COUNT = 10     # Number of sample titles to show in checkpoint state
+
 # Output defaults
 DEFAULT_OUTPUT_DIR = "~/.bmlibrarian/systematic_reviews"
 


### PR DESCRIPTION
## Fix N+1 Query Pattern in get_assessed_papers()

### Summary
- Fixed performance issue where `get_assessed_papers()` triggered redundant database queries
- Added efficient combined query method for fetching both scored and assessed papers
- Centralized checkpoint display constants to eliminate code duplication

### Changes

#### EvaluationStore (`store.py`)
- Added `get_evaluations_for_multiple_types()` method that fetches multiple evaluation types (e.g., `RELEVANCE_SCORE` and `QUALITY_ASSESSMENT`) in a single database query using PostgreSQL's `ANY()` operator

#### SystematicReviewAgent (`agent.py`)
- Added `get_scored_and_assessed_papers()` method that efficiently returns both scored and assessed papers from a single database roundtrip
- Modified `get_assessed_papers()` to accept optional pre-fetched scored papers map for internal optimization
- Updated `get_review_statistics()` to use the combined query method

#### CheckpointResumeMixin (`resume_mixin.py`)
- Updated `_restore_state_from_checkpoint()` to use combined query
- Updated `_continue_from_composite_scoring()` to use combined query

#### Constants (`config.py`)
- Centralized `CHECKPOINT_TITLE_TRUNCATE_LENGTH = 80` and `CHECKPOINT_SAMPLE_TITLES_COUNT = 10`
- Removed duplicates from `agent.py` and `resume_mixin.py`

### Performance Impact
Callers needing both scored and assessed papers now make **1 database query** instead of **3 queries**:
- Before: QUALITY_ASSESSMENT query + RELEVANCE_SCORE query (inside get_assessed_papers) + separate RELEVANCE_SCORE query
- After: Single query fetching both types

### Database Indexes
Verified that required indexes already exist in migration `026_create_unified_evaluations_schema.sql`:
- `idx_doc_eval_run_type` on `(run_id, evaluation_type)`
- `idx_doc_eval_document_id` on `(document_id)`

### Test Plan
- [ ] Verify syntax correctness (confirmed via Python AST parser)
- [ ] Run systematic review workflow to confirm no regressions
- [ ] Verify checkpoint resume functionality works correctly
- [ ] Confirm `get_review_statistics()` returns correct counts
