### PR TITLE
test: stop DB/Ollama tests from hanging the unattended suite

### DIFF
--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -5,10 +5,22 @@ Tests the complete workflow including audit trail.
 """
 
 import json
+
+import pytest
+
 from bmlibrarian.database import search_hybrid
 
+
+@pytest.mark.requires_database
 def test_hybrid_search():
-    """Test hybrid search with a simple query."""
+    """Test hybrid search with a simple query.
+
+    This is an end-to-end script that issues real queries via
+    ``search_hybrid``. An unreachable database does not raise promptly, it
+    blocks inside psycopg's socket wait, which hung the whole suite with no
+    per-test output. Marked ``requires_database`` so it can be deselected in
+    environments without a live database.
+    """
     print("=" * 80)
     print("HYBRID SEARCH TEST")
     print("=" * 80)

--- a/tests/test_iterative_search.py
+++ b/tests/test_iterative_search.py
@@ -200,6 +200,11 @@ class TestIterativeSearch:
 
         query_agent.convert_question = Mock(return_value='test & query')
         query_agent.find_abstracts = Mock(side_effect=[batch1, batch2, []])
+        # min_relevant=5 forces retry exhaustion, driving Phase 2 broadening.
+        # Without this mock, _generate_broader_query issues a real Ollama
+        # request that blocks the suite when no LLM is reachable (matching
+        # the sibling exhaustion tests below).
+        query_agent._generate_broader_query = Mock(return_value='broader | query')
 
         # Mock the database find_abstracts as well (for Phase 2 query modification)
         with patch('bmlibrarian.agents.query_agent.find_abstracts') as mock_db_find:


### PR DESCRIPTION
## Problem

`uv run python -m pytest tests/` could not run unattended. Two tests block, and both are invisible because a stalled test produces no failure to read.

## Investigation

I ran each test file in isolation with `--timeout-method=thread` (which dumps the stuck stack and exits, naming the culprit — unlike the signal method, which cannot interrupt a Qt event loop). Findings:

- The reported **Qt-modal hang is not reproducible in the current tree.** The prisma2020_lab autouse modal stub is intact, and a full offscreen `pytest tests/` (default signal-method `--timeout`, no `-m` filter) reaches **100%**. Because `QT_QPA_PLATFORM=offscreen` still blocks on `.exec()`, any unpatched modal reached would hang that run — it didn't.
- What remained were two **non-hermetic** tests that hit real services. Under the signal timeout they don't hang forever, but each burns the full 120s ceiling (a long silent stretch that *looks* like a hang); under the thread method / in DB-less CI they hang outright.

## Fix

1. **`test_hybrid_search.py::test_hybrid_search`** — a runnable *script* (shebang, `print()`s, no assertions, `if __name__ == "__main__"`) that pytest collects by name and which calls `search_hybrid()` against the real database. An unreachable DB blocks in psycopg's socket wait. Marked `requires_database` so it's deselectable, matching the established precedent.
2. **`test_iterative_search.py::TestIterativeSearch::test_deduplication_of_documents`** — sets `min_relevant=5` to force retry exhaustion, driving `find_abstracts_iterative` into `_generate_broader_query` (a real Ollama call). Its sibling exhaustion tests already mock `_generate_broader_query`; this one omitted it. Added the same one-line mock.

## Verification

- `tests/test_iterative_search.py` → 13 passed in 0.23s (was: hangs).
- Full offscreen `pytest tests/` (default signal timeout, no `-m` filter) → runs to 100%, no infinite hang. Pre-existing DB/Ollama/GUI failures are unchanged and out of scope.
- Ruff `F401,F811,F821,F841` on both files: identical to master baseline (no new lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)