### PR TITLE
LLM-layer polish: BaseAgent per-call overrides + PDFMatcher & SemanticQueryAgent migration

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -22,6 +22,9 @@ off new work. Longer-term structural items live in
   boundary was already clean (PR #249); this was consistency polish, not a
   correctness fix. Design spec:
   `docs/superpowers/specs/2026-07-22-baseagent-percall-overrides-design.md`.
+  Review follow-up: the four LLM error-path log records in `base.py` now
+  report `effective_model` (they still reported `self.model`, mislabelling
+  failures that used a per-call model override).
 - **Connection/concurrency P1 fixes** (2026-07-21): six findings from the
   2026-07-19 review. `queue_manager.py` — dequeue is now a single atomic
   `UPDATE … WHERE id = (SELECT … LIMIT 1) RETURNING *` (no cross-process

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -10,6 +10,18 @@ off new work. Longer-term structural items live in
 
 ## Recently landed (context)
 
+- **LLM-layer polish: BaseAgent per-call overrides + 2 migrations**
+  (2026-07-22): `base.py` `_make_llm_request`/`_generate_from_prompt` now take
+  optional `model`/`temperature`/`top_p` overrides (default `None` → `self.*`,
+  so existing calls are byte-for-byte unchanged), and `_make_llm_request`
+  forwards a `think` option to the chat client instead of dropping it. On top
+  of that, `PDFMatcher` and `SemanticQueryAgent` were migrated off
+  hand-constructed `LLMClient`s onto `BaseAgent` — `PDFMatcher` now activates
+  its previously-dead `FALLBACK_MODEL`; `SemanticQueryAgent`'s keyword
+  expansion uses the new per-call temperature override. The `import ollama`
+  boundary was already clean (PR #249); this was consistency polish, not a
+  correctness fix. Design spec:
+  `docs/superpowers/specs/2026-07-22-baseagent-percall-overrides-design.md`.
 - **Connection/concurrency P1 fixes** (2026-07-21): six findings from the
   2026-07-19 review. `queue_manager.py` — dequeue is now a single atomic
   `UPDATE … WHERE id = (SELECT … LIMIT 1) RETURNING *` (no cross-process
@@ -116,9 +128,27 @@ independent unless noted.
   `medrxiv_meca_importer.py:456-459` (zip) — reuse `_is_safe_zip_member()`
   from `europe_pmc_pdf_downloader.py:778-810`; ClinicalTrials matching does
   a per-trial leading-wildcard `LIKE` over full text — needs an indexed
-  strategy at scale; multi-model query generator hardcodes `num_predict:
-  100` (retriggers the documented gpt-oss:20b empty-response bug) and
-  bypasses `BaseAgent`/`LLMClient`.
+  strategy at scale.
+
+## LLM-layer polish follow-up (from 2026-07-22 slice)
+
+The BaseAgent per-call-override work (see "Recently landed") unblocks two
+more standalone-agent migrations that were deferred to keep that slice's
+regression signal clean. Both are optional consistency polish — they already
+route through the LLM layer correctly:
+
+- **`agents/query_generation/generator.py`** (`MultiModelQueryGenerator`):
+  a multi-model fan-out that builds its own `LLMClient`. Now migratable via
+  the new per-call `model`/`temperature` overrides (each `.chat(model=…)`
+  call becomes `self._make_llm_request(..., model=m, temperature=t)`), which
+  would roll all models' token usage into one metrics object. `num_predict`
+  is already fixed (`QUERY_GENERATION_MAX_TOKENS = 800`); it does **not**
+  hardcode 100 as older notes claimed.
+- **`qa/document_qa.py:answer_question`**: a module-level function using
+  `think=`. The `think` passthrough now exists on `_make_llm_request`, so
+  converting it to a small QA agent is possible — but that's a caller-facing
+  API change (callers pass `model`/`host`/`temperature` directly), so weigh
+  the churn before doing it.
 
 Re-verify all line numbers against current `HEAD` before fixing — they will
 have drifted since the 2026-07-19 review. Full details, including the

--- a/docs/superpowers/specs/2026-07-22-baseagent-percall-overrides-design.md
+++ b/docs/superpowers/specs/2026-07-22-baseagent-percall-overrides-design.md
@@ -1,0 +1,113 @@
+# BaseAgent per-call overrides + standalone-agent LLM-layer polish
+
+**Date:** 2026-07-22
+**Status:** Approved (design), implementation in progress
+**Scope:** `src/bmlibrarian/agents/base.py`, `src/bmlibrarian/importers/pdf_matcher.py`,
+`src/bmlibrarian/agents/semantic_query_agent.py`
+
+## Problem
+
+Golden rule #4 requires all model communication to go through the LLM
+abstraction. That is already true — the `import ollama` boundary is fully
+migrated (`tests/test_llm_layer_boundary.py` allowlist is empty). But ~10
+"standalone agent" classes construct their own `LLMClient` directly instead
+of inheriting `BaseAgent`, re-implementing agent-level plumbing (token
+accounting via `PerformanceMetrics`, `test_connection()`, host/config
+resolution, standardized retry/error handling).
+
+Investigation showed most of those sites do **not** cleanly fit `BaseAgent`
+today, because its helpers (`_make_llm_request`, `_generate_from_prompt`)
+hardcode `model=self.model`, `temperature=self.temperature`,
+`top_p=self.top_p`, and silently drop any leftover kwargs (so provider
+options like `think=` never reach the client). Consumers that vary these
+per call therefore cannot use the helpers:
+
+- `semantic_query_agent` — per-call temperature (rephrase vs. expand) and a
+  dedicated `rephrasing_model`.
+- `query_generation/generator` — fan-out over 1–3 models with per-attempt
+  temperature bumps (multi-model by design).
+- `qa/document_qa.answer_question` — a module-level function using `think=`.
+
+## Decision
+
+Extend `BaseAgent`'s helpers **additively** so per-call variation is
+expressible, then migrate the two sites this unblocks that are genuine
+single-agent shapes. This turns a one-off migration into a reusable
+capability and makes `BaseAgent` the true universal entry point — justified
+by three concrete consumers, not speculative generality.
+
+### Phase 1 — BaseAgent helper enhancement (zero behavior change for existing agents)
+
+In `_make_llm_request` and `_generate_from_prompt`:
+
+- Add optional params `model: Optional[str] = None`,
+  `temperature: Optional[float] = None`, `top_p: Optional[float] = None`.
+  Resolve each as `value if value is not None else self.<attr>` before the
+  client call. Every existing call omits them → byte-for-byte unchanged.
+- Forward a `think: Optional[bool] = None` passthrough to the client (only
+  included in the call when not `None`), instead of swallowing it.
+- Logging/metrics keep working; when `model` is overridden the structured
+  log should report the effective model.
+
+Backward compatibility: all new params default to `None`; the resolved
+values equal today's behavior when unset. The `_make_ollama_request` alias
+is untouched.
+
+### Phase 2 — migrate the clean fits
+
+**`pdf_matcher.PDFMatcher` → `BaseAgent`:**
+- `super().__init__(model=model or DEFAULT_MODEL, host=<resolved ollama host>,
+  temperature=METADATA_EXTRACTION_TEMPERATURE, top_p=METADATA_EXTRACTION_TOP_P,
+  fallback_model=FALLBACK_MODEL, show_model_info=False)`.
+- Implement `get_agent_type()` → `"pdf_matcher"`.
+- Replace `self.ollama_client.generate(...)` with
+  `self._generate_from_prompt(prompt)` (temperature/top_p already carried by
+  the instance). Adjust `response.content` → returned string.
+- Net win: **activates the currently-dead `FALLBACK_MODEL`** (defined but
+  never wired), adds token accounting + `test_connection()`, unifies host
+  handling. Metadata extraction behavior unchanged (same model, temp, top_p).
+- Constructor keeps its public signature (`pdf_base_dir`, `ollama_host`,
+  `model`) so the 4 call sites in `pdf_import_cli.py` and
+  `pdf_upload_workers.py` are unaffected.
+
+**`semantic_query_agent.SemanticQueryAgent` → `BaseAgent`:**
+- `super().__init__(model=rephrasing_model or DEFAULT_REPHRASING_MODEL,
+  host=<resolved host>, temperature=rephrasing_temperature,
+  show_model_info=False)`.
+- Implement `get_agent_type()` → `"semantic_query_agent"`.
+- Replace the two `self._llm_client.generate(...)` calls with
+  `self._generate_from_prompt(prompt, temperature=<per-call>, model=<per-call>,
+  num_predict=<max_tokens>)`, using the new per-call overrides for the
+  expand call's distinct temperature.
+- Keep the public `__init__` signature so callers are unaffected.
+
+### Deferred (documented follow-up, not this slice)
+
+- `query_generation/generator` (multi-model orchestrator): migratable via the
+  new per-call `model` override, but it is a fan-out shape deserving its own
+  pass. Track in HANDOVER.
+- `qa/document_qa.answer_question` (module function): converting to an agent
+  is a separate caller-facing API decision. The `think` passthrough lands in
+  Phase 1 so it is ready if/when converted.
+- Embedders (`document_embedder`, `chunk_embedder`): do embeddings, not chat;
+  out of scope. Docstring-only `LLMClient` mentions in `hyde_search.py`: n/a.
+
+## Testing
+
+- New unit tests (mirroring `tests/test_agents.py`: concrete `TestAgent(BaseAgent)`
+  + `@patch('bmlib.llm.client.LLMClient.chat'/'.generate')`):
+  - override params are honored when passed; `self.*` used when omitted;
+  - `think` reaches the client only when set;
+  - `PDFMatcher` inherits `BaseAgent`, passes `fallback_model`, and its
+    extraction call still returns parsed metadata (client mocked);
+  - `SemanticQueryAgent` rephrase/expand use the expected per-call temps.
+- Regression gate (no CI, broken baseline): capture failing node-IDs on
+  `master`, compare against this branch; **zero new failures** is the gate.
+- `ruff check --select F <touched files>` and `mypy` on touched files: no new
+  errors.
+
+## Non-goals
+
+- No change to `LLMClient`/`bmlib.llm`.
+- No change to any existing agent's behavior or public API.
+- No migration of the deferred sites in this slice.

--- a/src/bmlibrarian/agents/base.py
+++ b/src/bmlibrarian/agents/base.py
@@ -418,7 +418,7 @@ class BaseAgent(ABC):
             agent_logger.error(f"LLM request failed after {response_time:.2f}ms: {e}", extra={'structured_data': {
                 'event_type': 'agent_llm_error',
                 'agent_type': self.get_agent_type(),
-                'model': self.model,
+                'model': effective_model,
                 'provider': self._model_spec.provider.value,
                 'error_type': type(e).__name__,
                 'error_message': str(e),
@@ -432,7 +432,7 @@ class BaseAgent(ABC):
             agent_logger.error(f"Unexpected error in LLM request after {response_time:.2f}ms: {e}", extra={'structured_data': {
                 'event_type': 'agent_llm_error',
                 'agent_type': self.get_agent_type(),
-                'model': self.model,
+                'model': effective_model,
                 'provider': self._model_spec.provider.value,
                 'error_type': type(e).__name__,
                 'error_message': str(e),
@@ -488,6 +488,11 @@ class BaseAgent(ABC):
                 ``self.temperature`` when None
             top_p: Per-call top_p override; falls back to ``self.top_p`` when None
             **llm_options: Additional LLM options (max_tokens, json_mode, etc.)
+
+        Note:
+            The ``think`` provider option is not supported here (it is dropped
+            silently, like any other unrecognized ``llm_options`` key). Use
+            :meth:`_make_llm_request` if you need a reasoning trace.
 
         Returns:
             The model's response content
@@ -573,7 +578,7 @@ class BaseAgent(ABC):
             agent_logger.error(f"LLM generate failed after {response_time:.2f}ms: {e}", extra={'structured_data': {
                 'event_type': 'agent_llm_error',
                 'agent_type': self.get_agent_type(),
-                'model': self.model,
+                'model': effective_model,
                 'provider': self._model_spec.provider.value,
                 'error_type': type(e).__name__,
                 'error_message': str(e),
@@ -587,7 +592,7 @@ class BaseAgent(ABC):
             agent_logger.error(f"Unexpected error in LLM generate after {response_time:.2f}ms: {e}", extra={'structured_data': {
                 'event_type': 'agent_llm_error',
                 'agent_type': self.get_agent_type(),
-                'model': self.model,
+                'model': effective_model,
                 'provider': self._model_spec.provider.value,
                 'error_type': type(e).__name__,
                 'error_message': str(e),

--- a/src/bmlibrarian/agents/base.py
+++ b/src/bmlibrarian/agents/base.py
@@ -300,6 +300,10 @@ class BaseAgent(ABC):
         system_prompt: Optional[str] = None,
         max_retries: int = DEFAULT_MAX_RETRIES,
         retry_delay: float = DEFAULT_RETRY_DELAY,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        think: Optional[bool] = None,
         **llm_options
     ) -> str:
         """
@@ -313,6 +317,13 @@ class BaseAgent(ABC):
             system_prompt: Optional system prompt to prepend
             max_retries: Maximum number of retry attempts for transient failures
             retry_delay: Initial delay between retries in seconds
+            model: Per-call model override; falls back to ``self.model`` when None
+            temperature: Per-call temperature override; falls back to
+                ``self.temperature`` when None
+            top_p: Per-call top_p override; falls back to ``self.top_p`` when None
+            think: Request a reasoning trace from the provider. Left None the
+                option is not sent (whether a model accepts it is the
+                provider's business).
             **llm_options: Additional LLM options (max_tokens, json_mode, etc.)
 
         Returns:
@@ -325,11 +336,16 @@ class BaseAgent(ABC):
         agent_logger = logging.getLogger('bmlibrarian.agents')
         start_time = time.time()
 
+        # Resolve per-call overrides against the instance defaults.
+        effective_model = model if model is not None else self.model
+        effective_temperature = temperature if temperature is not None else self.temperature
+        effective_top_p = top_p if top_p is not None else self.top_p
+
         # Log the request
-        agent_logger.info(f"LLM request to {self.model}", extra={'structured_data': {
+        agent_logger.info(f"LLM request to {effective_model}", extra={'structured_data': {
             'event_type': 'agent_llm_request',
             'agent_type': self.get_agent_type(),
-            'model': self.model,
+            'model': effective_model,
             'provider': self._model_spec.provider.value,
             'message_count': len(messages),
             'has_system_prompt': system_prompt is not None,
@@ -347,18 +363,23 @@ class BaseAgent(ABC):
             max_tokens = llm_options.pop('num_predict', None)
             json_mode = llm_options.pop('json_mode', False)
 
+            # Only forward think when explicitly set; the provider rejects it
+            # for models without thinking support.
+            think_kwargs = {} if think is None else {'think': think}
+
             # Make request via LLM client
             response: LLMResponse = self._llm_client.chat(
                 messages=llm_messages,
-                model=self.model,
+                model=effective_model,
                 system_prompt=system_prompt,
-                temperature=self.temperature,
-                top_p=self.top_p,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
                 max_tokens=max_tokens,
                 json_mode=json_mode,
                 fallback_model=self.fallback_model,
                 max_retries=max_retries,
                 retry_delay=retry_delay,
+                **think_kwargs,
             )
 
             content = response.content
@@ -447,6 +468,9 @@ class BaseAgent(ABC):
         prompt: str,
         max_retries: int = DEFAULT_MAX_RETRIES,
         retry_delay: float = DEFAULT_RETRY_DELAY,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
         **llm_options
     ) -> str:
         """
@@ -459,6 +483,10 @@ class BaseAgent(ABC):
             prompt: The prompt string
             max_retries: Maximum number of retry attempts for transient failures
             retry_delay: Initial delay between retries in seconds
+            model: Per-call model override; falls back to ``self.model`` when None
+            temperature: Per-call temperature override; falls back to
+                ``self.temperature`` when None
+            top_p: Per-call top_p override; falls back to ``self.top_p`` when None
             **llm_options: Additional LLM options (max_tokens, json_mode, etc.)
 
         Returns:
@@ -476,11 +504,16 @@ class BaseAgent(ABC):
         agent_logger = logging.getLogger('bmlibrarian.agents')
         start_time = time.time()
 
+        # Resolve per-call overrides against the instance defaults.
+        effective_model = model if model is not None else self.model
+        effective_temperature = temperature if temperature is not None else self.temperature
+        effective_top_p = top_p if top_p is not None else self.top_p
+
         # Log the request
-        agent_logger.info(f"LLM generate request to {self.model}", extra={'structured_data': {
+        agent_logger.info(f"LLM generate request to {effective_model}", extra={'structured_data': {
             'event_type': 'agent_llm_generate',
             'agent_type': self.get_agent_type(),
-            'model': self.model,
+            'model': effective_model,
             'provider': self._model_spec.provider.value,
             'prompt_length': len(prompt),
             'timestamp': start_time
@@ -494,9 +527,9 @@ class BaseAgent(ABC):
             # Make request via LLM client
             response: LLMResponse = self._llm_client.generate(
                 prompt=prompt,
-                model=self.model,
-                temperature=self.temperature,
-                top_p=self.top_p,
+                model=effective_model,
+                temperature=effective_temperature,
+                top_p=effective_top_p,
                 max_tokens=max_tokens,
                 json_mode=json_mode,
                 fallback_model=self.fallback_model,

--- a/src/bmlibrarian/agents/semantic_query_agent.py
+++ b/src/bmlibrarian/agents/semantic_query_agent.py
@@ -44,7 +44,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional, Callable, TYPE_CHECKING
 
-from ..llm import LLMClient, LLMMessage
+from ..llm import DEFAULT_OLLAMA_HOST
+from .base import BaseAgent
 from .utils.query_syntax import strip_preamble
 
 if TYPE_CHECKING:
@@ -149,7 +150,7 @@ class SemanticSearchResult:
         )
 
 
-class SemanticQueryAgent:
+class SemanticQueryAgent(BaseAgent):
     """
     Adaptive semantic search agent.
 
@@ -205,27 +206,37 @@ class SemanticQueryAgent:
         self.threshold_step = threshold_step
         self.max_threshold_iterations = max_threshold_iterations
         self.max_query_rephrasings = max_query_rephrasings
-        self.rephrasing_model = rephrasing_model or DEFAULT_REPHRASING_MODEL
-        self.rephrasing_temperature = rephrasing_temperature
-
         # Hybrid search settings
         self.default_search_mode = default_search_mode
         self.semantic_weight = semantic_weight
         self.rrf_k = rrf_k
         self.hybrid_threshold = hybrid_threshold
 
-        # Load config defaults
+        # Load config defaults for the Ollama host.
         try:
             from bmlibrarian.config import get_config
             config = get_config()
             ollama_config = config.get("ollama", {})
-            self.ollama_host = ollama_host or ollama_config.get(
-                "host", "http://localhost:11434"
+            resolved_host = ollama_host or ollama_config.get(
+                "host", DEFAULT_OLLAMA_HOST
             )
         except ImportError:
-            self.ollama_host = ollama_host or "http://localhost:11434"
+            resolved_host = ollama_host or DEFAULT_OLLAMA_HOST
 
-        self._llm_client = LLMClient(ollama_host=self.ollama_host)
+        # The rephrasing model/temperature are the agent's LLM defaults; the
+        # keyword-expansion call overrides temperature per call.
+        super().__init__(
+            model=rephrasing_model or DEFAULT_REPHRASING_MODEL,
+            host=resolved_host,
+            temperature=rephrasing_temperature,
+            show_model_info=False,
+        )
+
+        # Retained as named aliases for readability at the call sites; they
+        # mirror BaseAgent's self.model / self.temperature.
+        self.rephrasing_model = self.model
+        self.rephrasing_temperature = self.temperature
+        self.ollama_host = resolved_host
 
         logger.info(
             f"SemanticQueryAgent initialized: threshold={initial_threshold}, "
@@ -233,6 +244,10 @@ class SemanticQueryAgent:
             f"max_rephrasings={max_query_rephrasings}, "
             f"default_mode={default_search_mode.value}"
         )
+
+    def get_agent_type(self) -> str:
+        """Return the stable identifier for this agent."""
+        return "semantic_query_agent"
 
     def search_document(
         self,
@@ -609,14 +624,12 @@ Generate a single alternative query that:
 
 Respond with ONLY the new query, nothing else."""
 
-            response = self._llm_client.generate(
-                prompt=prompt,
-                model=self.rephrasing_model,
-                temperature=self.rephrasing_temperature,
-                max_tokens=REPHRASING_MAX_TOKENS,
-            )
-
-            rephrased = (response.content or "").strip()
+            # Model and temperature come from the instance defaults
+            # (rephrasing model/temperature).
+            rephrased = self._generate_from_prompt(
+                prompt,
+                num_predict=REPHRASING_MAX_TOKENS,
+            ).strip()
 
             # Clean up the response. REPHRASING_MAX_TOKENS was raised from 50
             # to 800 so reasoning models can think before answering; at 50 a
@@ -673,14 +686,13 @@ EXPANDED: heart rate cardiac rate pulse 89 bpm beats per minute
 
 Now analyze the query:"""
 
-            response = self._llm_client.generate(
-                prompt=prompt,
-                model=self.rephrasing_model,
+            # Keyword expansion uses a lower temperature than rephrasing;
+            # override it per call while keeping the instance model.
+            text = self._generate_from_prompt(
+                prompt,
                 temperature=DEFAULT_EXPANSION_TEMPERATURE,
-                max_tokens=EXPANSION_MAX_TOKENS,
-            )
-
-            text = (response.content or "").strip()
+                num_predict=EXPANSION_MAX_TOKENS,
+            ).strip()
 
             # Parse the response
             result = {

--- a/src/bmlibrarian/importers/pdf_matcher.py
+++ b/src/bmlibrarian/importers/pdf_matcher.py
@@ -23,8 +23,9 @@ from typing import Optional, Dict, Any, List, Tuple
 from datetime import datetime
 
 
+from bmlibrarian.agents.base import BaseAgent
 from bmlibrarian.database import get_db_manager
-from bmlibrarian.llm import LLMClient
+from bmlibrarian.llm import DEFAULT_OLLAMA_HOST
 from bmlibrarian.utils.pdf_manager import PDFManager
 
 logger = logging.getLogger(__name__)
@@ -103,12 +104,16 @@ class DocumentStatus:
     document: Optional[Dict[str, Any]] = None
 
 
-class PDFMatcher:
+class PDFMatcher(BaseAgent):
     """
     PDF matcher and importer for BMLibrarian.
 
     Analyzes PDF files to extract metadata using LLM, matches them to existing
     documents in the database, and imports them with proper naming and organization.
+
+    Inherits BaseAgent so metadata extraction routes through the shared LLM
+    layer with token accounting, connection testing, and an active fallback
+    model.
     """
 
     DEFAULT_MODEL = "medgemma4B_it_q8:latest"
@@ -118,7 +123,8 @@ class PDFMatcher:
         self,
         pdf_base_dir: Optional[str] = None,
         ollama_host: Optional[str] = None,
-        model: Optional[str] = None
+        model: Optional[str] = None,
+        show_model_info: bool = False,
     ):
         """
         Initialize the PDF matcher.
@@ -126,15 +132,24 @@ class PDFMatcher:
         Args:
             pdf_base_dir: Base directory for PDF storage. If None, uses PDF_BASE_DIR
                          environment variable or defaults to ~/knowledgebase/pdf
-            ollama_host: Host URL for Ollama service. If None, uses OLLAMA_HOST
-                        environment variable or defaults to localhost:11434
+            ollama_host: Host URL for Ollama service. If None, uses the default
+                        Ollama host (http://localhost:11434)
             model: LLM model to use for metadata extraction
+            show_model_info: Whether to print the model banner on init
         """
-        self.db_manager = get_db_manager()
-        self.model = model or self.DEFAULT_MODEL
+        # Extraction uses a low, fixed temperature/top_p so metadata is
+        # transcribed from the page rather than invented; carry those as the
+        # instance defaults BaseAgent's helpers apply.
+        super().__init__(
+            model=model or self.DEFAULT_MODEL,
+            host=ollama_host or DEFAULT_OLLAMA_HOST,
+            temperature=METADATA_EXTRACTION_TEMPERATURE,
+            top_p=METADATA_EXTRACTION_TOP_P,
+            fallback_model=self.FALLBACK_MODEL,
+            show_model_info=show_model_info,
+        )
 
-        # Initialize Ollama client with optional custom host
-        self.ollama_client = LLMClient(ollama_host=ollama_host)
+        self.db_manager = get_db_manager()
 
         # Initialize the long-lived PDF manager WITHOUT a pooled connection:
         # this instance is only used for path/base_dir resolution. Every actual
@@ -145,6 +160,10 @@ class PDFMatcher:
 
         logger.info(f"PDF matcher initialized with model: {self.model}")
         logger.info(f"PDF base directory: {self.pdf_manager.base_dir}")
+
+    def get_agent_type(self) -> str:
+        """Return the stable identifier for this agent."""
+        return "pdf_matcher"
 
     def extract_first_page_text(self, pdf_path: Path) -> Optional[str]:
         """
@@ -483,15 +502,9 @@ Text to analyze:
 """
 
         try:
-            response = self.ollama_client.generate(
-                prompt=prompt,
-                model=self.model,
-                # Low temperature for factual extraction
-                temperature=METADATA_EXTRACTION_TEMPERATURE,
-                top_p=METADATA_EXTRACTION_TOP_P,
-            )
-
-            response_text = (response.content or '').strip()
+            # Model, temperature and top_p come from the instance defaults set
+            # in __init__ (metadata-extraction settings).
+            response_text = self._generate_from_prompt(prompt).strip()
 
             # Try to parse JSON from response
             metadata = self._parse_llm_response(response_text)

--- a/tests/test_base_agent_overrides.py
+++ b/tests/test_base_agent_overrides.py
@@ -1,0 +1,144 @@
+"""Per-call override tests for BaseAgent LLM helpers.
+
+BaseAgent's ``_make_llm_request`` and ``_generate_from_prompt`` historically
+hardcoded ``self.model`` / ``self.temperature`` / ``self.top_p`` and dropped
+any leftover kwargs. These tests pin the additive behavior that lets a caller
+vary those per call (defaulting to ``self.*`` when omitted) and forward the
+``think`` provider option to the chat client.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from bmlibrarian.agents import BaseAgent
+
+
+def _fake_response(content: str = "ok", model: str = "stub-model") -> SimpleNamespace:
+    """Build a minimal object with the attributes BaseAgent reads off a response."""
+    return SimpleNamespace(
+        content=content,
+        prompt_tokens=1,
+        completion_tokens=1,
+        duration_seconds=0.0,
+        model=model,
+        provider=SimpleNamespace(value="ollama"),
+    )
+
+
+class _StubAgent(BaseAgent):
+    """Concrete BaseAgent for exercising the shared helpers."""
+
+    def get_agent_type(self) -> str:
+        return "stub_agent"
+
+
+@pytest.fixture
+def agent() -> _StubAgent:
+    """A stub agent with distinctive instance defaults for override assertions."""
+    return _StubAgent(
+        model="instance-model",
+        temperature=0.3,
+        top_p=0.8,
+        show_model_info=False,
+    )
+
+
+# --- _generate_from_prompt -------------------------------------------------
+
+@patch("bmlibrarian.llm.client.LLMClient.generate")
+def test_generate_uses_instance_defaults_when_no_override(mock_generate, agent):
+    """Omitting overrides falls back to the instance's model/temperature/top_p."""
+    mock_generate.return_value = _fake_response()
+
+    agent._generate_from_prompt("hello")
+
+    kwargs = mock_generate.call_args.kwargs
+    assert kwargs["model"] == "instance-model"
+    assert kwargs["temperature"] == 0.3
+    assert kwargs["top_p"] == 0.8
+
+
+@patch("bmlibrarian.llm.client.LLMClient.generate")
+def test_generate_temperature_override_is_applied(mock_generate, agent):
+    """A per-call temperature overrides the instance temperature."""
+    mock_generate.return_value = _fake_response()
+
+    agent._generate_from_prompt("hello", temperature=0.95)
+
+    assert mock_generate.call_args.kwargs["temperature"] == 0.95
+
+
+@patch("bmlibrarian.llm.client.LLMClient.generate")
+def test_generate_model_override_is_applied(mock_generate, agent):
+    """A per-call model overrides the instance model."""
+    mock_generate.return_value = _fake_response()
+
+    agent._generate_from_prompt("hello", model="other-model")
+
+    assert mock_generate.call_args.kwargs["model"] == "other-model"
+
+
+@patch("bmlibrarian.llm.client.LLMClient.generate")
+def test_generate_top_p_override_is_applied(mock_generate, agent):
+    """A per-call top_p overrides the instance top_p."""
+    mock_generate.return_value = _fake_response()
+
+    agent._generate_from_prompt("hello", top_p=0.2)
+
+    assert mock_generate.call_args.kwargs["top_p"] == 0.2
+
+
+# --- _make_llm_request -----------------------------------------------------
+
+@patch("bmlibrarian.llm.client.LLMClient.chat")
+def test_chat_uses_instance_defaults_when_no_override(mock_chat, agent):
+    """Omitting overrides falls back to the instance's model/temperature/top_p."""
+    mock_chat.return_value = _fake_response()
+
+    agent._make_llm_request([{"role": "user", "content": "hi"}])
+
+    kwargs = mock_chat.call_args.kwargs
+    assert kwargs["model"] == "instance-model"
+    assert kwargs["temperature"] == 0.3
+    assert kwargs["top_p"] == 0.8
+
+
+@patch("bmlibrarian.llm.client.LLMClient.chat")
+def test_chat_overrides_are_applied(mock_chat, agent):
+    """Per-call model/temperature/top_p override the instance values."""
+    mock_chat.return_value = _fake_response()
+
+    agent._make_llm_request(
+        [{"role": "user", "content": "hi"}],
+        model="other-model",
+        temperature=0.95,
+        top_p=0.2,
+    )
+
+    kwargs = mock_chat.call_args.kwargs
+    assert kwargs["model"] == "other-model"
+    assert kwargs["temperature"] == 0.95
+    assert kwargs["top_p"] == 0.2
+
+
+@patch("bmlibrarian.llm.client.LLMClient.chat")
+def test_chat_forwards_think_when_set(mock_chat, agent):
+    """think is forwarded to the chat client when provided."""
+    mock_chat.return_value = _fake_response()
+
+    agent._make_llm_request([{"role": "user", "content": "hi"}], think=True)
+
+    assert mock_chat.call_args.kwargs.get("think") is True
+
+
+@patch("bmlibrarian.llm.client.LLMClient.chat")
+def test_chat_omits_think_by_default(mock_chat, agent):
+    """think is not sent to the client when the caller does not set it."""
+    mock_chat.return_value = _fake_response()
+
+    agent._make_llm_request([{"role": "user", "content": "hi"}])
+
+    # Either absent, or explicitly None (provider treats None as "don't send").
+    assert mock_chat.call_args.kwargs.get("think") is None

--- a/tests/test_base_agent_overrides.py
+++ b/tests/test_base_agent_overrides.py
@@ -142,3 +142,40 @@ def test_chat_omits_think_by_default(mock_chat, agent):
 
     # Either absent, or explicitly None (provider treats None as "don't send").
     assert mock_chat.call_args.kwargs.get("think") is None
+
+
+# --- error-path observability ----------------------------------------------
+
+def _error_model(caplog) -> object:
+    """Pull the model recorded on the first ``agent_llm_error`` log record."""
+    for record in caplog.records:
+        data = getattr(record, "structured_data", {})
+        if data.get("event_type") == "agent_llm_error":
+            return data.get("model")
+    raise AssertionError("no agent_llm_error record was logged")
+
+
+@patch("bmlibrarian.llm.client.LLMClient.chat")
+def test_chat_error_logs_effective_model(mock_chat, agent, caplog):
+    """On failure the error log reports the overridden model, not self.model."""
+    mock_chat.side_effect = ConnectionError("boom")
+
+    with caplog.at_level("ERROR", logger="bmlibrarian.agents"):
+        with pytest.raises(ConnectionError):
+            agent._make_llm_request(
+                [{"role": "user", "content": "hi"}], model="other-model"
+            )
+
+    assert _error_model(caplog) == "other-model"
+
+
+@patch("bmlibrarian.llm.client.LLMClient.generate")
+def test_generate_error_logs_effective_model(mock_generate, agent, caplog):
+    """On failure the error log reports the overridden model, not self.model."""
+    mock_generate.side_effect = ConnectionError("boom")
+
+    with caplog.at_level("ERROR", logger="bmlibrarian.agents"):
+        with pytest.raises(ConnectionError):
+            agent._generate_from_prompt("hello", model="other-model")
+
+    assert _error_model(caplog) == "other-model"

--- a/tests/test_pdf_matcher_agent.py
+++ b/tests/test_pdf_matcher_agent.py
@@ -1,0 +1,60 @@
+"""PDFMatcher BaseAgent-migration tests.
+
+PDFMatcher was migrated from a hand-constructed LLMClient onto BaseAgent so
+it gains token accounting, ``test_connection()``, unified host handling, and
+— crucially — a wired ``fallback_model`` (its ``FALLBACK_MODEL`` constant was
+previously dead). These tests pin that migration and confirm metadata
+extraction behavior is unchanged.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from bmlibrarian.agents import BaseAgent
+from bmlibrarian.importers.pdf_matcher import PDFMatcher
+
+
+@pytest.fixture
+def matcher():
+    """Construct a PDFMatcher without touching the database or filesystem."""
+    with patch("bmlibrarian.importers.pdf_matcher.get_db_manager"), \
+         patch("bmlibrarian.importers.pdf_matcher.PDFManager"):
+        return PDFMatcher(show_model_info=False)
+
+
+def test_pdf_matcher_is_base_agent(matcher):
+    """PDFMatcher inherits the shared agent plumbing."""
+    assert isinstance(matcher, BaseAgent)
+
+
+def test_pdf_matcher_agent_type(matcher):
+    """PDFMatcher exposes a stable agent-type identifier."""
+    assert matcher.get_agent_type() == "pdf_matcher"
+
+
+def test_pdf_matcher_wires_fallback_model(matcher):
+    """The previously-dead FALLBACK_MODEL is now an active fallback."""
+    assert matcher.fallback_model == PDFMatcher.FALLBACK_MODEL
+
+
+def test_extract_metadata_parses_llm_json(matcher):
+    """Metadata extraction still returns a parsed dict (behavior preserved)."""
+    response = SimpleNamespace(
+        content='{"doi": "10.1234/example", "pmid": "12345678", '
+                '"title": "A Study", "authors": ["Smith J"]}',
+        prompt_tokens=1,
+        completion_tokens=1,
+        duration_seconds=0.0,
+        model="stub",
+        provider=SimpleNamespace(value="ollama"),
+    )
+
+    with patch("bmlibrarian.llm.client.LLMClient.generate", return_value=response):
+        metadata = matcher.extract_metadata_with_llm("First page text of a paper")
+
+    assert metadata["doi"] == "10.1234/example"
+    assert metadata["pmid"] == "12345678"
+    assert metadata["title"] == "A Study"
+    assert metadata["authors"] == ["Smith J"]

--- a/tests/test_semantic_query_agent_migration.py
+++ b/tests/test_semantic_query_agent_migration.py
@@ -1,0 +1,68 @@
+"""SemanticQueryAgent BaseAgent-migration tests.
+
+SemanticQueryAgent was migrated onto BaseAgent. It varies temperature per
+call (a creative temperature for rephrasing, a low one for keyword
+expansion), which relies on BaseAgent's per-call override support. These
+tests pin the migration and that each call still uses its intended
+temperature.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from bmlibrarian.agents import BaseAgent
+from bmlibrarian.agents.semantic_query_agent import (
+    SemanticQueryAgent,
+    DEFAULT_EXPANSION_TEMPERATURE,
+    DEFAULT_REPHRASING_TEMPERATURE,
+)
+
+
+def _fake_response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        content=content,
+        prompt_tokens=1,
+        completion_tokens=1,
+        duration_seconds=0.0,
+        model="stub",
+        provider=SimpleNamespace(value="ollama"),
+    )
+
+
+@pytest.fixture
+def agent() -> SemanticQueryAgent:
+    return SemanticQueryAgent()
+
+
+def test_semantic_agent_is_base_agent(agent):
+    """SemanticQueryAgent inherits the shared agent plumbing."""
+    assert isinstance(agent, BaseAgent)
+
+
+def test_semantic_agent_type(agent):
+    """SemanticQueryAgent exposes a stable agent-type identifier."""
+    assert agent.get_agent_type() == "semantic_query_agent"
+
+
+def test_rephrase_uses_rephrasing_temperature(agent):
+    """Query rephrasing uses the (creative) rephrasing temperature."""
+    with patch(
+        "bmlibrarian.llm.client.LLMClient.generate",
+        return_value=_fake_response("an alternative phrasing of the query"),
+    ) as mock_generate:
+        agent._generate_query_variation("original query", 1, [])
+
+    assert mock_generate.call_args.kwargs["temperature"] == DEFAULT_REPHRASING_TEMPERATURE
+
+
+def test_expand_uses_expansion_temperature(agent):
+    """Keyword expansion uses the low expansion temperature (per-call override)."""
+    with patch(
+        "bmlibrarian.llm.client.LLMClient.generate",
+        return_value=_fake_response("KEYWORDS: a, b\nNUMBERS:\nEXPANDED: a b"),
+    ) as mock_generate:
+        agent.expand_query("some query")
+
+    assert mock_generate.call_args.kwargs["temperature"] == DEFAULT_EXPANSION_TEMPERATURE


### PR DESCRIPTION
## Summary

Consistency polish on the LLM layer. The `import ollama` boundary was already fully migrated (PR #249, empty allowlist in `tests/test_llm_layer_boundary.py`), so these are not correctness fixes — they route two standalone-agent classes through `BaseAgent` and add the small capability that made those migrations clean.

### Phase 1 — BaseAgent helper enhancement (additive, zero behavior change)
- `_make_llm_request` and `_generate_from_prompt` gain optional `model` / `temperature` / `top_p` params. Default `None` → fall back to `self.*`, so **every existing call is byte-for-byte unchanged**.
- `_make_llm_request` forwards a `think` option to the chat client (previously stray kwargs were silently dropped). `generate` doesn't accept `think`, so it's chat-only — matching `LLMClient`.

### Phase 2 — migrate the two clean fits
- **`PDFMatcher` → `BaseAgent`**: gains token accounting, `test_connection()`, unified host handling, and **activates its previously-dead `FALLBACK_MODEL`** (the constant was defined but never wired). Metadata extraction behavior unchanged (same model/temperature/top_p).
- **`SemanticQueryAgent` → `BaseAgent`**: rephrasing uses the instance temperature; keyword expansion uses the new per-call temperature override.

### Deferred to a follow-up (documented in HANDOVER)
- `query_generation/generator.py` (multi-model fan-out) — now migratable via the per-call `model` override, but it's an orchestrator shape deserving its own pass.
- `qa/document_qa.answer_question` (module-level function using `think=`) — converting it to an agent is a caller-facing API change; the `think` passthrough lands here so it's ready.

## Why not the other ~14 direct-`LLMClient` sites
The embedders do embeddings (not chat), some hits are docstrings, and the paperchecker / systematic-review sub-components are composed *under* parent `BaseAgent`s (a "reuse the parent's client" shape, not independent agents). Scope was deliberately bounded to standalone agents.

## Testing
- New TDD tests (all written test-first, watched fail, then implemented):
  - `tests/test_base_agent_overrides.py` — override resolution + `think` passthrough (incl. regression tests that omitting overrides uses `self.*`).
  - `tests/test_pdf_matcher_agent.py` — BaseAgent inheritance, active fallback, metadata extraction preserved.
  - `tests/test_semantic_query_agent_migration.py` — inheritance + per-call temperatures (rephrase vs. expand).
- Broad agent-focused sweep (agents, performance_metrics, hyde, paperchecker, queue, reporting, document_interrogation, boundary, pdf_upload_workers, systematic_review_data_models): **285 passed**.
- Regression gate on touched files vs `master`: **no new ruff F errors, no new mypy errors** (mypy 11 == 11, all pre-existing in untouched regions).

## Design
`docs/superpowers/specs/2026-07-22-baseagent-percall-overrides-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)