### PR TITLE
Add MeSH local database import and lookup system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,13 @@ Since this project uses `uv` for package management:
   - `uv run python embed_documents_cli.py embed --source medrxiv --limit 100` - Generate embeddings for medRxiv abstracts
   - `uv run python embed_documents_cli.py count --source medrxiv` - Count documents needing embeddings
   - `uv run python embed_documents_cli.py status` - Show embedding statistics
+  - `uv run python mesh_import_cli.py import --year 2025` - Download and import MeSH vocabulary (~400MB with SCRs)
+  - `uv run python mesh_import_cli.py import --year 2025 --no-supplementary` - Import MeSH without SCRs (~180MB, faster)
+  - `uv run python mesh_import_cli.py status` - Show MeSH database statistics and local DB availability
+  - `uv run python mesh_import_cli.py lookup "heart attack"` - Look up a MeSH term (uses local DB if available)
+  - `uv run python mesh_import_cli.py search "cardio"` - Search MeSH by partial match
+  - `uv run python mesh_import_cli.py expand "MI"` - Expand term to all synonyms/entry terms
+  - `uv run python mesh_import_cli.py history` - Show MeSH import history
   - `uv run python pdf_import_cli.py file /path/to/paper.pdf` - Import single PDF with LLM-based metadata extraction and database matching
   - `uv run python pdf_import_cli.py directory /path/to/pdfs/` - Import directory of PDFs with intelligent matching
   - `uv run python pdf_import_cli.py directory /pdfs/ --recursive` - Import PDFs recursively from subdirectories

--- a/doc/users/mesh_import_guide.md
+++ b/doc/users/mesh_import_guide.md
@@ -1,0 +1,344 @@
+# MeSH Import Guide
+
+This guide explains how to download and import the MeSH (Medical Subject Headings) vocabulary into BMLibrarian for fast local lookup.
+
+## Overview
+
+MeSH is a controlled vocabulary developed by the National Library of Medicine (NLM) for indexing and searching biomedical literature. BMLibrarian can store MeSH data locally for:
+
+- **Fast term validation** - Instantly validate MeSH terms without API calls
+- **Term expansion** - Expand queries with synonyms and entry terms
+- **Hierarchical navigation** - Navigate broader/narrower terms
+- **Offline operation** - Work without internet connectivity
+
+## Database Size
+
+| Component | Approximate Count | Storage |
+|-----------|------------------|---------|
+| Descriptors | ~30,000 | ~50 MB |
+| Concepts | ~60,000 | ~20 MB |
+| Terms (entry terms) | ~300,000 | ~100 MB |
+| Tree numbers | ~60,000 | ~10 MB |
+| Qualifiers | ~80 | <1 MB |
+| Supplementary Concepts (SCRs) | ~300,000 | ~200 MB |
+
+**Total estimated storage:** ~400 MB with SCRs, ~180 MB without
+
+**Download sizes (compressed XML):**
+- Descriptors: ~150 MB
+- Qualifiers: ~1 MB
+- Supplementary: ~200 MB
+
+## Quick Start
+
+### 1. Import MeSH Data
+
+```bash
+# Import MeSH 2025 (descriptors, qualifiers, and supplementary concepts)
+uv run python mesh_import_cli.py import --year 2025
+
+# Skip supplementary concepts for faster import (~180 MB vs ~400 MB)
+uv run python mesh_import_cli.py import --year 2025 --no-supplementary
+
+# Auto-confirm without prompt
+uv run python mesh_import_cli.py import --year 2025 -y
+```
+
+### 2. Verify Import
+
+```bash
+# Check database statistics
+uv run python mesh_import_cli.py status
+
+# View import history
+uv run python mesh_import_cli.py history
+```
+
+### 3. Test Lookup
+
+```bash
+# Look up a term
+uv run python mesh_import_cli.py lookup "heart attack"
+
+# Search by partial match
+uv run python mesh_import_cli.py search "cardio"
+
+# Expand term to all synonyms
+uv run python mesh_import_cli.py expand "MI"
+```
+
+## CLI Commands
+
+### Import Command
+
+```bash
+uv run python mesh_import_cli.py import [options]
+```
+
+Options:
+- `--year YEAR` - MeSH year to import (default: current year)
+- `--no-supplementary` - Skip supplementary concept records
+- `--download-dir PATH` - Directory for downloaded files
+- `--delete-downloads` - Delete downloaded files after import
+- `-y, --yes` - Skip confirmation prompt
+
+### Status Command
+
+```bash
+uv run python mesh_import_cli.py status
+```
+
+Shows:
+- Local database statistics
+- API cache statistics
+- Connection status
+
+### History Command
+
+```bash
+uv run python mesh_import_cli.py history [--limit N]
+```
+
+Shows import history with statistics.
+
+### Lookup Command
+
+```bash
+uv run python mesh_import_cli.py lookup "term"
+```
+
+Look up a MeSH term and display:
+- Descriptor UI and name
+- Scope note (definition)
+- Tree numbers (hierarchy)
+- Entry terms (synonyms)
+- PubMed query syntax
+
+### Search Command
+
+```bash
+uv run python mesh_import_cli.py search "query" [--limit N]
+```
+
+Search MeSH by partial match.
+
+### Expand Command
+
+```bash
+uv run python mesh_import_cli.py expand "term"
+```
+
+Expand a term to all synonyms/entry terms.
+
+### Clear Cache Command
+
+```bash
+uv run python mesh_import_cli.py clear-cache [-y]
+```
+
+Clear the API cache (SQLite).
+
+## Programmatic Usage
+
+### Using MeSHService
+
+```python
+from bmlibrarian.mesh import MeSHService
+
+# Create service (auto-detects local database)
+service = MeSHService()
+
+# Check if local database is available
+print(f"Local DB: {service.is_local_db_available()}")
+
+# Look up a term
+result = service.lookup("heart attack")
+if result.found:
+    print(f"Descriptor: {result.descriptor_name}")
+    print(f"UI: {result.descriptor_ui}")
+    print(f"Source: {result.source}")  # local_database, nlm_api, or cache
+    print(f"Entry terms: {result.entry_terms}")
+
+# Expand term to all synonyms
+terms = service.expand("MI")
+print(f"Synonyms: {terms}")
+
+# Search by partial match
+results = service.search("cardio", limit=10)
+for r in results:
+    print(f"  {r.descriptor_name} ({r.descriptor_ui})")
+
+# Get broader terms (parents in hierarchy)
+broader = service.get_broader_terms("D009203")  # Myocardial Infarction
+
+# Get narrower terms (children in hierarchy)
+narrower = service.get_narrower_terms("D006331")  # Heart Diseases
+```
+
+### Using MeSHLookup (Existing API)
+
+The existing `MeSHLookup` class now automatically uses the local database:
+
+```python
+from bmlibrarian.pubmed_search import MeSHLookup
+
+# Create lookup (now checks local DB first)
+lookup = MeSHLookup()
+
+# Check local DB availability
+print(f"Local DB: {lookup.is_local_db_available()}")
+
+# Validate a term
+result = lookup.validate_term("Cardiovascular Diseases")
+if result.is_valid:
+    print(f"Valid: {result.descriptor_name}")
+    print(f"Entry terms: {result.entry_terms}")
+
+# Disable local DB lookup (API only)
+lookup_api_only = MeSHLookup(use_local_db=False)
+```
+
+### Using MeSHImporter
+
+```python
+from bmlibrarian.importers import MeSHImporter
+
+# Create importer
+importer = MeSHImporter(keep_downloads=True)
+
+# Import MeSH 2025
+stats = importer.import_mesh(year=2025, include_supplementary=True)
+
+print(f"Imported: {stats.descriptors:,} descriptors")
+print(f"          {stats.concepts:,} concepts")
+print(f"          {stats.terms:,} terms")
+print(f"          {stats.supplementary_concepts:,} SCRs")
+print(f"Duration: {stats.duration_seconds:.1f}s")
+
+# Get import history
+history = importer.get_import_history()
+
+# Get current statistics
+stats = importer.get_statistics()
+```
+
+## Database Schema
+
+The MeSH data is stored in the `mesh` schema:
+
+```sql
+-- Main descriptors (MeSH headings)
+mesh.descriptors
+
+-- Concepts within descriptors
+mesh.concepts
+
+-- Term variants (entry terms, synonyms)
+mesh.terms
+
+-- Hierarchical tree numbers
+mesh.tree_numbers
+
+-- Subheading qualifiers
+mesh.qualifiers
+
+-- Supplementary concept records (chemicals, drugs, etc.)
+mesh.supplementary_concepts
+
+-- Import history
+mesh.import_history
+```
+
+### Utility Functions
+
+The schema includes helpful PostgreSQL functions:
+
+```sql
+-- Look up a term
+SELECT * FROM mesh.lookup_term('heart attack');
+
+-- Get all entry terms for a descriptor
+SELECT * FROM mesh.get_entry_terms('D009203');
+
+-- Get tree hierarchy
+SELECT * FROM mesh.get_tree_hierarchy('D009203');
+
+-- Get broader (parent) terms
+SELECT * FROM mesh.get_broader_terms('D009203');
+
+-- Get narrower (child) terms
+SELECT * FROM mesh.get_narrower_terms('D006331');
+
+-- Search by partial match
+SELECT * FROM mesh.search('cardio', 20);
+
+-- Expand term to all synonyms
+SELECT * FROM mesh.expand_term('MI');
+
+-- Get database statistics
+SELECT * FROM mesh.get_statistics();
+```
+
+## Lookup Behavior
+
+When validating MeSH terms, the system checks sources in this order:
+
+1. **Local PostgreSQL database** (mesh schema) - Fastest, no network
+2. **SQLite API cache** - For previously looked up terms (API results)
+3. **NLM API** - For terms not in local DB or cache
+
+This ensures:
+- Fast lookups when local data is available
+- Automatic fallback when local data is incomplete
+- Cached API results to minimize network calls
+
+## Updating MeSH Data
+
+MeSH is updated annually (new version released in November/December). To update:
+
+```bash
+# Import new year's data
+uv run python mesh_import_cli.py import --year 2026
+
+# The importer uses UPSERT, so existing records are updated
+```
+
+## Troubleshooting
+
+### Import Fails to Download
+
+Check network connectivity and try:
+```bash
+# Specify download directory
+uv run python mesh_import_cli.py import --year 2025 --download-dir ~/Downloads/mesh
+```
+
+### Database Connection Issues
+
+Ensure PostgreSQL is running and credentials are configured:
+```bash
+# Check connection
+uv run python -c "from bmlibrarian.database import get_db_manager; print(get_db_manager())"
+```
+
+### Migration Not Applied
+
+If the `mesh` schema doesn't exist, apply migrations:
+```bash
+# Migrations are auto-applied on database connection
+uv run python -c "from bmlibrarian.database import get_db_manager; get_db_manager()"
+```
+
+### Slow Lookups
+
+If lookups are slow, ensure indexes exist:
+```sql
+-- Check for indexes
+SELECT indexname FROM pg_indexes WHERE schemaname = 'mesh';
+```
+
+## See Also
+
+- [PubMed Search Lab](pubmed_search_lab_guide.md) - Uses MeSH for query conversion
+- [Query Converter](query_converter_guide.md) - Natural language to PubMed queries
+- [MeSH Architecture](../developers/mesh_architecture.md) - Technical documentation

--- a/mesh_import_cli.py
+++ b/mesh_import_cli.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""
+MeSH Import CLI - Download and import MeSH vocabulary into BMLibrarian.
+
+This CLI tool downloads MeSH XML files from NLM and imports them into the
+local PostgreSQL database for fast lookup and term expansion.
+
+Usage:
+    # Download and import MeSH 2025 (descriptors, qualifiers, and SCRs)
+    uv run python mesh_import_cli.py import --year 2025
+
+    # Import without supplementary concepts (faster, smaller)
+    uv run python mesh_import_cli.py import --year 2025 --no-supplementary
+
+    # Show current database statistics
+    uv run python mesh_import_cli.py status
+
+    # Show import history
+    uv run python mesh_import_cli.py history
+
+    # Look up a MeSH term
+    uv run python mesh_import_cli.py lookup "heart attack"
+
+    # Search MeSH
+    uv run python mesh_import_cli.py search "cardio" --limit 20
+"""
+
+import argparse
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+# Set up logging before imports
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def get_current_mesh_year() -> int:
+    """Get the current MeSH year (typically previous year until mid-year)."""
+    now = datetime.now()
+    # MeSH is typically released in November/December for the next year
+    # But we should default to the current year
+    return now.year
+
+
+def format_size(size_bytes: int) -> str:
+    """Format byte size for display."""
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def format_duration(seconds: float) -> str:
+    """Format duration for display."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    elif seconds < 3600:
+        minutes = seconds / 60
+        return f"{minutes:.1f}m"
+    else:
+        hours = seconds / 3600
+        return f"{hours:.1f}h"
+
+
+def cmd_import(args: argparse.Namespace) -> int:
+    """Import MeSH vocabulary from NLM."""
+    from bmlibrarian.importers.mesh_importer import MeSHImporter
+
+    year = args.year or get_current_mesh_year()
+    include_supplementary = not args.no_supplementary
+
+    print(f"\nMeSH {year} Import")
+    print("=" * 50)
+    print(f"Year: {year}")
+    print(f"Include supplementary concepts: {include_supplementary}")
+    print(f"Download directory: {args.download_dir or 'default'}")
+    print()
+
+    if not args.yes:
+        confirm = input("Proceed with import? [y/N]: ").strip().lower()
+        if confirm != "y":
+            print("Import cancelled.")
+            return 1
+
+    try:
+        download_dir = Path(args.download_dir) if args.download_dir else None
+        importer = MeSHImporter(
+            download_dir=download_dir,
+            keep_downloads=not args.delete_downloads,
+        )
+
+        def progress_callback(phase: str, processed: int, total: int) -> None:
+            if total > 0:
+                pct = (processed / total) * 100
+                print(f"\r{phase}: {processed:,}/{total:,} ({pct:.1f}%)    ", end="", flush=True)
+            else:
+                print(f"\r{phase}: {processed:,}    ", end="", flush=True)
+
+        print("Starting import...")
+        stats = importer.import_mesh(
+            year=year,
+            include_supplementary=include_supplementary,
+            progress_callback=progress_callback,
+        )
+        print()  # New line after progress
+
+        print("\nImport Complete!")
+        print("-" * 50)
+        print(f"Descriptors: {stats.descriptors:,}")
+        print(f"Concepts: {stats.concepts:,}")
+        print(f"Terms: {stats.terms:,}")
+        print(f"Tree numbers: {stats.tree_numbers:,}")
+        print(f"Qualifiers: {stats.qualifiers:,}")
+        print(f"Supplementary concepts: {stats.supplementary_concepts:,}")
+        print(f"Duration: {format_duration(stats.duration_seconds or 0)}")
+        print(f"Status: {stats.status}")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Import failed: {e}")
+        return 1
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Show MeSH database statistics."""
+    from bmlibrarian.mesh import MeSHService
+
+    print("\nMeSH Database Status")
+    print("=" * 50)
+
+    try:
+        service = MeSHService()
+        stats = service.get_statistics()
+
+        print(f"Local database available: {stats.get('local_db_available', False)}")
+        print(f"API fallback enabled: {stats.get('api_fallback_enabled', True)}")
+        print()
+
+        if stats.get("local_db_available"):
+            print("Local Database Contents:")
+            print("-" * 30)
+            print(f"  Descriptors: {stats.get('local_descriptors', 0):,}")
+            print(f"  Concepts: {stats.get('local_concepts', 0):,}")
+            print(f"  Terms: {stats.get('local_terms', 0):,}")
+            print(f"  Tree numbers: {stats.get('local_tree_numbers', 0):,}")
+            print(f"  Qualifiers: {stats.get('local_qualifiers', 0):,}")
+            print(f"  Supplementary concepts: {stats.get('local_supplementary_concepts', 0):,}")
+        else:
+            print("Local database not available or empty.")
+            print("Run 'mesh_import_cli.py import' to import MeSH data.")
+
+        print()
+        print("API Cache:")
+        print("-" * 30)
+        print(f"  Cache entries: {stats.get('cache_entries', 0):,}")
+        print(f"  Cache TTL: {stats.get('cache_ttl_days', 30)} days")
+        print(f"  Cache path: {stats.get('cache_path', 'N/A')}")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Could not get status: {e}")
+        return 1
+
+
+def cmd_history(args: argparse.Namespace) -> int:
+    """Show import history."""
+    from bmlibrarian.importers.mesh_importer import MeSHImporter
+
+    print("\nMeSH Import History")
+    print("=" * 50)
+
+    try:
+        importer = MeSHImporter()
+        history = importer.get_import_history()
+
+        if not history:
+            print("No import history found.")
+            return 0
+
+        for i, record in enumerate(history[:args.limit]):
+            print(f"\n[{i + 1}] Import #{record['id']}")
+            print("-" * 30)
+            print(f"  Year: {record['mesh_year']}")
+            print(f"  Type: {record['import_type']}")
+            print(f"  Status: {record['status']}")
+            print(f"  Started: {record['started_at']}")
+            if record.get("completed_at"):
+                print(f"  Completed: {record['completed_at']}")
+            print(f"  Descriptors: {record['descriptors']:,}")
+            print(f"  Concepts: {record['concepts']:,}")
+            print(f"  Terms: {record['terms']:,}")
+            print(f"  Qualifiers: {record['qualifiers']:,}")
+            print(f"  SCRs: {record['scrs']:,}")
+            if record.get("error_message"):
+                print(f"  Error: {record['error_message']}")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Could not get history: {e}")
+        return 1
+
+
+def cmd_lookup(args: argparse.Namespace) -> int:
+    """Look up a MeSH term."""
+    from bmlibrarian.mesh import MeSHService
+
+    term = " ".join(args.term)
+    print(f"\nLooking up: '{term}'")
+    print("=" * 50)
+
+    try:
+        service = MeSHService()
+        result = service.lookup(term)
+
+        if result.found:
+            print(f"Found: Yes")
+            print(f"Source: {result.source.value}")
+            print(f"Descriptor UI: {result.descriptor_ui}")
+            print(f"Descriptor Name: {result.descriptor_name}")
+
+            if result.scope_note:
+                print(f"\nScope Note:")
+                # Word wrap at 70 chars
+                words = result.scope_note.split()
+                line = "  "
+                for word in words:
+                    if len(line) + len(word) + 1 > 70:
+                        print(line)
+                        line = "  "
+                    line += word + " "
+                if line.strip():
+                    print(line)
+
+            if result.tree_numbers:
+                print(f"\nTree Numbers ({len(result.tree_numbers)}):")
+                for tn in result.tree_numbers[:10]:
+                    print(f"  {tn}")
+                if len(result.tree_numbers) > 10:
+                    print(f"  ... and {len(result.tree_numbers) - 10} more")
+
+            if result.entry_terms:
+                print(f"\nEntry Terms ({len(result.entry_terms)}):")
+                for et in result.entry_terms[:20]:
+                    print(f"  {et}")
+                if len(result.entry_terms) > 20:
+                    print(f"  ... and {len(result.entry_terms) - 20} more")
+
+            print(f"\nPubMed Syntax: {result.to_pubmed_syntax()}")
+        else:
+            print(f"Found: No")
+            print(f"The term '{term}' was not found in MeSH.")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Lookup failed: {e}")
+        return 1
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    """Search MeSH by partial match."""
+    from bmlibrarian.mesh import MeSHService
+
+    query = " ".join(args.query)
+    print(f"\nSearching MeSH for: '{query}'")
+    print("=" * 50)
+
+    try:
+        service = MeSHService()
+        results = service.search(query, limit=args.limit)
+
+        if not results:
+            print("No results found.")
+            return 0
+
+        print(f"Found {len(results)} result(s):\n")
+
+        for i, result in enumerate(results):
+            print(f"[{i + 1}] {result.descriptor_name}")
+            print(f"    UI: {result.descriptor_ui}")
+            print(f"    Matched: '{result.matched_term}'")
+            print(f"    Match type: {result.match_type}")
+            if result.score > 0:
+                print(f"    Score: {result.score:.4f}")
+            print()
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Search failed: {e}")
+        return 1
+
+
+def cmd_expand(args: argparse.Namespace) -> int:
+    """Expand a MeSH term to all synonyms."""
+    from bmlibrarian.mesh import MeSHService
+
+    term = " ".join(args.term)
+    print(f"\nExpanding: '{term}'")
+    print("=" * 50)
+
+    try:
+        service = MeSHService()
+        terms = service.expand(term)
+
+        if len(terms) <= 1:
+            print(f"No expansion found for '{term}'.")
+            return 0
+
+        print(f"Found {len(terms)} terms:\n")
+        for t in terms:
+            if t.lower() == term.lower():
+                print(f"  * {t}  (searched term)")
+            else:
+                print(f"    {t}")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Expansion failed: {e}")
+        return 1
+
+
+def cmd_clear_cache(args: argparse.Namespace) -> int:
+    """Clear the MeSH API cache."""
+    from bmlibrarian.mesh import MeSHService
+
+    if not args.yes:
+        confirm = input("Clear MeSH API cache? [y/N]: ").strip().lower()
+        if confirm != "y":
+            print("Cancelled.")
+            return 1
+
+    try:
+        service = MeSHService()
+        count = service.clear_cache()
+        print(f"Cleared {count} cache entries.")
+        return 0
+
+    except Exception as e:
+        logger.error(f"Clear cache failed: {e}")
+        return 1
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="MeSH Import CLI - Download and import MeSH vocabulary into BMLibrarian",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s import --year 2025        Download and import MeSH 2025
+  %(prog)s import --no-supplementary Import without SCRs (faster)
+  %(prog)s status                    Show database statistics
+  %(prog)s history                   Show import history
+  %(prog)s lookup "heart attack"     Look up a MeSH term
+  %(prog)s search "cardio"           Search MeSH by partial match
+  %(prog)s expand "MI"               Expand term to all synonyms
+        """,
+    )
+
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose output",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Import command
+    import_parser = subparsers.add_parser(
+        "import",
+        help="Download and import MeSH vocabulary",
+    )
+    import_parser.add_argument(
+        "--year",
+        type=int,
+        help=f"MeSH year to import (default: {get_current_mesh_year()})",
+    )
+    import_parser.add_argument(
+        "--no-supplementary",
+        action="store_true",
+        help="Skip supplementary concept records (faster, smaller)",
+    )
+    import_parser.add_argument(
+        "--download-dir",
+        help="Directory for downloaded files",
+    )
+    import_parser.add_argument(
+        "--delete-downloads",
+        action="store_true",
+        help="Delete downloaded files after import",
+    )
+    import_parser.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    import_parser.set_defaults(func=cmd_import)
+
+    # Status command
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show MeSH database statistics",
+    )
+    status_parser.set_defaults(func=cmd_status)
+
+    # History command
+    history_parser = subparsers.add_parser(
+        "history",
+        help="Show import history",
+    )
+    history_parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum history records to show (default: 10)",
+    )
+    history_parser.set_defaults(func=cmd_history)
+
+    # Lookup command
+    lookup_parser = subparsers.add_parser(
+        "lookup",
+        help="Look up a MeSH term",
+    )
+    lookup_parser.add_argument(
+        "term",
+        nargs="+",
+        help="MeSH term to look up",
+    )
+    lookup_parser.set_defaults(func=cmd_lookup)
+
+    # Search command
+    search_parser = subparsers.add_parser(
+        "search",
+        help="Search MeSH by partial match",
+    )
+    search_parser.add_argument(
+        "query",
+        nargs="+",
+        help="Search query",
+    )
+    search_parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum results (default: 20)",
+    )
+    search_parser.set_defaults(func=cmd_search)
+
+    # Expand command
+    expand_parser = subparsers.add_parser(
+        "expand",
+        help="Expand a MeSH term to all synonyms",
+    )
+    expand_parser.add_argument(
+        "term",
+        nargs="+",
+        help="MeSH term to expand",
+    )
+    expand_parser.set_defaults(func=cmd_expand)
+
+    # Clear cache command
+    clear_parser = subparsers.add_parser(
+        "clear-cache",
+        help="Clear the MeSH API cache",
+    )
+    clear_parser.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    clear_parser.set_defaults(func=cmd_clear_cache)
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrations/028_create_mesh_schema.sql
+++ b/migrations/028_create_mesh_schema.sql
@@ -1,0 +1,628 @@
+-- Migration: Create MeSH (Medical Subject Headings) Schema
+-- Description: Creates dedicated mesh schema for MeSH vocabulary storage and lookup
+-- Source: NLM MeSH (https://www.nlm.nih.gov/mesh/)
+-- Purpose: Local MeSH database for fast lookup with API fallback
+-- Author: BMLibrarian
+-- Date: 2025-12-13
+
+-- ============================================================================
+-- Create schema
+-- ============================================================================
+
+CREATE SCHEMA IF NOT EXISTS mesh;
+
+COMMENT ON SCHEMA mesh IS
+'Medical Subject Headings (MeSH) controlled vocabulary from NLM.
+Provides local storage for fast MeSH term lookup, validation, and expansion.
+Supports ~30,000 descriptors with ~300,000 entry terms and hierarchical relationships.';
+
+-- ============================================================================
+-- Create descriptors table (main MeSH terms)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.descriptors (
+    id SERIAL PRIMARY KEY,
+    descriptor_ui TEXT NOT NULL UNIQUE,  -- e.g., D009203
+    descriptor_name TEXT NOT NULL,        -- Preferred term, e.g., "Myocardial Infarction"
+    scope_note TEXT,                      -- Definition/description
+    annotation TEXT,                      -- Usage notes for indexers
+    history_note TEXT,                    -- Historical information
+    public_mesh_note TEXT,                -- Public notes
+    nlm_classification TEXT,              -- NLM classification number
+    date_created DATE,                    -- Date descriptor was created
+    date_revised DATE,                    -- Date last revised
+    date_established DATE,                -- Date established as MeSH term
+    mesh_year INTEGER NOT NULL,           -- MeSH version year (e.g., 2025)
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE mesh.descriptors IS
+'Main MeSH descriptors (controlled vocabulary headings).
+Each descriptor represents a unique biomedical concept with a preferred name.
+Expected scale: ~30,000 descriptors for current MeSH.';
+
+COMMENT ON COLUMN mesh.descriptors.descriptor_ui IS 'Unique MeSH identifier (e.g., D009203 for Myocardial Infarction)';
+COMMENT ON COLUMN mesh.descriptors.descriptor_name IS 'Preferred/canonical term for this descriptor';
+COMMENT ON COLUMN mesh.descriptors.scope_note IS 'Definition and scope of the descriptor';
+COMMENT ON COLUMN mesh.descriptors.annotation IS 'Indexing notes and usage guidelines';
+COMMENT ON COLUMN mesh.descriptors.mesh_year IS 'MeSH vocabulary year (e.g., 2025)';
+
+-- ============================================================================
+-- Create concepts table (semantic units within descriptors)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.concepts (
+    id SERIAL PRIMARY KEY,
+    concept_ui TEXT NOT NULL UNIQUE,      -- e.g., M0014340
+    concept_name TEXT NOT NULL,           -- Preferred concept name
+    descriptor_id INTEGER NOT NULL REFERENCES mesh.descriptors(id) ON DELETE CASCADE,
+    is_preferred BOOLEAN NOT NULL DEFAULT FALSE,  -- Is this the preferred concept?
+    scope_note TEXT,                      -- Concept-specific scope note
+    cas_registry_number TEXT,             -- Chemical Abstracts Service number (for chemicals)
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE mesh.concepts IS
+'MeSH concepts - semantic units within descriptors.
+A descriptor may have multiple concepts; one is marked as preferred.
+Example: Descriptor "Heart Attack" has concepts for different clinical presentations.';
+
+COMMENT ON COLUMN mesh.concepts.concept_ui IS 'Unique concept identifier (e.g., M0014340)';
+COMMENT ON COLUMN mesh.concepts.is_preferred IS 'True if this is the preferred concept for the descriptor';
+COMMENT ON COLUMN mesh.concepts.cas_registry_number IS 'CAS number for chemical substances';
+
+-- ============================================================================
+-- Create terms table (all term variants)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.terms (
+    id SERIAL PRIMARY KEY,
+    term_ui TEXT NOT NULL,                -- e.g., T000745
+    term_text TEXT NOT NULL,              -- The actual term string
+    concept_id INTEGER NOT NULL REFERENCES mesh.concepts(id) ON DELETE CASCADE,
+    is_preferred BOOLEAN NOT NULL DEFAULT FALSE,  -- Preferred term for this concept?
+    is_permuted BOOLEAN NOT NULL DEFAULT FALSE,   -- Is this a permuted term?
+    lexical_tag TEXT,                     -- ABB, ABX, ACR, EPO, EQV, LAB, NAM, NON, TRD
+    entry_combination TEXT,               -- Entry combination info
+    sort_version TEXT,                    -- Sort key
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    -- Constraint for lexical tags
+    CONSTRAINT chk_mesh_terms_lexical_tag
+        CHECK (lexical_tag IS NULL OR lexical_tag IN (
+            'ABB',   -- Abbreviation
+            'ABX',   -- Embedded abbreviation
+            'ACR',   -- Acronym
+            'EPO',   -- Eponym
+            'EQV',   -- Equivalent term
+            'LAB',   -- Lab number
+            'NAM',   -- Proper name
+            'NON',   -- None (standard term)
+            'TRD'    -- Trade name
+        ))
+);
+
+COMMENT ON TABLE mesh.terms IS
+'All MeSH term variants (entry terms, synonyms, abbreviations).
+Terms are linked to concepts, which are linked to descriptors.
+Expected scale: ~300,000 terms for current MeSH.';
+
+COMMENT ON COLUMN mesh.terms.term_ui IS 'Unique term identifier (e.g., T000745)';
+COMMENT ON COLUMN mesh.terms.term_text IS 'Actual term string (e.g., "MI", "Heart Attack")';
+COMMENT ON COLUMN mesh.terms.is_preferred IS 'True if this is the preferred term for the concept';
+COMMENT ON COLUMN mesh.terms.lexical_tag IS 'Term type: ABB (abbreviation), ACR (acronym), TRD (trade name), etc.';
+
+-- ============================================================================
+-- Create tree_numbers table (hierarchical structure)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.tree_numbers (
+    id SERIAL PRIMARY KEY,
+    descriptor_id INTEGER NOT NULL REFERENCES mesh.descriptors(id) ON DELETE CASCADE,
+    tree_number TEXT NOT NULL,            -- e.g., C14.280.647.500
+    tree_level INTEGER NOT NULL,          -- Depth in hierarchy (1 = top)
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    -- Ensure unique tree numbers per descriptor
+    CONSTRAINT uq_mesh_tree_numbers UNIQUE(descriptor_id, tree_number),
+
+    -- Validate tree number format
+    CONSTRAINT chk_mesh_tree_format CHECK (tree_number ~ '^[A-Z][0-9]{2}(\.[0-9]+)*$'),
+
+    -- Validate tree level
+    CONSTRAINT chk_mesh_tree_level CHECK (tree_level >= 1 AND tree_level <= 15)
+);
+
+COMMENT ON TABLE mesh.tree_numbers IS
+'MeSH tree structure for hierarchical navigation.
+Tree numbers encode the hierarchy: C14.280.647.500 = Diseases > Cardiovascular > Heart > Ischemia > Infarction.
+Used for broader/narrower term navigation.';
+
+COMMENT ON COLUMN mesh.tree_numbers.tree_number IS 'Hierarchical tree number (e.g., C14.280.647.500)';
+COMMENT ON COLUMN mesh.tree_numbers.tree_level IS 'Depth in tree (1 = top level category)';
+
+-- ============================================================================
+-- Create qualifiers table (subheadings)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.qualifiers (
+    id SERIAL PRIMARY KEY,
+    qualifier_ui TEXT NOT NULL UNIQUE,    -- e.g., Q000175
+    qualifier_name TEXT NOT NULL,         -- e.g., "diagnosis"
+    abbreviation TEXT NOT NULL,           -- e.g., "DI"
+    scope_note TEXT,
+    annotation TEXT,
+    mesh_year INTEGER NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE mesh.qualifiers IS
+'MeSH qualifiers (subheadings) that can modify descriptors.
+Example: "therapy" (TH), "diagnosis" (DI), "adverse effects" (AE).
+Expected scale: ~80 qualifiers.';
+
+-- ============================================================================
+-- Create allowable_qualifiers table (descriptor-qualifier pairs)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.allowable_qualifiers (
+    id SERIAL PRIMARY KEY,
+    descriptor_id INTEGER NOT NULL REFERENCES mesh.descriptors(id) ON DELETE CASCADE,
+    qualifier_id INTEGER NOT NULL REFERENCES mesh.qualifiers(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    -- Each pair is unique
+    CONSTRAINT uq_mesh_allowable_qualifiers UNIQUE(descriptor_id, qualifier_id)
+);
+
+COMMENT ON TABLE mesh.allowable_qualifiers IS
+'Maps which qualifiers can be used with which descriptors.
+Not all combinations are valid in MeSH.';
+
+-- ============================================================================
+-- Create supplementary_concepts table (SCRs - chemicals, drugs, etc.)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.supplementary_concepts (
+    id SERIAL PRIMARY KEY,
+    supplemental_ui TEXT NOT NULL UNIQUE,  -- e.g., C000657245
+    supplemental_name TEXT NOT NULL,
+    note TEXT,
+    cas_registry_number TEXT,
+    frequency INTEGER,                     -- Usage frequency in MEDLINE
+    heading_mapped_to TEXT[],              -- Array of descriptor UIs
+    indexing_information TEXT,
+    mesh_year INTEGER NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE mesh.supplementary_concepts IS
+'MeSH Supplementary Concept Records (SCRs) for chemicals, drugs, diseases.
+Mapped to main descriptors but provide more specific terminology.
+Expected scale: ~300,000 SCRs.';
+
+-- ============================================================================
+-- Create import_history table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mesh.import_history (
+    id SERIAL PRIMARY KEY,
+    mesh_year INTEGER NOT NULL,
+    import_type TEXT NOT NULL,            -- 'full', 'incremental', 'supplementary'
+    file_name TEXT,
+    file_size_bytes BIGINT,
+    descriptors_imported INTEGER NOT NULL DEFAULT 0,
+    concepts_imported INTEGER NOT NULL DEFAULT 0,
+    terms_imported INTEGER NOT NULL DEFAULT 0,
+    tree_numbers_imported INTEGER NOT NULL DEFAULT 0,
+    qualifiers_imported INTEGER NOT NULL DEFAULT 0,
+    scrs_imported INTEGER NOT NULL DEFAULT 0,
+    import_status TEXT NOT NULL DEFAULT 'in_progress',
+    started_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMP,
+    error_message TEXT,
+
+    -- Validate import status
+    CONSTRAINT chk_mesh_import_status
+        CHECK (import_status IN ('in_progress', 'completed', 'failed', 'partial')),
+
+    -- Validate import type
+    CONSTRAINT chk_mesh_import_type
+        CHECK (import_type IN ('full', 'incremental', 'supplementary'))
+);
+
+COMMENT ON TABLE mesh.import_history IS
+'Audit trail for MeSH imports. Tracks statistics and status for each import operation.';
+
+-- ============================================================================
+-- Create indexes for performance
+-- ============================================================================
+
+-- Descriptors indexes
+CREATE INDEX IF NOT EXISTS idx_mesh_descriptors_name_lower
+    ON mesh.descriptors(LOWER(descriptor_name));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_descriptors_name_gin
+    ON mesh.descriptors USING gin(to_tsvector('english', descriptor_name));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_descriptors_year
+    ON mesh.descriptors(mesh_year);
+
+-- Concepts indexes
+CREATE INDEX IF NOT EXISTS idx_mesh_concepts_descriptor
+    ON mesh.concepts(descriptor_id);
+
+CREATE INDEX IF NOT EXISTS idx_mesh_concepts_preferred
+    ON mesh.concepts(descriptor_id, is_preferred) WHERE is_preferred = TRUE;
+
+-- Terms indexes
+CREATE INDEX IF NOT EXISTS idx_mesh_terms_text_lower
+    ON mesh.terms(LOWER(term_text));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_terms_text_gin
+    ON mesh.terms USING gin(to_tsvector('english', term_text));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_terms_concept
+    ON mesh.terms(concept_id);
+
+CREATE INDEX IF NOT EXISTS idx_mesh_terms_preferred
+    ON mesh.terms(concept_id, is_preferred) WHERE is_preferred = TRUE;
+
+-- Combined search index (term_ui + text)
+CREATE INDEX IF NOT EXISTS idx_mesh_terms_ui_text
+    ON mesh.terms(term_ui, LOWER(term_text));
+
+-- Tree numbers indexes
+CREATE INDEX IF NOT EXISTS idx_mesh_tree_descriptor
+    ON mesh.tree_numbers(descriptor_id);
+
+CREATE INDEX IF NOT EXISTS idx_mesh_tree_number
+    ON mesh.tree_numbers(tree_number);
+
+CREATE INDEX IF NOT EXISTS idx_mesh_tree_pattern
+    ON mesh.tree_numbers(tree_number text_pattern_ops);
+
+CREATE INDEX IF NOT EXISTS idx_mesh_tree_level
+    ON mesh.tree_numbers(tree_level);
+
+-- Qualifiers indexes
+CREATE INDEX IF NOT EXISTS idx_mesh_qualifiers_name
+    ON mesh.qualifiers(LOWER(qualifier_name));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_qualifiers_abbrev
+    ON mesh.qualifiers(abbreviation);
+
+-- Supplementary concepts indexes
+CREATE INDEX IF NOT EXISTS idx_mesh_scr_name_lower
+    ON mesh.supplementary_concepts(LOWER(supplemental_name));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_scr_name_gin
+    ON mesh.supplementary_concepts USING gin(to_tsvector('english', supplemental_name));
+
+CREATE INDEX IF NOT EXISTS idx_mesh_scr_cas
+    ON mesh.supplementary_concepts(cas_registry_number) WHERE cas_registry_number IS NOT NULL;
+
+-- ============================================================================
+-- Create triggers for auto-updating timestamps
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION mesh.update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_mesh_descriptors_updated_at ON mesh.descriptors;
+CREATE TRIGGER trigger_mesh_descriptors_updated_at
+    BEFORE UPDATE ON mesh.descriptors
+    FOR EACH ROW
+    EXECUTE FUNCTION mesh.update_updated_at();
+
+-- ============================================================================
+-- Create utility functions
+-- ============================================================================
+
+-- Function: Look up a MeSH term and return descriptor info
+CREATE OR REPLACE FUNCTION mesh.lookup_term(search_term TEXT)
+RETURNS TABLE(
+    descriptor_ui TEXT,
+    descriptor_name TEXT,
+    matched_term TEXT,
+    is_preferred_term BOOLEAN,
+    lexical_tag TEXT,
+    scope_note TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT
+        d.descriptor_ui,
+        d.descriptor_name,
+        t.term_text AS matched_term,
+        (t.is_preferred AND c.is_preferred) AS is_preferred_term,
+        t.lexical_tag,
+        d.scope_note
+    FROM mesh.terms t
+    JOIN mesh.concepts c ON t.concept_id = c.id
+    JOIN mesh.descriptors d ON c.descriptor_id = d.id
+    WHERE LOWER(t.term_text) = LOWER(search_term)
+    ORDER BY is_preferred_term DESC, d.descriptor_name;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.lookup_term(TEXT) IS
+'Look up a MeSH term by exact match and return descriptor information.
+Returns multiple rows if term maps to multiple descriptors.
+Example: mesh.lookup_term(''heart attack'')';
+
+-- Function: Get all entry terms (synonyms) for a descriptor
+CREATE OR REPLACE FUNCTION mesh.get_entry_terms(p_descriptor_ui TEXT)
+RETURNS TABLE(
+    term_text TEXT,
+    is_preferred BOOLEAN,
+    lexical_tag TEXT,
+    concept_name TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        t.term_text,
+        (t.is_preferred AND c.is_preferred) AS is_preferred,
+        t.lexical_tag,
+        c.concept_name
+    FROM mesh.terms t
+    JOIN mesh.concepts c ON t.concept_id = c.id
+    JOIN mesh.descriptors d ON c.descriptor_id = d.id
+    WHERE d.descriptor_ui = p_descriptor_ui
+    ORDER BY is_preferred DESC, t.term_text;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.get_entry_terms(TEXT) IS
+'Get all entry terms (synonyms) for a descriptor by UI.
+Example: mesh.get_entry_terms(''D009203'')';
+
+-- Function: Get tree hierarchy for a descriptor
+CREATE OR REPLACE FUNCTION mesh.get_tree_hierarchy(p_descriptor_ui TEXT)
+RETURNS TABLE(
+    tree_number TEXT,
+    tree_level INTEGER,
+    parent_tree_number TEXT,
+    parent_descriptor_ui TEXT,
+    parent_descriptor_name TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH descriptor_trees AS (
+        SELECT tn.tree_number, tn.tree_level
+        FROM mesh.tree_numbers tn
+        JOIN mesh.descriptors d ON tn.descriptor_id = d.id
+        WHERE d.descriptor_ui = p_descriptor_ui
+    )
+    SELECT
+        dt.tree_number,
+        dt.tree_level,
+        substring(dt.tree_number from '^(.+)\.[^.]+$') AS parent_tree_number,
+        pd.descriptor_ui AS parent_descriptor_ui,
+        pd.descriptor_name AS parent_descriptor_name
+    FROM descriptor_trees dt
+    LEFT JOIN mesh.tree_numbers ptn ON ptn.tree_number = substring(dt.tree_number from '^(.+)\.[^.]+$')
+    LEFT JOIN mesh.descriptors pd ON ptn.descriptor_id = pd.id
+    ORDER BY dt.tree_number;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.get_tree_hierarchy(TEXT) IS
+'Get tree hierarchy information for a descriptor, including parent terms.
+Example: mesh.get_tree_hierarchy(''D009203'')';
+
+-- Function: Get broader (parent) terms
+CREATE OR REPLACE FUNCTION mesh.get_broader_terms(p_descriptor_ui TEXT)
+RETURNS TABLE(
+    descriptor_ui TEXT,
+    descriptor_name TEXT,
+    tree_number TEXT,
+    tree_level INTEGER
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH input_trees AS (
+        SELECT tn.tree_number, tn.tree_level
+        FROM mesh.tree_numbers tn
+        JOIN mesh.descriptors d ON tn.descriptor_id = d.id
+        WHERE d.descriptor_ui = p_descriptor_ui
+    ),
+    parent_trees AS (
+        SELECT DISTINCT substring(it.tree_number from '^(.+)\.[^.]+$') AS parent_tree
+        FROM input_trees it
+        WHERE it.tree_number ~ '\.'
+    )
+    SELECT DISTINCT
+        d.descriptor_ui,
+        d.descriptor_name,
+        tn.tree_number,
+        tn.tree_level
+    FROM mesh.tree_numbers tn
+    JOIN mesh.descriptors d ON tn.descriptor_id = d.id
+    JOIN parent_trees pt ON tn.tree_number = pt.parent_tree
+    ORDER BY tn.tree_level, d.descriptor_name;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.get_broader_terms(TEXT) IS
+'Get broader (parent) terms in the MeSH hierarchy.
+Example: mesh.get_broader_terms(''D009203'') -- parents of Myocardial Infarction';
+
+-- Function: Get narrower (child) terms
+CREATE OR REPLACE FUNCTION mesh.get_narrower_terms(p_descriptor_ui TEXT)
+RETURNS TABLE(
+    descriptor_ui TEXT,
+    descriptor_name TEXT,
+    tree_number TEXT,
+    tree_level INTEGER
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH input_trees AS (
+        SELECT tn.tree_number, tn.tree_level
+        FROM mesh.tree_numbers tn
+        JOIN mesh.descriptors d ON tn.descriptor_id = d.id
+        WHERE d.descriptor_ui = p_descriptor_ui
+    )
+    SELECT DISTINCT
+        d.descriptor_ui,
+        d.descriptor_name,
+        tn.tree_number,
+        tn.tree_level
+    FROM mesh.tree_numbers tn
+    JOIN mesh.descriptors d ON tn.descriptor_id = d.id
+    JOIN input_trees it ON tn.tree_number LIKE it.tree_number || '.%'
+    WHERE tn.tree_level = it.tree_level + 1  -- Only immediate children
+    ORDER BY tn.tree_number, d.descriptor_name;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.get_narrower_terms(TEXT) IS
+'Get narrower (child) terms in the MeSH hierarchy (immediate children only).
+Example: mesh.get_narrower_terms(''D006331'') -- children of Heart Diseases';
+
+-- Function: Search MeSH by partial match
+CREATE OR REPLACE FUNCTION mesh.search(
+    search_text TEXT,
+    max_results INTEGER DEFAULT 20
+)
+RETURNS TABLE(
+    descriptor_ui TEXT,
+    descriptor_name TEXT,
+    matched_term TEXT,
+    match_type TEXT,
+    score REAL
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT ON (d.descriptor_ui)
+        d.descriptor_ui,
+        d.descriptor_name,
+        t.term_text AS matched_term,
+        CASE
+            WHEN LOWER(d.descriptor_name) = LOWER(search_text) THEN 'exact_preferred'
+            WHEN LOWER(t.term_text) = LOWER(search_text) THEN 'exact_entry'
+            WHEN d.descriptor_name ILIKE search_text || '%' THEN 'prefix_preferred'
+            WHEN t.term_text ILIKE search_text || '%' THEN 'prefix_entry'
+            ELSE 'partial'
+        END AS match_type,
+        ts_rank(
+            to_tsvector('english', d.descriptor_name || ' ' || COALESCE(d.scope_note, '')),
+            plainto_tsquery('english', search_text)
+        ) AS score
+    FROM mesh.terms t
+    JOIN mesh.concepts c ON t.concept_id = c.id
+    JOIN mesh.descriptors d ON c.descriptor_id = d.id
+    WHERE
+        LOWER(d.descriptor_name) LIKE '%' || LOWER(search_text) || '%'
+        OR LOWER(t.term_text) LIKE '%' || LOWER(search_text) || '%'
+        OR to_tsvector('english', d.descriptor_name) @@ plainto_tsquery('english', search_text)
+    ORDER BY
+        d.descriptor_ui,
+        CASE match_type
+            WHEN 'exact_preferred' THEN 1
+            WHEN 'exact_entry' THEN 2
+            WHEN 'prefix_preferred' THEN 3
+            WHEN 'prefix_entry' THEN 4
+            ELSE 5
+        END,
+        score DESC
+    LIMIT max_results;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.search(TEXT, INTEGER) IS
+'Search MeSH by partial text match on descriptors and entry terms.
+Returns ranked results with match type classification.
+Example: mesh.search(''heart attack'', 10)';
+
+-- Function: Expand a term to all synonyms
+CREATE OR REPLACE FUNCTION mesh.expand_term(search_term TEXT)
+RETURNS TABLE(
+    term_text TEXT,
+    is_original BOOLEAN,
+    lexical_tag TEXT,
+    descriptor_ui TEXT,
+    descriptor_name TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH matched_descriptors AS (
+        SELECT DISTINCT d.id, d.descriptor_ui, d.descriptor_name
+        FROM mesh.terms t
+        JOIN mesh.concepts c ON t.concept_id = c.id
+        JOIN mesh.descriptors d ON c.descriptor_id = d.id
+        WHERE LOWER(t.term_text) = LOWER(search_term)
+    )
+    SELECT DISTINCT
+        t.term_text,
+        (LOWER(t.term_text) = LOWER(search_term)) AS is_original,
+        t.lexical_tag,
+        md.descriptor_ui,
+        md.descriptor_name
+    FROM mesh.terms t
+    JOIN mesh.concepts c ON t.concept_id = c.id
+    JOIN matched_descriptors md ON c.descriptor_id = md.id
+    ORDER BY is_original DESC, t.term_text;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.expand_term(TEXT) IS
+'Expand a MeSH term to all its synonyms/entry terms.
+Example: mesh.expand_term(''MI'') returns Myocardial Infarction, Heart Attack, etc.';
+
+-- Function: Get statistics
+CREATE OR REPLACE FUNCTION mesh.get_statistics()
+RETURNS TABLE(
+    stat_name TEXT,
+    stat_value BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 'descriptors'::TEXT, COUNT(*)::BIGINT FROM mesh.descriptors
+    UNION ALL
+    SELECT 'concepts', COUNT(*) FROM mesh.concepts
+    UNION ALL
+    SELECT 'terms', COUNT(*) FROM mesh.terms
+    UNION ALL
+    SELECT 'tree_numbers', COUNT(*) FROM mesh.tree_numbers
+    UNION ALL
+    SELECT 'qualifiers', COUNT(*) FROM mesh.qualifiers
+    UNION ALL
+    SELECT 'supplementary_concepts', COUNT(*) FROM mesh.supplementary_concepts
+    ORDER BY stat_name;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION mesh.get_statistics() IS
+'Get counts of all MeSH entities in the database.';
+
+-- ============================================================================
+-- Grant permissions
+-- ============================================================================
+
+GRANT USAGE ON SCHEMA mesh TO PUBLIC;
+GRANT SELECT ON ALL TABLES IN SCHEMA mesh TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA mesh TO PUBLIC;
+
+-- ============================================================================
+-- Migration complete
+-- ============================================================================
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 028: MeSH schema created successfully';
+    RAISE NOTICE 'Tables created: descriptors, concepts, terms, tree_numbers, qualifiers, supplementary_concepts, import_history';
+    RAISE NOTICE 'Functions created: lookup_term, get_entry_terms, get_tree_hierarchy, get_broader_terms, get_narrower_terms, search, expand_term, get_statistics';
+    RAISE NOTICE 'Next steps:';
+    RAISE NOTICE '  1. Run mesh_import_cli.py to download and import MeSH data';
+    RAISE NOTICE '  2. Verify import with: SELECT * FROM mesh.get_statistics();';
+    RAISE NOTICE '  3. Test lookup with: SELECT * FROM mesh.lookup_term(''heart attack'');';
+END $$;

--- a/src/bmlibrarian/importers/__init__.py
+++ b/src/bmlibrarian/importers/__init__.py
@@ -1,10 +1,11 @@
 """
-Importers for external data sources (medRxiv, PubMed, etc.)
+Importers for external data sources (medRxiv, PubMed, MeSH, etc.)
 """
 
 from .medrxiv_importer import MedRxivImporter
 from .pubmed_importer import PubMedImporter
 from .pubmed_bulk_importer import PubMedBulkImporter
+from .mesh_importer import MeSHImporter, ImportStats as MeSHImportStats
 from .pdf_matcher import PDFMatcher, DocumentStatus, ExtractedIdentifiers
 from .pdf_converter import (
     PDFConverter,
@@ -22,6 +23,8 @@ __all__ = [
     'MedRxivImporter',
     'PubMedImporter',
     'PubMedBulkImporter',
+    'MeSHImporter',
+    'MeSHImportStats',
     'PDFMatcher',
     'DocumentStatus',
     'ExtractedIdentifiers',

--- a/src/bmlibrarian/importers/mesh_importer.py
+++ b/src/bmlibrarian/importers/mesh_importer.py
@@ -1,0 +1,990 @@
+"""
+MeSH (Medical Subject Headings) Importer.
+
+Downloads and imports the MeSH vocabulary from NLM into the local PostgreSQL database.
+Supports full descriptors, supplementary concept records (SCRs), and qualifiers.
+
+Example usage:
+    from bmlibrarian.importers import MeSHImporter
+
+    importer = MeSHImporter()
+
+    # Download and import full MeSH
+    stats = importer.import_mesh(year=2025)
+    print(f"Imported {stats.descriptors} descriptors")
+
+    # Import supplementary concepts only
+    stats = importer.import_supplementary_concepts(year=2025)
+"""
+
+import gzip
+import logging
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, List, Dict, Any, Iterator, Callable
+from urllib.parse import urljoin
+import requests
+
+from bmlibrarian.database import get_db_manager
+
+logger = logging.getLogger(__name__)
+
+
+# NLM FTP/HTTPS URLs for MeSH data
+MESH_BASE_URL = "https://nlmpubs.nlm.nih.gov/projects/mesh/"
+MESH_FTP_URL = "ftp://nlmpubs.nlm.nih.gov/online/mesh/"
+
+# File names
+DESCRIPTOR_FILE = "desc{year}.xml"
+QUALIFIER_FILE = "qual{year}.xml"
+SUPPLEMENTARY_FILE = "supp{year}.xml"
+
+# Default download directory
+DEFAULT_DOWNLOAD_DIR = Path.home() / ".bmlibrarian" / "downloads" / "mesh"
+
+# Batch sizes for database operations
+DESCRIPTOR_BATCH_SIZE = 100
+TERM_BATCH_SIZE = 1000
+SCR_BATCH_SIZE = 500
+
+# Request settings
+REQUEST_TIMEOUT_SECONDS = 60
+REQUEST_CHUNK_SIZE = 8192
+MAX_RETRIES = 3
+RETRY_DELAY_SECONDS = 5
+
+
+@dataclass
+class MeSHDescriptor:
+    """Parsed MeSH descriptor record."""
+
+    descriptor_ui: str
+    descriptor_name: str
+    scope_note: Optional[str] = None
+    annotation: Optional[str] = None
+    history_note: Optional[str] = None
+    public_mesh_note: Optional[str] = None
+    nlm_classification: Optional[str] = None
+    date_created: Optional[str] = None
+    date_revised: Optional[str] = None
+    date_established: Optional[str] = None
+    concepts: List[Dict[str, Any]] = field(default_factory=list)
+    tree_numbers: List[str] = field(default_factory=list)
+    allowable_qualifiers: List[str] = field(default_factory=list)
+
+
+@dataclass
+class MeSHQualifier:
+    """Parsed MeSH qualifier record."""
+
+    qualifier_ui: str
+    qualifier_name: str
+    abbreviation: str
+    scope_note: Optional[str] = None
+    annotation: Optional[str] = None
+
+
+@dataclass
+class MeSHSupplementary:
+    """Parsed MeSH supplementary concept record."""
+
+    supplemental_ui: str
+    supplemental_name: str
+    note: Optional[str] = None
+    cas_registry_number: Optional[str] = None
+    frequency: Optional[int] = None
+    heading_mapped_to: List[str] = field(default_factory=list)
+    indexing_information: Optional[str] = None
+
+
+@dataclass
+class ImportStats:
+    """Statistics from a MeSH import operation."""
+
+    mesh_year: int
+    import_type: str
+    descriptors: int = 0
+    concepts: int = 0
+    terms: int = 0
+    tree_numbers: int = 0
+    qualifiers: int = 0
+    supplementary_concepts: int = 0
+    started_at: datetime = field(default_factory=datetime.now)
+    completed_at: Optional[datetime] = None
+    duration_seconds: Optional[float] = None
+    status: str = "in_progress"
+    error_message: Optional[str] = None
+
+    def mark_completed(self) -> None:
+        """Mark import as completed and calculate duration."""
+        self.completed_at = datetime.now()
+        self.duration_seconds = (self.completed_at - self.started_at).total_seconds()
+        self.status = "completed"
+
+    def mark_failed(self, error: str) -> None:
+        """Mark import as failed with error message."""
+        self.completed_at = datetime.now()
+        self.duration_seconds = (self.completed_at - self.started_at).total_seconds()
+        self.status = "failed"
+        self.error_message = error
+
+
+class MeSHImporter:
+    """
+    Importer for MeSH (Medical Subject Headings) vocabulary.
+
+    Downloads MeSH XML files from NLM and imports them into the mesh schema.
+    Supports descriptors, qualifiers, and supplementary concept records.
+    """
+
+    def __init__(
+        self,
+        download_dir: Optional[Path] = None,
+        keep_downloads: bool = True,
+    ) -> None:
+        """
+        Initialize MeSH importer.
+
+        Args:
+            download_dir: Directory for downloaded files (default: ~/.bmlibrarian/downloads/mesh)
+            keep_downloads: Whether to keep downloaded files after import
+        """
+        self.db_manager = get_db_manager()
+        self.download_dir = download_dir or DEFAULT_DOWNLOAD_DIR
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        self.keep_downloads = keep_downloads
+
+        logger.info(f"MeSH importer initialized, download dir: {self.download_dir}")
+
+    def _download_file(
+        self,
+        url: str,
+        output_path: Path,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> bool:
+        """
+        Download a file with progress tracking.
+
+        Args:
+            url: URL to download
+            output_path: Local path to save file
+            progress_callback: Optional callback(downloaded_bytes, total_bytes)
+
+        Returns:
+            True if download succeeded
+        """
+        for attempt in range(MAX_RETRIES):
+            try:
+                logger.info(f"Downloading {url} (attempt {attempt + 1}/{MAX_RETRIES})")
+
+                response = requests.get(
+                    url,
+                    stream=True,
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                    headers={"User-Agent": "BMLibrarian/1.0"},
+                )
+                response.raise_for_status()
+
+                total_size = int(response.headers.get("content-length", 0))
+                downloaded = 0
+
+                with open(output_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=REQUEST_CHUNK_SIZE):
+                        if chunk:
+                            f.write(chunk)
+                            downloaded += len(chunk)
+                            if progress_callback:
+                                progress_callback(downloaded, total_size)
+
+                logger.info(f"Downloaded {output_path.name} ({downloaded:,} bytes)")
+                return True
+
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"Download failed: {e}")
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAY_SECONDS)
+                else:
+                    logger.error(f"Download failed after {MAX_RETRIES} attempts")
+                    return False
+
+        return False
+
+    def _get_download_url(self, year: int, file_type: str) -> str:
+        """
+        Get download URL for a MeSH file.
+
+        Args:
+            year: MeSH year (e.g., 2025)
+            file_type: 'descriptor', 'qualifier', or 'supplementary'
+
+        Returns:
+            Full URL for downloading
+        """
+        if file_type == "descriptor":
+            filename = DESCRIPTOR_FILE.format(year=year)
+        elif file_type == "qualifier":
+            filename = QUALIFIER_FILE.format(year=year)
+        elif file_type == "supplementary":
+            filename = SUPPLEMENTARY_FILE.format(year=year)
+        else:
+            raise ValueError(f"Unknown file type: {file_type}")
+
+        # Use HTTPS URL structure
+        return urljoin(MESH_BASE_URL, f"{year}/xmlmesh/{filename}.gz")
+
+    def download_mesh_files(
+        self,
+        year: int,
+        include_supplementary: bool = True,
+        progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    ) -> Dict[str, Path]:
+        """
+        Download MeSH XML files for a given year.
+
+        Args:
+            year: MeSH year to download
+            include_supplementary: Whether to download supplementary concepts
+            progress_callback: Optional callback(file_type, downloaded, total)
+
+        Returns:
+            Dictionary mapping file type to local path
+        """
+        downloaded_files = {}
+
+        # Download descriptors
+        desc_url = self._get_download_url(year, "descriptor")
+        desc_path = self.download_dir / f"desc{year}.xml.gz"
+        if self._download_file(
+            desc_url,
+            desc_path,
+            lambda d, t: progress_callback("descriptor", d, t) if progress_callback else None,
+        ):
+            downloaded_files["descriptor"] = desc_path
+
+        # Download qualifiers
+        qual_url = self._get_download_url(year, "qualifier")
+        qual_path = self.download_dir / f"qual{year}.xml.gz"
+        if self._download_file(
+            qual_url,
+            qual_path,
+            lambda d, t: progress_callback("qualifier", d, t) if progress_callback else None,
+        ):
+            downloaded_files["qualifier"] = qual_path
+
+        # Download supplementary concepts
+        if include_supplementary:
+            supp_url = self._get_download_url(year, "supplementary")
+            supp_path = self.download_dir / f"supp{year}.xml.gz"
+            if self._download_file(
+                supp_url,
+                supp_path,
+                lambda d, t: progress_callback("supplementary", d, t) if progress_callback else None,
+            ):
+                downloaded_files["supplementary"] = supp_path
+
+        return downloaded_files
+
+    def _parse_descriptor(self, elem: ET.Element) -> MeSHDescriptor:
+        """
+        Parse a DescriptorRecord XML element.
+
+        Args:
+            elem: XML element for DescriptorRecord
+
+        Returns:
+            Parsed MeSHDescriptor
+        """
+        descriptor = MeSHDescriptor(
+            descriptor_ui=self._get_text(elem, "DescriptorUI") or "",
+            descriptor_name=self._get_text(elem, "DescriptorName/String") or "",
+        )
+
+        # Parse optional fields
+        descriptor.scope_note = self._get_text(elem, ".//ScopeNote")
+        descriptor.annotation = self._get_text(elem, "Annotation")
+        descriptor.history_note = self._get_text(elem, "HistoryNote")
+        descriptor.public_mesh_note = self._get_text(elem, "PublicMeSHNote")
+        descriptor.nlm_classification = self._get_text(elem, "NLMClassificationNumber")
+        descriptor.date_created = self._get_text(elem, "DateCreated/Year")
+        descriptor.date_revised = self._get_text(elem, "DateRevised/Year")
+        descriptor.date_established = self._get_text(elem, "DateEstablished/Year")
+
+        # Parse tree numbers
+        for tree_elem in elem.findall(".//TreeNumber"):
+            if tree_elem.text:
+                descriptor.tree_numbers.append(tree_elem.text)
+
+        # Parse concepts and terms
+        for concept_elem in elem.findall(".//Concept"):
+            concept = self._parse_concept(concept_elem)
+            descriptor.concepts.append(concept)
+
+        # Parse allowable qualifiers
+        for qual_elem in elem.findall(".//AllowableQualifier/QualifierReferredTo/QualifierUI"):
+            if qual_elem.text:
+                descriptor.allowable_qualifiers.append(qual_elem.text)
+
+        return descriptor
+
+    def _parse_concept(self, elem: ET.Element) -> Dict[str, Any]:
+        """
+        Parse a Concept XML element.
+
+        Args:
+            elem: XML element for Concept
+
+        Returns:
+            Dictionary with concept data
+        """
+        concept = {
+            "concept_ui": self._get_text(elem, "ConceptUI") or "",
+            "concept_name": self._get_text(elem, "ConceptName/String") or "",
+            "is_preferred": elem.get("PreferredConceptYN") == "Y",
+            "scope_note": self._get_text(elem, "ScopeNote"),
+            "cas_registry_number": self._get_text(elem, "CASN1Name"),
+            "terms": [],
+        }
+
+        # Parse terms
+        for term_elem in elem.findall(".//Term"):
+            term = {
+                "term_ui": self._get_text(term_elem, "TermUI") or "",
+                "term_text": self._get_text(term_elem, "String") or "",
+                "is_preferred": term_elem.get("ConceptPreferredTermYN") == "Y",
+                "is_permuted": term_elem.get("IsPermutedTermYN") == "Y",
+                "lexical_tag": term_elem.get("LexicalTag"),
+                "entry_combination": self._get_text(term_elem, "EntryVersion"),
+                "sort_version": self._get_text(term_elem, "SortVersion"),
+            }
+            concept["terms"].append(term)
+
+        return concept
+
+    def _parse_qualifier(self, elem: ET.Element) -> MeSHQualifier:
+        """
+        Parse a QualifierRecord XML element.
+
+        Args:
+            elem: XML element for QualifierRecord
+
+        Returns:
+            Parsed MeSHQualifier
+        """
+        return MeSHQualifier(
+            qualifier_ui=self._get_text(elem, "QualifierUI") or "",
+            qualifier_name=self._get_text(elem, "QualifierName/String") or "",
+            abbreviation=self._get_text(elem, "Abbreviation") or "",
+            scope_note=self._get_text(elem, ".//ScopeNote"),
+            annotation=self._get_text(elem, "Annotation"),
+        )
+
+    def _parse_supplementary(self, elem: ET.Element) -> MeSHSupplementary:
+        """
+        Parse a SupplementalRecord XML element.
+
+        Args:
+            elem: XML element for SupplementalRecord
+
+        Returns:
+            Parsed MeSHSupplementary
+        """
+        scr = MeSHSupplementary(
+            supplemental_ui=self._get_text(elem, "SupplementalRecordUI") or "",
+            supplemental_name=self._get_text(elem, "SupplementalRecordName/String") or "",
+        )
+
+        scr.note = self._get_text(elem, "Note")
+        scr.indexing_information = self._get_text(elem, "IndexingInformation")
+
+        # Parse frequency
+        freq_text = self._get_text(elem, "Frequency")
+        if freq_text:
+            try:
+                scr.frequency = int(freq_text)
+            except ValueError:
+                pass
+
+        # Parse mapped headings
+        for mapping in elem.findall(".//HeadingMappedTo/DescriptorReferredTo/DescriptorUI"):
+            if mapping.text:
+                scr.heading_mapped_to.append(mapping.text)
+
+        # Parse CAS number from concepts
+        cas = self._get_text(elem, ".//CASN1Name")
+        if cas:
+            scr.cas_registry_number = cas
+
+        return scr
+
+    def _get_text(self, elem: ET.Element, path: str) -> Optional[str]:
+        """
+        Get text content from an XML element by path.
+
+        Args:
+            elem: Parent XML element
+            path: XPath to child element
+
+        Returns:
+            Text content or None
+        """
+        child = elem.find(path)
+        if child is not None and child.text:
+            return child.text.strip()
+        return None
+
+    def _iter_xml_records(
+        self,
+        file_path: Path,
+        record_tag: str,
+    ) -> Iterator[ET.Element]:
+        """
+        Iterate over XML records in a (possibly gzipped) file.
+
+        Uses iterparse for memory-efficient streaming.
+
+        Args:
+            file_path: Path to XML or XML.gz file
+            record_tag: XML tag name for records
+
+        Yields:
+            XML elements for each record
+        """
+        # Open file (gzipped or plain)
+        if file_path.suffix == ".gz":
+            f = gzip.open(file_path, "rb")
+        else:
+            f = open(file_path, "rb")
+
+        try:
+            context = ET.iterparse(f, events=("end",))
+            for event, elem in context:
+                if elem.tag == record_tag:
+                    yield elem
+                    # Clear element to save memory
+                    elem.clear()
+        finally:
+            f.close()
+
+    def _store_descriptor(
+        self,
+        descriptor: MeSHDescriptor,
+        mesh_year: int,
+        conn: Any,
+    ) -> int:
+        """
+        Store a descriptor and its concepts/terms in the database.
+
+        Args:
+            descriptor: Parsed descriptor
+            mesh_year: MeSH year
+            conn: Database connection
+
+        Returns:
+            Number of terms stored
+        """
+        terms_count = 0
+
+        with conn.cursor() as cur:
+            # Insert descriptor
+            cur.execute(
+                """
+                INSERT INTO mesh.descriptors (
+                    descriptor_ui, descriptor_name, scope_note, annotation,
+                    history_note, public_mesh_note, nlm_classification,
+                    date_created, date_revised, date_established, mesh_year
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (descriptor_ui) DO UPDATE SET
+                    descriptor_name = EXCLUDED.descriptor_name,
+                    scope_note = EXCLUDED.scope_note,
+                    annotation = EXCLUDED.annotation,
+                    history_note = EXCLUDED.history_note,
+                    public_mesh_note = EXCLUDED.public_mesh_note,
+                    nlm_classification = EXCLUDED.nlm_classification,
+                    date_revised = EXCLUDED.date_revised,
+                    mesh_year = EXCLUDED.mesh_year,
+                    updated_at = NOW()
+                RETURNING id
+                """,
+                (
+                    descriptor.descriptor_ui,
+                    descriptor.descriptor_name,
+                    descriptor.scope_note,
+                    descriptor.annotation,
+                    descriptor.history_note,
+                    descriptor.public_mesh_note,
+                    descriptor.nlm_classification,
+                    self._parse_date(descriptor.date_created),
+                    self._parse_date(descriptor.date_revised),
+                    self._parse_date(descriptor.date_established),
+                    mesh_year,
+                ),
+            )
+            descriptor_id = cur.fetchone()[0]
+
+            # Delete existing tree numbers (for clean update)
+            cur.execute(
+                "DELETE FROM mesh.tree_numbers WHERE descriptor_id = %s",
+                (descriptor_id,),
+            )
+
+            # Insert tree numbers
+            for tree_num in descriptor.tree_numbers:
+                level = tree_num.count(".") + 1
+                cur.execute(
+                    """
+                    INSERT INTO mesh.tree_numbers (descriptor_id, tree_number, tree_level)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (descriptor_id, tree_number) DO NOTHING
+                    """,
+                    (descriptor_id, tree_num, level),
+                )
+
+            # Insert concepts and terms
+            for concept_data in descriptor.concepts:
+                cur.execute(
+                    """
+                    INSERT INTO mesh.concepts (
+                        concept_ui, concept_name, descriptor_id, is_preferred,
+                        scope_note, cas_registry_number
+                    ) VALUES (%s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (concept_ui) DO UPDATE SET
+                        concept_name = EXCLUDED.concept_name,
+                        is_preferred = EXCLUDED.is_preferred,
+                        scope_note = EXCLUDED.scope_note
+                    RETURNING id
+                    """,
+                    (
+                        concept_data["concept_ui"],
+                        concept_data["concept_name"],
+                        descriptor_id,
+                        concept_data["is_preferred"],
+                        concept_data.get("scope_note"),
+                        concept_data.get("cas_registry_number"),
+                    ),
+                )
+                concept_id = cur.fetchone()[0]
+
+                # Insert terms
+                for term_data in concept_data.get("terms", []):
+                    cur.execute(
+                        """
+                        INSERT INTO mesh.terms (
+                            term_ui, term_text, concept_id, is_preferred,
+                            is_permuted, lexical_tag, entry_combination, sort_version
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT DO NOTHING
+                        """,
+                        (
+                            term_data["term_ui"],
+                            term_data["term_text"],
+                            concept_id,
+                            term_data["is_preferred"],
+                            term_data["is_permuted"],
+                            term_data.get("lexical_tag"),
+                            term_data.get("entry_combination"),
+                            term_data.get("sort_version"),
+                        ),
+                    )
+                    terms_count += 1
+
+        return terms_count
+
+    def _parse_date(self, year_str: Optional[str]) -> Optional[str]:
+        """
+        Parse a year string to a date.
+
+        Args:
+            year_str: Year string (e.g., "2025")
+
+        Returns:
+            Date string or None
+        """
+        if year_str:
+            try:
+                return f"{int(year_str)}-01-01"
+            except ValueError:
+                pass
+        return None
+
+    def import_descriptors(
+        self,
+        file_path: Path,
+        mesh_year: int,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> ImportStats:
+        """
+        Import MeSH descriptors from XML file.
+
+        Args:
+            file_path: Path to descriptor XML file
+            mesh_year: MeSH year
+            progress_callback: Optional callback(processed, total)
+
+        Returns:
+            Import statistics
+        """
+        stats = ImportStats(mesh_year=mesh_year, import_type="full")
+
+        try:
+            # Count total records first (for progress)
+            total_records = sum(1 for _ in self._iter_xml_records(file_path, "DescriptorRecord"))
+            logger.info(f"Found {total_records:,} descriptor records")
+
+            # Process records
+            with self.db_manager.get_connection() as conn:
+                for i, elem in enumerate(self._iter_xml_records(file_path, "DescriptorRecord")):
+                    descriptor = self._parse_descriptor(elem)
+                    terms_count = self._store_descriptor(descriptor, mesh_year, conn)
+
+                    stats.descriptors += 1
+                    stats.concepts += len(descriptor.concepts)
+                    stats.terms += terms_count
+                    stats.tree_numbers += len(descriptor.tree_numbers)
+
+                    if progress_callback and (i + 1) % 100 == 0:
+                        progress_callback(i + 1, total_records)
+
+                conn.commit()
+
+            stats.mark_completed()
+            logger.info(
+                f"Imported {stats.descriptors:,} descriptors, "
+                f"{stats.concepts:,} concepts, {stats.terms:,} terms"
+            )
+
+        except Exception as e:
+            logger.error(f"Error importing descriptors: {e}")
+            stats.mark_failed(str(e))
+            raise
+
+        return stats
+
+    def import_qualifiers(
+        self,
+        file_path: Path,
+        mesh_year: int,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> ImportStats:
+        """
+        Import MeSH qualifiers from XML file.
+
+        Args:
+            file_path: Path to qualifier XML file
+            mesh_year: MeSH year
+            progress_callback: Optional callback(processed, total)
+
+        Returns:
+            Import statistics
+        """
+        stats = ImportStats(mesh_year=mesh_year, import_type="full")
+
+        try:
+            with self.db_manager.get_connection() as conn:
+                with conn.cursor() as cur:
+                    for elem in self._iter_xml_records(file_path, "QualifierRecord"):
+                        qualifier = self._parse_qualifier(elem)
+
+                        cur.execute(
+                            """
+                            INSERT INTO mesh.qualifiers (
+                                qualifier_ui, qualifier_name, abbreviation,
+                                scope_note, annotation, mesh_year
+                            ) VALUES (%s, %s, %s, %s, %s, %s)
+                            ON CONFLICT (qualifier_ui) DO UPDATE SET
+                                qualifier_name = EXCLUDED.qualifier_name,
+                                abbreviation = EXCLUDED.abbreviation,
+                                scope_note = EXCLUDED.scope_note,
+                                annotation = EXCLUDED.annotation,
+                                mesh_year = EXCLUDED.mesh_year
+                            """,
+                            (
+                                qualifier.qualifier_ui,
+                                qualifier.qualifier_name,
+                                qualifier.abbreviation,
+                                qualifier.scope_note,
+                                qualifier.annotation,
+                                mesh_year,
+                            ),
+                        )
+                        stats.qualifiers += 1
+
+                        if progress_callback:
+                            progress_callback(stats.qualifiers, 0)
+
+                conn.commit()
+
+            stats.mark_completed()
+            logger.info(f"Imported {stats.qualifiers:,} qualifiers")
+
+        except Exception as e:
+            logger.error(f"Error importing qualifiers: {e}")
+            stats.mark_failed(str(e))
+            raise
+
+        return stats
+
+    def import_supplementary_concepts(
+        self,
+        file_path: Path,
+        mesh_year: int,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> ImportStats:
+        """
+        Import MeSH supplementary concept records from XML file.
+
+        Args:
+            file_path: Path to supplementary XML file
+            mesh_year: MeSH year
+            progress_callback: Optional callback(processed, total)
+
+        Returns:
+            Import statistics
+        """
+        stats = ImportStats(mesh_year=mesh_year, import_type="supplementary")
+
+        try:
+            # Count total records
+            total_records = sum(
+                1 for _ in self._iter_xml_records(file_path, "SupplementalRecord")
+            )
+            logger.info(f"Found {total_records:,} supplementary records")
+
+            with self.db_manager.get_connection() as conn:
+                with conn.cursor() as cur:
+                    for i, elem in enumerate(
+                        self._iter_xml_records(file_path, "SupplementalRecord")
+                    ):
+                        scr = self._parse_supplementary(elem)
+
+                        cur.execute(
+                            """
+                            INSERT INTO mesh.supplementary_concepts (
+                                supplemental_ui, supplemental_name, note,
+                                cas_registry_number, frequency, heading_mapped_to,
+                                indexing_information, mesh_year
+                            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                            ON CONFLICT (supplemental_ui) DO UPDATE SET
+                                supplemental_name = EXCLUDED.supplemental_name,
+                                note = EXCLUDED.note,
+                                cas_registry_number = EXCLUDED.cas_registry_number,
+                                frequency = EXCLUDED.frequency,
+                                heading_mapped_to = EXCLUDED.heading_mapped_to,
+                                indexing_information = EXCLUDED.indexing_information,
+                                mesh_year = EXCLUDED.mesh_year
+                            """,
+                            (
+                                scr.supplemental_ui,
+                                scr.supplemental_name,
+                                scr.note,
+                                scr.cas_registry_number,
+                                scr.frequency,
+                                scr.heading_mapped_to,
+                                scr.indexing_information,
+                                mesh_year,
+                            ),
+                        )
+                        stats.supplementary_concepts += 1
+
+                        if progress_callback and (i + 1) % 1000 == 0:
+                            progress_callback(i + 1, total_records)
+
+                conn.commit()
+
+            stats.mark_completed()
+            logger.info(f"Imported {stats.supplementary_concepts:,} supplementary concepts")
+
+        except Exception as e:
+            logger.error(f"Error importing supplementary concepts: {e}")
+            stats.mark_failed(str(e))
+            raise
+
+        return stats
+
+    def _record_import(self, stats: ImportStats) -> int:
+        """
+        Record import in history table.
+
+        Args:
+            stats: Import statistics
+
+        Returns:
+            Import history ID
+        """
+        with self.db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO mesh.import_history (
+                        mesh_year, import_type, descriptors_imported,
+                        concepts_imported, terms_imported, tree_numbers_imported,
+                        qualifiers_imported, scrs_imported, import_status,
+                        started_at, completed_at, error_message
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    RETURNING id
+                    """,
+                    (
+                        stats.mesh_year,
+                        stats.import_type,
+                        stats.descriptors,
+                        stats.concepts,
+                        stats.terms,
+                        stats.tree_numbers,
+                        stats.qualifiers,
+                        stats.supplementary_concepts,
+                        stats.status,
+                        stats.started_at,
+                        stats.completed_at,
+                        stats.error_message,
+                    ),
+                )
+                import_id = cur.fetchone()[0]
+            conn.commit()
+        return import_id
+
+    def import_mesh(
+        self,
+        year: int,
+        include_supplementary: bool = True,
+        progress_callback: Optional[Callable[[str, int, int], None]] = None,
+    ) -> ImportStats:
+        """
+        Download and import complete MeSH vocabulary for a year.
+
+        Args:
+            year: MeSH year to import
+            include_supplementary: Whether to include supplementary concepts
+            progress_callback: Optional callback(phase, processed, total)
+
+        Returns:
+            Combined import statistics
+        """
+        total_stats = ImportStats(mesh_year=year, import_type="full")
+
+        try:
+            # Download files
+            logger.info(f"Downloading MeSH {year} files...")
+            if progress_callback:
+                progress_callback("download", 0, 3 if include_supplementary else 2)
+
+            files = self.download_mesh_files(year, include_supplementary)
+
+            if "descriptor" not in files:
+                raise ValueError("Failed to download descriptor file")
+
+            # Import descriptors
+            logger.info("Importing descriptors...")
+            desc_stats = self.import_descriptors(
+                files["descriptor"],
+                year,
+                lambda p, t: progress_callback("descriptors", p, t)
+                if progress_callback
+                else None,
+            )
+            total_stats.descriptors = desc_stats.descriptors
+            total_stats.concepts = desc_stats.concepts
+            total_stats.terms = desc_stats.terms
+            total_stats.tree_numbers = desc_stats.tree_numbers
+
+            # Import qualifiers
+            if "qualifier" in files:
+                logger.info("Importing qualifiers...")
+                qual_stats = self.import_qualifiers(
+                    files["qualifier"],
+                    year,
+                    lambda p, t: progress_callback("qualifiers", p, t)
+                    if progress_callback
+                    else None,
+                )
+                total_stats.qualifiers = qual_stats.qualifiers
+
+            # Import supplementary concepts
+            if include_supplementary and "supplementary" in files:
+                logger.info("Importing supplementary concepts...")
+                supp_stats = self.import_supplementary_concepts(
+                    files["supplementary"],
+                    year,
+                    lambda p, t: progress_callback("supplementary", p, t)
+                    if progress_callback
+                    else None,
+                )
+                total_stats.supplementary_concepts = supp_stats.supplementary_concepts
+
+            # Clean up downloads if requested
+            if not self.keep_downloads:
+                for file_path in files.values():
+                    try:
+                        file_path.unlink()
+                    except Exception as e:
+                        logger.warning(f"Could not delete {file_path}: {e}")
+
+            total_stats.mark_completed()
+            self._record_import(total_stats)
+
+            logger.info(
+                f"MeSH {year} import complete: "
+                f"{total_stats.descriptors:,} descriptors, "
+                f"{total_stats.concepts:,} concepts, "
+                f"{total_stats.terms:,} terms, "
+                f"{total_stats.qualifiers:,} qualifiers, "
+                f"{total_stats.supplementary_concepts:,} SCRs"
+            )
+
+        except Exception as e:
+            logger.error(f"MeSH import failed: {e}")
+            total_stats.mark_failed(str(e))
+            self._record_import(total_stats)
+            raise
+
+        return total_stats
+
+    def get_import_history(self) -> List[Dict[str, Any]]:
+        """
+        Get import history from database.
+
+        Returns:
+            List of import history records
+        """
+        with self.db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        id, mesh_year, import_type,
+                        descriptors_imported, concepts_imported, terms_imported,
+                        tree_numbers_imported, qualifiers_imported, scrs_imported,
+                        import_status, started_at, completed_at, error_message
+                    FROM mesh.import_history
+                    ORDER BY started_at DESC
+                    """
+                )
+                columns = [
+                    "id",
+                    "mesh_year",
+                    "import_type",
+                    "descriptors",
+                    "concepts",
+                    "terms",
+                    "tree_numbers",
+                    "qualifiers",
+                    "scrs",
+                    "status",
+                    "started_at",
+                    "completed_at",
+                    "error_message",
+                ]
+                return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+    def get_statistics(self) -> Dict[str, int]:
+        """
+        Get current MeSH database statistics.
+
+        Returns:
+            Dictionary with counts of each entity type
+        """
+        with self.db_manager.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM mesh.get_statistics()")
+                return {row[0]: row[1] for row in cur.fetchall()}

--- a/src/bmlibrarian/mesh/__init__.py
+++ b/src/bmlibrarian/mesh/__init__.py
@@ -1,0 +1,42 @@
+"""
+MeSH (Medical Subject Headings) module for BMLibrarian.
+
+This module provides local MeSH database storage and lookup functionality
+with automatic fallback to NLM's public API when local data is unavailable.
+
+Example usage:
+    from bmlibrarian.mesh import MeSHService, MeSHResult
+
+    # Create service (automatically uses local DB if available)
+    service = MeSHService()
+
+    # Look up a term
+    result = service.lookup("heart attack")
+    if result.found:
+        print(f"Descriptor: {result.descriptor_name}")
+        print(f"Entry terms: {result.entry_terms}")
+
+    # Expand a term to all synonyms
+    synonyms = service.expand("MI")  # Returns all terms for Myocardial Infarction
+
+    # Search MeSH by partial match
+    results = service.search("cardio", limit=10)
+"""
+
+from .lookup import MeSHService, MeSHResult, MeSHSource
+from .data_types import (
+    MeSHDescriptorInfo,
+    MeSHTermInfo,
+    MeSHTreeInfo,
+    MeSHSearchResult,
+)
+
+__all__ = [
+    "MeSHService",
+    "MeSHResult",
+    "MeSHSource",
+    "MeSHDescriptorInfo",
+    "MeSHTermInfo",
+    "MeSHTreeInfo",
+    "MeSHSearchResult",
+]

--- a/src/bmlibrarian/mesh/data_types.py
+++ b/src/bmlibrarian/mesh/data_types.py
@@ -1,0 +1,193 @@
+"""
+Type-safe dataclasses for MeSH module.
+
+This module defines all data structures used throughout the MeSH system,
+ensuring type safety and clear interfaces between components.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, List
+
+
+class MeSHSource(Enum):
+    """Source of MeSH lookup result."""
+
+    LOCAL_DATABASE = "local_database"
+    NLM_API = "nlm_api"
+    CACHE = "cache"
+    NOT_FOUND = "not_found"
+
+
+@dataclass
+class MeSHTermInfo:
+    """
+    Information about a MeSH term variant.
+
+    Attributes:
+        term_text: The term string (e.g., "MI", "Heart Attack")
+        is_preferred: Whether this is the preferred term for its concept
+        lexical_tag: Type of term (ABB, SYN, TRD, etc.)
+        concept_name: Name of the parent concept
+    """
+
+    term_text: str
+    is_preferred: bool = False
+    lexical_tag: Optional[str] = None
+    concept_name: Optional[str] = None
+
+
+@dataclass
+class MeSHTreeInfo:
+    """
+    Information about a MeSH tree number (hierarchy position).
+
+    Attributes:
+        tree_number: The tree number (e.g., "C14.280.647.500")
+        tree_level: Depth in hierarchy (1 = top level)
+        parent_tree_number: Parent tree number if exists
+        parent_descriptor_ui: Parent descriptor UI
+        parent_descriptor_name: Parent descriptor name
+    """
+
+    tree_number: str
+    tree_level: int
+    parent_tree_number: Optional[str] = None
+    parent_descriptor_ui: Optional[str] = None
+    parent_descriptor_name: Optional[str] = None
+
+
+@dataclass
+class MeSHDescriptorInfo:
+    """
+    Complete information about a MeSH descriptor.
+
+    Attributes:
+        descriptor_ui: Unique identifier (e.g., "D009203")
+        descriptor_name: Preferred/canonical name
+        scope_note: Definition/description
+        entry_terms: All term variants (synonyms, abbreviations, etc.)
+        tree_numbers: Hierarchical tree positions
+        tree_info: Detailed tree hierarchy information
+    """
+
+    descriptor_ui: str
+    descriptor_name: str
+    scope_note: Optional[str] = None
+    entry_terms: List[str] = field(default_factory=list)
+    tree_numbers: List[str] = field(default_factory=list)
+    tree_info: List[MeSHTreeInfo] = field(default_factory=list)
+    term_details: List[MeSHTermInfo] = field(default_factory=list)
+
+    def get_abbreviations(self) -> List[str]:
+        """Get all abbreviation terms."""
+        return [
+            t.term_text
+            for t in self.term_details
+            if t.lexical_tag in ("ABB", "ABX", "ACR")
+        ]
+
+    def get_synonyms(self) -> List[str]:
+        """Get all synonym terms (excluding abbreviations)."""
+        return [
+            t.term_text
+            for t in self.term_details
+            if t.lexical_tag not in ("ABB", "ABX", "ACR")
+            and not t.is_preferred
+        ]
+
+
+@dataclass
+class MeSHSearchResult:
+    """
+    Result from a MeSH search operation.
+
+    Attributes:
+        descriptor_ui: MeSH descriptor UI
+        descriptor_name: Preferred descriptor name
+        matched_term: The term that matched the search
+        match_type: Type of match (exact, prefix, partial)
+        score: Relevance score
+    """
+
+    descriptor_ui: str
+    descriptor_name: str
+    matched_term: str
+    match_type: str = "partial"
+    score: float = 0.0
+
+
+@dataclass
+class MeSHResult:
+    """
+    Result of a MeSH term lookup operation.
+
+    Attributes:
+        found: Whether the term was found
+        source: Where the result came from (local DB, API, cache)
+        descriptor_ui: MeSH descriptor UI if found
+        descriptor_name: Preferred descriptor name if found
+        scope_note: Definition if available
+        entry_terms: All term variants
+        tree_numbers: Hierarchical tree positions
+        searched_term: Original term that was searched
+        is_valid: Whether term is a valid MeSH term
+    """
+
+    found: bool
+    source: MeSHSource
+    searched_term: str
+    descriptor_ui: str = ""
+    descriptor_name: str = ""
+    scope_note: Optional[str] = None
+    entry_terms: List[str] = field(default_factory=list)
+    tree_numbers: List[str] = field(default_factory=list)
+    is_valid: bool = False
+
+    @classmethod
+    def not_found(cls, searched_term: str) -> "MeSHResult":
+        """Create a not-found result."""
+        return cls(
+            found=False,
+            source=MeSHSource.NOT_FOUND,
+            searched_term=searched_term,
+            is_valid=False,
+        )
+
+    @classmethod
+    def from_descriptor_info(
+        cls,
+        info: MeSHDescriptorInfo,
+        searched_term: str,
+        source: MeSHSource,
+    ) -> "MeSHResult":
+        """Create result from descriptor info."""
+        return cls(
+            found=True,
+            source=source,
+            searched_term=searched_term,
+            descriptor_ui=info.descriptor_ui,
+            descriptor_name=info.descriptor_name,
+            scope_note=info.scope_note,
+            entry_terms=info.entry_terms,
+            tree_numbers=info.tree_numbers,
+            is_valid=True,
+        )
+
+    def to_pubmed_syntax(self, explode: bool = True) -> str:
+        """
+        Convert to PubMed query syntax.
+
+        Args:
+            explode: If True, include narrower terms (default MeSH behavior)
+
+        Returns:
+            PubMed-formatted MeSH term query
+        """
+        if not self.is_valid or not self.descriptor_name:
+            return ""
+
+        if explode:
+            return f'"{self.descriptor_name}"[MeSH Terms]'
+        else:
+            return f'"{self.descriptor_name}"[MeSH Terms:noexp]'

--- a/src/bmlibrarian/mesh/lookup.py
+++ b/src/bmlibrarian/mesh/lookup.py
@@ -1,0 +1,778 @@
+"""
+MeSH lookup service with local database and API fallback.
+
+This module provides a unified interface for MeSH term lookup that:
+1. First checks the local PostgreSQL database (mesh schema)
+2. Falls back to NLM's public MeSH API if local data unavailable
+3. Caches API results in a local SQLite database
+
+Example usage:
+    from bmlibrarian.mesh import MeSHService
+
+    service = MeSHService()
+
+    # Lookup a term
+    result = service.lookup("heart attack")
+    if result.found:
+        print(f"Found: {result.descriptor_name}")
+        print(f"Source: {result.source}")
+
+    # Expand to all synonyms
+    terms = service.expand("MI")
+
+    # Search by partial match
+    results = service.search("cardio", limit=10)
+"""
+
+import json
+import logging
+import sqlite3
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+import requests
+
+from .data_types import (
+    MeSHSource,
+    MeSHResult,
+    MeSHDescriptorInfo,
+    MeSHTermInfo,
+    MeSHTreeInfo,
+    MeSHSearchResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# Import shared constants from pubmed_search to avoid duplication (golden rule #2)
+try:
+    from bmlibrarian.pubmed_search.constants import (
+        MESH_BROWSER_API_URL,
+        ESEARCH_URL,
+        EFETCH_URL,
+        REQUEST_TIMEOUT_SECONDS,
+        MAX_RETRIES,
+        INITIAL_RETRY_DELAY_SECONDS,
+        RETRY_BACKOFF_MULTIPLIER,
+        REQUEST_DELAY_WITHOUT_KEY,
+        MESH_CACHE_TTL_DAYS as CACHE_TTL_DAYS,
+    )
+except ImportError:
+    # Fallback constants if pubmed_search not available
+    MESH_BROWSER_API_URL = "https://id.nlm.nih.gov/mesh/lookup/descriptor"
+    ESEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    EFETCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    REQUEST_TIMEOUT_SECONDS = 30
+    MAX_RETRIES = 3
+    INITIAL_RETRY_DELAY_SECONDS = 1
+    RETRY_BACKOFF_MULTIPLIER = 2
+    REQUEST_DELAY_WITHOUT_KEY = 0.34
+    CACHE_TTL_DAYS = 30
+
+# Cache settings (specific to this module)
+DEFAULT_CACHE_DIR = Path.home() / ".bmlibrarian" / "cache"
+CACHE_FILENAME = "mesh_api_cache.db"
+
+
+class MeSHService:
+    """
+    Unified MeSH lookup service with local database and API fallback.
+
+    Provides methods for:
+    - Term lookup (exact match)
+    - Term expansion (get all synonyms)
+    - Term search (partial match)
+    - Broader/narrower term navigation
+
+    Automatically uses local PostgreSQL database when available,
+    falls back to NLM API when needed, and caches API results.
+    """
+
+    def __init__(
+        self,
+        use_local_db: bool = True,
+        use_api_fallback: bool = True,
+        cache_dir: Optional[Path] = None,
+        cache_ttl_days: int = CACHE_TTL_DAYS,
+        email: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize MeSH service.
+
+        Args:
+            use_local_db: Whether to check local PostgreSQL database
+            use_api_fallback: Whether to fall back to NLM API
+            cache_dir: Directory for API cache (default: ~/.bmlibrarian/cache)
+            cache_ttl_days: Days before cache entries expire
+            email: Email for NCBI API (recommended)
+            api_key: NCBI API key for higher rate limits
+        """
+        self.use_local_db = use_local_db
+        self.use_api_fallback = use_api_fallback
+        self.cache_ttl_days = cache_ttl_days
+        self.email = email
+        self.api_key = api_key
+        self.request_delay = REQUEST_DELAY_WITHOUT_KEY if not api_key else 0.1
+
+        # Initialize local database connection
+        self._db_manager = None
+        self._local_db_available = False
+        if use_local_db:
+            self._check_local_db()
+
+        # Initialize API cache
+        if cache_dir is None:
+            cache_dir = DEFAULT_CACHE_DIR
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_path = self.cache_dir / CACHE_FILENAME
+        self._init_cache()
+
+        logger.info(
+            f"MeSH service initialized: "
+            f"local_db={'available' if self._local_db_available else 'unavailable'}, "
+            f"api_fallback={use_api_fallback}"
+        )
+
+    def _check_local_db(self) -> None:
+        """Check if local PostgreSQL database is available and has MeSH data."""
+        try:
+            from bmlibrarian.database import get_db_manager
+
+            self._db_manager = get_db_manager()
+
+            # Check if mesh schema exists and has data
+            with self._db_manager.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1 FROM information_schema.schemata
+                            WHERE schema_name = 'mesh'
+                        )
+                        """
+                    )
+                    schema_exists = cur.fetchone()[0]
+
+                    if schema_exists:
+                        cur.execute("SELECT COUNT(*) FROM mesh.descriptors")
+                        count = cur.fetchone()[0]
+                        self._local_db_available = count > 0
+                        if self._local_db_available:
+                            logger.info(f"Local MeSH database available: {count:,} descriptors")
+                    else:
+                        logger.info("MeSH schema not found in database")
+
+        except Exception as e:
+            logger.warning(f"Could not connect to local database: {e}")
+            self._local_db_available = False
+
+    def _init_cache(self) -> None:
+        """Initialize the SQLite API cache database."""
+        with sqlite3.connect(self.cache_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS mesh_cache (
+                    search_term TEXT PRIMARY KEY,
+                    result_json TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_mesh_cache_cached_at
+                    ON mesh_cache(cached_at);
+                """
+            )
+
+    def _get_from_cache(self, search_term: str) -> Optional[MeSHResult]:
+        """
+        Get a cached result if valid.
+
+        Args:
+            search_term: Term to look up
+
+        Returns:
+            Cached MeSHResult or None
+        """
+        normalized = search_term.lower().strip()
+
+        with sqlite3.connect(self.cache_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT result_json, cached_at FROM mesh_cache WHERE search_term = ?",
+                (normalized,),
+            )
+            row = cursor.fetchone()
+
+            if row is None:
+                return None
+
+            # Check if cache is expired
+            cached_at = datetime.fromisoformat(row["cached_at"])
+            if datetime.now() - cached_at > timedelta(days=self.cache_ttl_days):
+                conn.execute("DELETE FROM mesh_cache WHERE search_term = ?", (normalized,))
+                return None
+
+            try:
+                data = json.loads(row["result_json"])
+                return MeSHResult(
+                    found=data["found"],
+                    source=MeSHSource.CACHE,
+                    searched_term=search_term,
+                    descriptor_ui=data.get("descriptor_ui", ""),
+                    descriptor_name=data.get("descriptor_name", ""),
+                    scope_note=data.get("scope_note"),
+                    entry_terms=data.get("entry_terms", []),
+                    tree_numbers=data.get("tree_numbers", []),
+                    is_valid=data.get("is_valid", False),
+                )
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning(f"Invalid cache entry for {search_term}: {e}")
+                return None
+
+    def _save_to_cache(self, result: MeSHResult) -> None:
+        """
+        Save a result to cache.
+
+        Args:
+            result: MeSHResult to cache
+        """
+        normalized = result.searched_term.lower().strip()
+
+        data = {
+            "found": result.found,
+            "descriptor_ui": result.descriptor_ui,
+            "descriptor_name": result.descriptor_name,
+            "scope_note": result.scope_note,
+            "entry_terms": result.entry_terms,
+            "tree_numbers": result.tree_numbers,
+            "is_valid": result.is_valid,
+        }
+
+        with sqlite3.connect(self.cache_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO mesh_cache (search_term, result_json, source, cached_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (normalized, json.dumps(data), result.source.value, datetime.now().isoformat()),
+            )
+
+    def _lookup_local(self, term: str) -> Optional[MeSHResult]:
+        """
+        Look up a term in the local PostgreSQL database.
+
+        Args:
+            term: Term to look up
+
+        Returns:
+            MeSHResult or None if not found
+        """
+        if not self._local_db_available or self._db_manager is None:
+            return None
+
+        try:
+            with self._db_manager.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT * FROM mesh.lookup_term(%s)",
+                        (term,),
+                    )
+                    rows = cur.fetchall()
+
+                    if not rows:
+                        return None
+
+                    # Use first result (exact match prioritized)
+                    row = rows[0]
+                    descriptor_ui = row[0]
+                    descriptor_name = row[1]
+                    scope_note = row[5]
+
+                    # Get entry terms
+                    cur.execute(
+                        "SELECT term_text FROM mesh.get_entry_terms(%s)",
+                        (descriptor_ui,),
+                    )
+                    entry_terms = [r[0] for r in cur.fetchall()]
+
+                    # Get tree numbers
+                    cur.execute(
+                        """
+                        SELECT tree_number FROM mesh.tree_numbers tn
+                        JOIN mesh.descriptors d ON tn.descriptor_id = d.id
+                        WHERE d.descriptor_ui = %s
+                        """,
+                        (descriptor_ui,),
+                    )
+                    tree_numbers = [r[0] for r in cur.fetchall()]
+
+                    return MeSHResult(
+                        found=True,
+                        source=MeSHSource.LOCAL_DATABASE,
+                        searched_term=term,
+                        descriptor_ui=descriptor_ui,
+                        descriptor_name=descriptor_name,
+                        scope_note=scope_note,
+                        entry_terms=entry_terms,
+                        tree_numbers=tree_numbers,
+                        is_valid=True,
+                    )
+
+        except Exception as e:
+            logger.warning(f"Local database lookup failed: {e}")
+            return None
+
+    def _make_request(
+        self,
+        url: str,
+        params: Dict[str, Any],
+        retries: int = MAX_RETRIES,
+    ) -> Optional[requests.Response]:
+        """
+        Make an HTTP request with retry logic.
+
+        Args:
+            url: API endpoint URL
+            params: Query parameters
+            retries: Number of retry attempts
+
+        Returns:
+            Response object or None if failed
+        """
+        delay = INITIAL_RETRY_DELAY_SECONDS
+        headers = {
+            "User-Agent": "BMLibrarian/1.0 (https://github.com/hherb/bmlibrarian; Python requests)",
+            "Accept": "application/json",
+        }
+
+        for attempt in range(retries):
+            try:
+                time.sleep(self.request_delay)
+                response = requests.get(
+                    url,
+                    params=params,
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                    headers=headers,
+                )
+                response.raise_for_status()
+                return response
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"API request failed (attempt {attempt + 1}/{retries}): {e}")
+                if attempt < retries - 1:
+                    time.sleep(delay)
+                    delay *= RETRY_BACKOFF_MULTIPLIER
+                else:
+                    logger.error(f"API request failed after {retries} attempts")
+                    return None
+
+        return None
+
+    def _lookup_api(self, term: str) -> Optional[MeSHResult]:
+        """
+        Look up a term via NLM MeSH API.
+
+        Args:
+            term: Term to look up
+
+        Returns:
+            MeSHResult or None if not found
+        """
+        if not self.use_api_fallback:
+            return None
+
+        # Try NLM MeSH Browser API first
+        params = {
+            "label": term,
+            "match": "exact",
+            "limit": 5,
+        }
+
+        response = self._make_request(MESH_BROWSER_API_URL, params)
+
+        # Try contains match if exact fails
+        if response and response.status_code == 200:
+            data = response.json()
+            if not data:
+                params["match"] = "contains"
+                response = self._make_request(MESH_BROWSER_API_URL, params)
+                if response:
+                    data = response.json()
+        elif response is None:
+            return None
+        else:
+            data = []
+
+        if not data:
+            # Try NCBI E-utilities as fallback
+            return self._lookup_via_esearch(term)
+
+        try:
+            # Find exact match if possible
+            best_match = None
+            for item in data:
+                label = item.get("label", "")
+                if label.lower() == term.lower():
+                    best_match = item
+                    break
+
+            if best_match is None and data:
+                best_match = data[0]
+
+            if best_match:
+                resource = best_match.get("resource", "")
+                descriptor_ui = resource.split("/")[-1] if "/" in resource else ""
+                descriptor_name = best_match.get("label", term)
+
+                return MeSHResult(
+                    found=True,
+                    source=MeSHSource.NLM_API,
+                    searched_term=term,
+                    descriptor_ui=descriptor_ui,
+                    descriptor_name=descriptor_name,
+                    is_valid=True,
+                )
+
+        except (json.JSONDecodeError, KeyError, IndexError) as e:
+            logger.debug(f"Error parsing NLM MeSH API response: {e}")
+
+        return None
+
+    def _lookup_via_esearch(self, term: str) -> Optional[MeSHResult]:
+        """
+        Look up a term via NCBI E-utilities esearch.
+
+        Args:
+            term: Term to look up
+
+        Returns:
+            MeSHResult or None if not found
+        """
+        params = {
+            "db": "mesh",
+            "term": f'"{term}"',
+            "retmode": "json",
+            "retmax": 5,
+        }
+
+        if self.email:
+            params["email"] = self.email
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        response = self._make_request(ESEARCH_URL, params)
+        if not response:
+            return None
+
+        try:
+            data = response.json()
+            result = data.get("esearchresult", {})
+            id_list = result.get("idlist", [])
+
+            if id_list:
+                descriptor_ui = f"D{id_list[0]}" if not id_list[0].startswith("D") else id_list[0]
+
+                return MeSHResult(
+                    found=True,
+                    source=MeSHSource.NLM_API,
+                    searched_term=term,
+                    descriptor_ui=descriptor_ui,
+                    descriptor_name=term,  # Name not available from esearch
+                    is_valid=True,
+                )
+
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.debug(f"Error parsing esearch response: {e}")
+
+        return None
+
+    def lookup(self, term: str, use_cache: bool = True) -> MeSHResult:
+        """
+        Look up a MeSH term.
+
+        Checks sources in order:
+        1. Local PostgreSQL database (if available)
+        2. Local SQLite cache (if use_cache=True)
+        3. NLM API (if use_api_fallback=True)
+
+        Args:
+            term: MeSH term to look up
+            use_cache: Whether to use/update cache
+
+        Returns:
+            MeSHResult with lookup results
+        """
+        if not term or not term.strip():
+            return MeSHResult.not_found("")
+
+        normalized_term = term.strip()
+
+        # 1. Try local database first
+        if self.use_local_db and self._local_db_available:
+            result = self._lookup_local(normalized_term)
+            if result:
+                logger.debug(f"MeSH lookup: {term} -> found in local DB")
+                return result
+
+        # 2. Try cache
+        if use_cache:
+            result = self._get_from_cache(normalized_term)
+            if result:
+                logger.debug(f"MeSH lookup: {term} -> found in cache")
+                return result
+
+        # 3. Try API
+        if self.use_api_fallback:
+            result = self._lookup_api(normalized_term)
+            if result:
+                logger.debug(f"MeSH lookup: {term} -> found via API")
+                if use_cache:
+                    self._save_to_cache(result)
+                return result
+
+        # Not found
+        logger.debug(f"MeSH lookup: {term} -> not found")
+        result = MeSHResult.not_found(normalized_term)
+        if use_cache:
+            self._save_to_cache(result)
+        return result
+
+    def expand(self, term: str) -> List[str]:
+        """
+        Expand a MeSH term to all its synonyms/entry terms.
+
+        Args:
+            term: MeSH term to expand
+
+        Returns:
+            List of all terms including the original
+        """
+        if not term or not term.strip():
+            return [term] if term else []
+
+        # Try local database first
+        if self.use_local_db and self._local_db_available:
+            try:
+                with self._db_manager.get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT term_text FROM mesh.expand_term(%s)",
+                            (term,),
+                        )
+                        terms = [row[0] for row in cur.fetchall()]
+                        if terms:
+                            return terms
+            except Exception as e:
+                logger.warning(f"Local database expansion failed: {e}")
+
+        # Fall back to lookup and use entry terms
+        result = self.lookup(term)
+        if result.found:
+            all_terms = [result.descriptor_name] + result.entry_terms
+            return list(set(all_terms))
+
+        return [term]
+
+    def search(self, query: str, limit: int = 20) -> List[MeSHSearchResult]:
+        """
+        Search MeSH by partial match.
+
+        Args:
+            query: Search query
+            limit: Maximum results to return
+
+        Returns:
+            List of MeSHSearchResult objects
+        """
+        if not query or not query.strip():
+            return []
+
+        # Try local database first
+        if self.use_local_db and self._local_db_available:
+            try:
+                with self._db_manager.get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT * FROM mesh.search(%s, %s)",
+                            (query, limit),
+                        )
+                        return [
+                            MeSHSearchResult(
+                                descriptor_ui=row[0],
+                                descriptor_name=row[1],
+                                matched_term=row[2],
+                                match_type=row[3],
+                                score=row[4] or 0.0,
+                            )
+                            for row in cur.fetchall()
+                        ]
+            except Exception as e:
+                logger.warning(f"Local database search failed: {e}")
+
+        # Fall back to API search
+        if self.use_api_fallback:
+            params = {
+                "label": query,
+                "match": "contains",
+                "limit": limit,
+            }
+            response = self._make_request(MESH_BROWSER_API_URL, params)
+            if response:
+                try:
+                    data = response.json()
+                    return [
+                        MeSHSearchResult(
+                            descriptor_ui=item.get("resource", "").split("/")[-1],
+                            descriptor_name=item.get("label", ""),
+                            matched_term=item.get("label", ""),
+                            match_type="api_search",
+                            score=0.0,
+                        )
+                        for item in data[:limit]
+                    ]
+                except (json.JSONDecodeError, KeyError) as e:
+                    logger.warning(f"Error parsing search response: {e}")
+
+        return []
+
+    def get_broader_terms(self, descriptor_ui: str) -> List[MeSHSearchResult]:
+        """
+        Get broader (parent) terms for a descriptor.
+
+        Args:
+            descriptor_ui: MeSH descriptor UI
+
+        Returns:
+            List of parent descriptors
+        """
+        if self.use_local_db and self._local_db_available:
+            try:
+                with self._db_manager.get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT * FROM mesh.get_broader_terms(%s)",
+                            (descriptor_ui,),
+                        )
+                        return [
+                            MeSHSearchResult(
+                                descriptor_ui=row[0],
+                                descriptor_name=row[1],
+                                matched_term=row[1],
+                                match_type="broader",
+                            )
+                            for row in cur.fetchall()
+                        ]
+            except Exception as e:
+                logger.warning(f"Could not get broader terms: {e}")
+
+        return []
+
+    def get_narrower_terms(self, descriptor_ui: str) -> List[MeSHSearchResult]:
+        """
+        Get narrower (child) terms for a descriptor.
+
+        Args:
+            descriptor_ui: MeSH descriptor UI
+
+        Returns:
+            List of child descriptors
+        """
+        if self.use_local_db and self._local_db_available:
+            try:
+                with self._db_manager.get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT * FROM mesh.get_narrower_terms(%s)",
+                            (descriptor_ui,),
+                        )
+                        return [
+                            MeSHSearchResult(
+                                descriptor_ui=row[0],
+                                descriptor_name=row[1],
+                                matched_term=row[1],
+                                match_type="narrower",
+                            )
+                            for row in cur.fetchall()
+                        ]
+            except Exception as e:
+                logger.warning(f"Could not get narrower terms: {e}")
+
+        return []
+
+    def validate_term(self, term: str) -> MeSHResult:
+        """
+        Validate a MeSH term (alias for lookup).
+
+        Args:
+            term: Term to validate
+
+        Returns:
+            MeSHResult with validation results
+        """
+        return self.lookup(term)
+
+    def validate_terms(self, terms: List[str]) -> List[MeSHResult]:
+        """
+        Validate multiple MeSH terms.
+
+        Args:
+            terms: List of terms to validate
+
+        Returns:
+            List of MeSHResult objects in same order
+        """
+        return [self.lookup(term) for term in terms]
+
+    def is_local_db_available(self) -> bool:
+        """Check if local database is available."""
+        return self._local_db_available
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """
+        Get MeSH service statistics.
+
+        Returns:
+            Dictionary with statistics
+        """
+        stats = {
+            "local_db_available": self._local_db_available,
+            "api_fallback_enabled": self.use_api_fallback,
+            "cache_path": str(self.cache_path),
+            "cache_ttl_days": self.cache_ttl_days,
+        }
+
+        # Get local DB stats if available
+        if self._local_db_available and self._db_manager:
+            try:
+                with self._db_manager.get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute("SELECT * FROM mesh.get_statistics()")
+                        for row in cur.fetchall():
+                            stats[f"local_{row[0]}"] = row[1]
+            except Exception:
+                pass
+
+        # Get cache stats
+        try:
+            with sqlite3.connect(self.cache_path) as conn:
+                cursor = conn.execute("SELECT COUNT(*) FROM mesh_cache")
+                stats["cache_entries"] = cursor.fetchone()[0]
+        except Exception:
+            pass
+
+        return stats
+
+    def clear_cache(self) -> int:
+        """
+        Clear all cached API results.
+
+        Returns:
+            Number of entries cleared
+        """
+        with sqlite3.connect(self.cache_path) as conn:
+            cursor = conn.execute("SELECT COUNT(*) FROM mesh_cache")
+            count = cursor.fetchone()[0]
+            conn.execute("DELETE FROM mesh_cache")
+            logger.info(f"Cleared {count} entries from MeSH API cache")
+            return count


### PR DESCRIPTION
## MeSH Local Database Import and Lookup System

### Summary
- Add MeSH (Medical Subject Headings) import system for local database storage
- Implement database-first lookup with API fallback for MeSH term validation
- Create new `mesh` PostgreSQL schema with comprehensive vocabulary storage
- Add CLI tool for MeSH download, import, and lookup operations

### Changes

**New PostgreSQL Schema (`migrations/028_create_mesh_schema.sql`)**
- 7 tables: descriptors, concepts, terms, tree_numbers, qualifiers, supplementary_concepts, import_history
- PostgreSQL utility functions for term lookup, expansion, and hierarchical navigation
- Optimized indexes for fast text search and fuzzy matching

**New MeSH Importer (`src/bmlibrarian/importers/mesh_importer.py`)**
- Downloads MeSH XML from NLM HTTPS endpoints
- Memory-efficient streaming XML parser using iterparse
- Imports ~30,000 descriptors, ~300,000 terms, ~300,000 supplementary concepts
- Progress callbacks for UI integration

**New MeSH Service Module (`src/bmlibrarian/mesh/`)**
- `MeSHService` class with database-first, API-fallback pattern
- Methods: `lookup()`, `expand()`, `search()`, `get_broader_terms()`, `get_narrower_terms()`
- Type-safe dataclasses for all return types

**Updated MeSH Lookup (`src/bmlibrarian/pubmed_search/mesh_lookup.py`)**
- Added `use_local_db` parameter (default: True)
- Lookup order: Local PostgreSQL → SQLite cache → NLM API
- New `is_local_db_available()` method for status checking

**New CLI Tool (`mesh_import_cli.py`)**
- Commands: `import`, `status`, `history`, `lookup`, `search`, `expand`, `clear-cache`
- Progress display during import
- Configurable supplementary concept inclusion

### Test plan
- [ ] Run `uv run python mesh_import_cli.py status` to verify schema creation
- [ ] Run `uv run python mesh_import_cli.py import --year 2025 --no-supplementary -y` for quick test import
- [ ] Run `uv run python mesh_import_cli.py lookup "heart attack"` to verify lookup
- [ ] Run `uv run python mesh_import_cli.py search "cardio"` to verify search
- [ ] Test pubmed_search_lab.py MeSH validation with local database
- [ ] Verify API fallback when local database is empty

### Storage Requirements
- Without SCRs: ~180 MB
- With SCRs: ~400 MB
- Download (compressed XML): ~350 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)